### PR TITLE
fixed sparse efficiency warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ To start using OpenFermion, clone this git repo, change directory to the top lev
 
   python -m pip install -e .
 
-Alternatively, one can install using pip with the command
+Alternatively, one can install the last major release using pip with the command
 
 .. code-block:: bash
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -61,4 +61,4 @@ Further examples can be found in the docs (`Examples` in the panel on the left) 
 Plugins
 -------
 
-In order to generate molecular hamiltonians in Gaussian basis sets and perform other complicated electronic structure calculations, one can install plugins. We currently support Psi4 (plugin `here <www.openfermion.org>`__, recommended) and PySCF (plugin `here <www.openfermion.org>`__).
+In order to simulate and compile quantum circuits or perform other complicated electronic structure calculations, one can install OpenFermion plugins. We currently support a circuit simulation plugin for `ProjectQ <https://projectq.ch>`__, which you can find at `OpenFermion-ProjectQ <http://github.com/quantumlib/OpenFermion-ProjectQ>`__. We also support electronic structure plugins for `Psi4 <http://psicode.org>`__, which you can find at `OpenFermion-Psi4 <http://github.com/quantumlib/OpenFermion-Psi4>`__ (recommended), and for `PySCF <https://github.com/sunqm/pyscf>`__, which you can find at `OpenFermion-PySCF <http://github.com/quantumlib/OpenFermion-PySCF>`__.

--- a/src/openfermion/ops/_interaction_tensor_test.py
+++ b/src/openfermion/ops/_interaction_tensor_test.py
@@ -202,6 +202,26 @@ class InteractionTensorTest(unittest.TestCase):
         self.assertEqual(interaction_tensor.__str__(), want_str)
         self.assertEqual(interaction_tensor.__repr__(), want_str)
 
+    def test_init_none(self):
+        n_qubits = 2
+        constant = 23.0
+
+        one_body = numpy.zeros((self.n_qubits, self.n_qubits))
+        two_body = numpy.zeros((self.n_qubits, self.n_qubits,
+                                self.n_qubits, self.n_qubits))
+        one_body[0, 1] = 2
+        one_body[1, 0] = 3
+        two_body[0, 1, 0, 1] = 4
+        two_body[1, 1, 0, 0] = 5
+        interaction_tensor = InteractionTensor(None,
+                                               one_body, two_body)
+        self.assertAlmostEqual(interaction_tensor.constant, 0.)
+
+        self.interaction_tensor_a[()] = 0.
+        self.assertAlmostEqual(self.interaction_tensor_a, interaction_tensor)
+        self.interaction_tensor_a[()] = self.constant
+
+
     def test_rotate_basis_identical(self):
         rotation_matrix_identical = numpy.zeros((self.n_qubits, self.n_qubits))
         rotation_matrix_identical[0, 0] = 1

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -59,3 +59,7 @@ from ._sparse_tools import (expectation,
                             sparse_eigenspectrum)
 
 from ._trotter_error import error_bound, error_operator
+
+# Imports out of alphabetical order to avoid circular dependancy.
+from ._jellium_hf_state import hartree_fock_state_jellium
+

--- a/src/openfermion/utils/_jellium_hf_state.py
+++ b/src/openfermion/utils/_jellium_hf_state.py
@@ -17,7 +17,7 @@ from openfermion.ops import FermionOperator, normal_ordered
 from openfermion.utils import (count_qubits, jellium_model,
                                inverse_fourier_transform, plane_wave_kinetic)
 
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, dok_matrix
 
 import numpy
 
@@ -94,9 +94,8 @@ def hartree_fock_state_jellium(grid, n_electrons, spinless=True,
             dual_basis_hf_creation_operator)
 
         # Initialize the HF state as a sparse matrix.
-        hartree_fock_state = csr_matrix(
-            ([], ([], [])), shape=(2 ** count_qubits(hamiltonian), 1),
-            dtype=complex)
+        hartree_fock_state = dok_matrix(
+            (2 ** count_qubits(hamiltonian), 1), dtype=complex)
 
         # Populate the elements of the HF state in the dual basis.
         for term in dual_basis_hf_creation.terms:
@@ -104,5 +103,6 @@ def hartree_fock_state_jellium(grid, n_electrons, spinless=True,
             for operator in term:
                 index += 2 ** operator[0]
             hartree_fock_state[index, 0] = dual_basis_hf_creation.terms[term]
+        hartree_fock_state = hartree_fock_state.tocsr()
 
     return hartree_fock_state

--- a/src/openfermion/utils/_jellium_hf_state_test.py
+++ b/src/openfermion/utils/_jellium_hf_state_test.py
@@ -9,11 +9,9 @@ import unittest
 
 from openfermion.transforms import get_sparse_operator
 from openfermion.utils import (expectation, get_ground_state,
-                               Grid, jellium_model)
-from openfermion.utils._plane_wave_hamiltonian import wigner_seitz_length_scale
-from openfermion.utils._sparse_tools import jw_number_restrict_operator
-
-from openfermion.utils._jellium_hf_state import hartree_fock_state_jellium
+                               Grid, hartree_fock_state_jellium,
+                               jellium_model, jw_number_restrict_operator,
+                               wigner_seitz_length_scale)
 
 
 class JelliumHartreeFockStateTest(unittest.TestCase):


### PR DESCRIPTION
Changed code in _jw_hf_state.py to use dok_matrix instead of csr_matrix in order to avoid sparse efficiency warning.