### PR TITLE
Added hubbard model with particle-hole symmetry

### DIFF
--- a/src/openfermion/hamiltonians/__init__.py
+++ b/src/openfermion/hamiltonians/__init__.py
@@ -14,7 +14,7 @@ from ._chemical_series import (make_atomic_ring,
                                make_atomic_lattice,
                                make_atom)
 
-from ._hubbard import fermi_hubbard
+from ._hubbard import fermi_hubbard, fermi_hubbard_phs
 
 from ._jellium import (dual_basis_kinetic,
                        dual_basis_potential,

--- a/src/openfermion/hamiltonians/__init__.py
+++ b/src/openfermion/hamiltonians/__init__.py
@@ -14,7 +14,7 @@ from ._chemical_series import (make_atomic_ring,
                                make_atomic_lattice,
                                make_atom)
 
-from ._hubbard import fermi_hubbard, fermi_hubbard_phs
+from ._hubbard import fermi_hubbard
 
 from ._jellium import (dual_basis_kinetic,
                        dual_basis_potential,

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -187,3 +187,154 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
 
     # Return.
     return hubbard_model
+
+
+def fermi_hubbard_phs(x_dimension, y_dimension, tunneling, coulomb,
+                      chemical_potential=None, magnetic_field=None,
+                      periodic=True, spinless=False):
+    """Return symbolic representation of a Fermi-Hubbard Hamiltonian.
+    Version with particle-hole symmetry. In this version, the term:
+
+    coulomb sum_{k=1}^{N-1} a_k^dagger a_k a_{k+1}^dagger a_{k+1}
+
+    is replaced by:
+
+    coulomb sum_{k=1}^{N-1} (a_k^dagger a_k - 1/2)
+    (a_{k+1}^dagger a_{k+1} - 1/2)
+
+    which is unchanged under a particle-hole transformation. For
+    chemical_potential = 0  magnetic field=0, the ground states
+    correspond to half-filling and the ground state energies are
+    symmetric with respect to chemical_potential = 0.
+
+    Args:
+        x_dimension: An integer giving the number of sites in width.
+        y_dimension: An integer giving the number of sites in height.
+        tunneling: A float giving the tunneling amplitude.
+        coulomb: A float giving the attractive local interaction strength.
+        chemical_potential: An optional float giving the potential of each
+            site. Default value is None.
+        magnetic_field: An optional float giving a magnetic field at each
+            site. Default value is None.
+        periodic: If True, add periodic boundary conditions.
+        spinless: An optional Boolean. If False, each site has spin up
+            orbitals and spin down orbitals. If True, return a spinless
+            Fermi-Hubbard model.
+        verbose: An optional Boolean. If True, print all second quantized
+            terms.
+
+    Returns:
+        hubbard_model: An instance of the FermionOperator class.
+    """
+    # Initialize fermion operator class.
+    n_sites = x_dimension * y_dimension
+    if spinless:
+        n_spin_orbitals = n_sites
+    else:
+        n_spin_orbitals = 2 * n_sites
+    hubbard_model = FermionOperator((), 0.0)
+    half_unit = FermionOperator((), 0.5)
+
+    # Loop through sites and add terms.
+    for site in range(n_sites):
+
+        # Add chemical potential and magnetic field terms.
+        if chemical_potential and spinless:
+            x_index = site % x_dimension
+            y_index = (site - 1) // x_dimension
+            sign = (-1.) ** (x_index + y_index)
+            coefficient = sign * chemical_potential
+            hubbard_model += number_operator(
+                n_spin_orbitals, site, coefficient)
+
+        if chemical_potential and not spinless:
+            coefficient = -1. * chemical_potential
+            hubbard_model += number_operator(
+                n_spin_orbitals, up_index(site), coefficient)
+            hubbard_model += number_operator(
+                n_spin_orbitals, down_index(site), coefficient)
+
+        if magnetic_field and not spinless:
+            coefficient = magnetic_field
+            hubbard_model += number_operator(
+                n_spin_orbitals, up_index(site), -coefficient)
+            hubbard_model += number_operator(
+                n_spin_orbitals, down_index(site), coefficient)
+
+        # Add local pair interaction terms.
+        if not spinless:
+            operator_1 = number_operator(
+                n_spin_orbitals, up_index(site), 1.0) - half_unit
+            operator_2 = number_operator(
+                n_spin_orbitals, down_index(site), 1.0) - half_unit
+            hubbard_model += coulomb*operator_1*operator_2
+
+        # Index coupled orbitals.
+        right_neighbor = site + 1
+        bottom_neighbor = site + x_dimension
+
+        # Account for periodic boundaries.
+        if periodic:
+            if (x_dimension > 2) and ((site + 1) % x_dimension == 0):
+                right_neighbor -= x_dimension
+            if (y_dimension > 2) and (site + x_dimension + 1 > n_sites):
+                bottom_neighbor -= x_dimension * y_dimension
+
+        # Add transition to neighbor on right.
+        if (site + 1) % x_dimension or (periodic and x_dimension > 2):
+            if spinless:
+                # Add Coulomb term.
+                operator_1 = number_operator(
+                    n_spin_orbitals, site, 1.0) - half_unit
+                operator_2 = number_operator(
+                    n_spin_orbitals, right_neighbor, 1.0) - half_unit
+                hubbard_model += coulomb*operator_1*operator_2
+
+                # Add hopping term.
+                operators = ((site, 1), (right_neighbor, 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+            else:
+                # Add hopping term.
+                operators = ((up_index(site), 1),
+                             (up_index(right_neighbor), 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+                operators = ((down_index(site), 1),
+                             (down_index(right_neighbor), 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+
+        # Add transition to neighbor below.
+        if site + x_dimension + 1 <= n_sites or (periodic and y_dimension > 2):
+            if spinless:
+                # Add Coulomb term.
+                operator_1 = number_operator(
+                    n_spin_orbitals, site, 1.0) - half_unit
+                operator_2 = number_operator(
+                    n_spin_orbitals, bottom_neighbor, 1.0) - half_unit
+                hubbard_model += coulomb*operator_1*operator_2
+
+                # Add hopping term.
+                operators = ((site, 1), (bottom_neighbor, 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+            else:
+                # Add hopping term.
+                operators = ((up_index(site), 1),
+                             (up_index(bottom_neighbor), 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+                operators = ((down_index(site), 1),
+                             (down_index(bottom_neighbor), 0))
+                hopping_term = FermionOperator(operators, -tunneling)
+                hubbard_model += hopping_term
+                hubbard_model += hermitian_conjugated(hopping_term)
+
+    # Return.
+    return hubbard_model

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -60,7 +60,8 @@ def down_index(index):
 
 def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
                   chemical_potential=None, magnetic_field=None,
-                  periodic=True, spinless=False):
+                  periodic=True, spinless=False,
+                  particle_hole_symmetry=False):
     """Return symbolic representation of a Fermi-Hubbard Hamiltonian.
 
     Args:
@@ -76,6 +77,13 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
         spinless: An optional Boolean. If False, each site has spin up
             orbitals and spin down orbitals. If True, return a spinless
             Fermi-Hubbard model.
+        particle_hole_symmetry: an optional Boolean. If False, the repulsion
+            term corresponds to:
+            coulomb sum_{k=1}^{N-1} a_k^dagger a_k a_{k+1}^dagger a_{k+1}
+            If true, the repulsion term is replaced by:
+            coulomb sum_{k=1}^{N-1} (a_k^dagger a_k - 1/2)
+            (a_{k+1}^dagger a_{k+1} - 1/2)
+            which is unchanged under a particle-hole transformation.
         verbose: An optional Boolean. If True, print all second quantized
             terms.
 
@@ -89,151 +97,11 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
     else:
         n_spin_orbitals = 2 * n_sites
     hubbard_model = FermionOperator((), 0.0)
-
-    # Loop through sites and add terms.
-    for site in range(n_sites):
-
-        # Add chemical potential and magnetic field terms.
-        if chemical_potential and spinless:
-            x_index = site % x_dimension
-            y_index = (site - 1) // x_dimension
-            sign = (-1.) ** (x_index + y_index)
-            coefficient = sign * chemical_potential
-            hubbard_model += number_operator(
-                n_spin_orbitals, site, coefficient)
-
-        if chemical_potential and not spinless:
-            coefficient = -1. * chemical_potential
-            hubbard_model += number_operator(
-                n_spin_orbitals, up_index(site), coefficient)
-            hubbard_model += number_operator(
-                n_spin_orbitals, down_index(site), coefficient)
-
-        if magnetic_field and not spinless:
-            coefficient = magnetic_field
-            hubbard_model += number_operator(
-                n_spin_orbitals, up_index(site), -coefficient)
-            hubbard_model += number_operator(
-                n_spin_orbitals, down_index(site), coefficient)
-
-        # Add local pair interaction terms.
-        if not spinless:
-            operators = ((up_index(site), 1), (up_index(site), 0),
-                         (down_index(site), 1), (down_index(site), 0))
-            hubbard_model += FermionOperator(operators, coulomb)
-
-        # Index coupled orbitals.
-        right_neighbor = site + 1
-        bottom_neighbor = site + x_dimension
-
-        # Account for periodic boundaries.
-        if periodic:
-            if (x_dimension > 2) and ((site + 1) % x_dimension == 0):
-                right_neighbor -= x_dimension
-            if (y_dimension > 2) and (site + x_dimension + 1 > n_sites):
-                bottom_neighbor -= x_dimension * y_dimension
-
-        # Add transition to neighbor on right.
-        if (site + 1) % x_dimension or (periodic and x_dimension > 2):
-            if spinless:
-                # Add Coulomb term.
-                operators = ((site, 1), (site, 0),
-                             (right_neighbor, 1), (right_neighbor, 0))
-                hubbard_model += FermionOperator(operators, coulomb)
-
-                # Add hopping term.
-                operators = ((site, 1), (right_neighbor, 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-            else:
-                # Add hopping term.
-                operators = ((up_index(site), 1),
-                             (up_index(right_neighbor), 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-                operators = ((down_index(site), 1),
-                             (down_index(right_neighbor), 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-
-        # Add transition to neighbor below.
-        if site + x_dimension + 1 <= n_sites or (periodic and y_dimension > 2):
-            if spinless:
-                # Add Coulomb term.
-                operators = ((site, 1), (site, 0),
-                             (bottom_neighbor, 1), (bottom_neighbor, 0))
-                hubbard_model += FermionOperator(operators, coulomb)
-
-                # Add hopping term.
-                operators = ((site, 1), (bottom_neighbor, 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-            else:
-                # Add hopping term.
-                operators = ((up_index(site), 1),
-                             (up_index(bottom_neighbor), 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-                operators = ((down_index(site), 1),
-                             (down_index(bottom_neighbor), 0))
-                hopping_term = FermionOperator(operators, -tunneling)
-                hubbard_model += hopping_term
-                hubbard_model += hermitian_conjugated(hopping_term)
-
-    # Return.
-    return hubbard_model
-
-
-def fermi_hubbard_phs(x_dimension, y_dimension, tunneling, coulomb,
-                      chemical_potential=None, magnetic_field=None,
-                      periodic=True, spinless=False):
-    """Return symbolic representation of a Fermi-Hubbard Hamiltonian.
-    Version with particle-hole symmetry. In this version, the term:
-
-    coulomb sum_{k=1}^{N-1} a_k^dagger a_k a_{k+1}^dagger a_{k+1}
-
-    is replaced by:
-
-    coulomb sum_{k=1}^{N-1} (a_k^dagger a_k - 1/2)
-    (a_{k+1}^dagger a_{k+1} - 1/2)
-
-    which is unchanged under a particle-hole transformation. For
-    chemical_potential = 0  magnetic field=0, the ground states
-    correspond to half-filling and the ground state energies are
-    symmetric with respect to chemical_potential = 0.
-
-    Args:
-        x_dimension: An integer giving the number of sites in width.
-        y_dimension: An integer giving the number of sites in height.
-        tunneling: A float giving the tunneling amplitude.
-        coulomb: A float giving the attractive local interaction strength.
-        chemical_potential: An optional float giving the potential of each
-            site. Default value is None.
-        magnetic_field: An optional float giving a magnetic field at each
-            site. Default value is None.
-        periodic: If True, add periodic boundary conditions.
-        spinless: An optional Boolean. If False, each site has spin up
-            orbitals and spin down orbitals. If True, return a spinless
-            Fermi-Hubbard model.
-        verbose: An optional Boolean. If True, print all second quantized
-            terms.
-
-    Returns:
-        hubbard_model: An instance of the FermionOperator class.
-    """
-    # Initialize fermion operator class.
-    n_sites = x_dimension * y_dimension
-    if spinless:
-        n_spin_orbitals = n_sites
+    # select particle-hole symmetry
+    if particle_hole_symmetry:
+        coulomb_shift = FermionOperator((), 0.5)
     else:
-        n_spin_orbitals = 2 * n_sites
-    hubbard_model = FermionOperator((), 0.0)
-    half_unit = FermionOperator((), 0.5)
+        coulomb_shift = FermionOperator((), 0.0)
 
     # Loop through sites and add terms.
     for site in range(n_sites):
@@ -264,10 +132,10 @@ def fermi_hubbard_phs(x_dimension, y_dimension, tunneling, coulomb,
         # Add local pair interaction terms.
         if not spinless:
             operator_1 = number_operator(
-                n_spin_orbitals, up_index(site), 1.0) - half_unit
+                n_spin_orbitals, up_index(site), 1.0) - coulomb_shift
             operator_2 = number_operator(
-                n_spin_orbitals, down_index(site), 1.0) - half_unit
-            hubbard_model += coulomb*operator_1*operator_2
+                n_spin_orbitals, down_index(site), 1.0) - coulomb_shift
+            hubbard_model += coulomb * operator_1 * operator_2
 
         # Index coupled orbitals.
         right_neighbor = site + 1
@@ -285,10 +153,10 @@ def fermi_hubbard_phs(x_dimension, y_dimension, tunneling, coulomb,
             if spinless:
                 # Add Coulomb term.
                 operator_1 = number_operator(
-                    n_spin_orbitals, site, 1.0) - half_unit
+                    n_spin_orbitals, site, 1.0) - coulomb_shift
                 operator_2 = number_operator(
-                    n_spin_orbitals, right_neighbor, 1.0) - half_unit
-                hubbard_model += coulomb*operator_1*operator_2
+                    n_spin_orbitals, right_neighbor, 1.0) - coulomb_shift
+                hubbard_model += coulomb * operator_1 * operator_2
 
                 # Add hopping term.
                 operators = ((site, 1), (right_neighbor, 0))
@@ -313,10 +181,10 @@ def fermi_hubbard_phs(x_dimension, y_dimension, tunneling, coulomb,
             if spinless:
                 # Add Coulomb term.
                 operator_1 = number_operator(
-                    n_spin_orbitals, site, 1.0) - half_unit
+                    n_spin_orbitals, site, 1.0) - coulomb_shift
                 operator_2 = number_operator(
-                    n_spin_orbitals, bottom_neighbor, 1.0) - half_unit
-                hubbard_model += coulomb*operator_1*operator_2
+                    n_spin_orbitals, bottom_neighbor, 1.0) - coulomb_shift
+                hubbard_model += coulomb * operator_1 * operator_2
 
                 # Add hopping term.
                 operators = ((site, 1), (bottom_neighbor, 0))

--- a/src/openfermion/hamiltonians/_hubbard_test.py
+++ b/src/openfermion/hamiltonians/_hubbard_test.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from openfermion.hamiltonians import fermi_hubbard
+from openfermion.hamiltonians import fermi_hubbard, fermi_hubbard_phs
 
 
 class FermiHubbardTest(unittest.TestCase):
@@ -113,6 +113,135 @@ class FermiHubbardTest(unittest.TestCase):
 
     def test_three_by_two_spinless_periodic_rudimentary(self):
         hubbard_model = fermi_hubbard(
+            3, 2, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+        # Check up top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
+                               -self.tunneling)
+
+    def test_two_by_two_spinful_phs(self):
+
+        # Initialize the Hamiltonian.
+        hubbard_model = fermi_hubbard_phs(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            self.periodic, self.spinless)
+
+        # Check up independent terms.
+        self.assertAlmostEqual(hubbard_model.terms[()], 1.0)
+
+        # Check up spin on site terms.
+        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0))], -1.25)
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0))], -1.25)
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0))], -1.25)
+        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0))], -1.25)
+
+        # Check down spin on site terms.
+        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (1, 0))], -.25)
+        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (3, 0))], -.25)
+        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (5, 0))], -.25)
+        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (7, 0))], -.25)
+
+        # Check up right/left hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (2, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (6, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (4, 0))], -2.)
+
+        # Check up top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (4, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (6, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (2, 0))], -2.)
+
+        # Check down right/left hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (3, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (1, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (7, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (5, 0))], -2.)
+
+        # Check down top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (5, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (1, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (7, 0))], -2.)
+        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (3, 0))], -2.)
+
+        # Check on site interaction term.
+        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0),
+                                                    (1, 1), (1, 0))], 1.)
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0),
+                                                    (3, 1), (3, 0))], 1.)
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0),
+                                                    (5, 1), (5, 0))], 1.)
+        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0),
+                                                    (7, 1), (7, 0))], 1.)
+
+    def test_two_by_two_spinful_periodic_rudimentary(self):
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=False)
+
+    def test_two_by_two_spinful_aperiodic_rudimentary(self):
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=False, spinless=False)
+
+    def test_two_by_two_spinless_periodic_rudimentary(self):
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+
+    def test_two_by_three_spinless_periodic_rudimentary(self):
+        hubbard_model = fermi_hubbard(
+            2, 3, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+        # Check up top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
+                               -self.tunneling)
+
+    def test_three_by_two_spinless_periodic_rudimentary(self):
+        hubbard_model = fermi_hubbard(
+            3, 2, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+        # Check up top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
+                               -self.tunneling)
+
+    def test_two_by_two_spinful_periodic_rudimentary_phs(self):
+        hubbard_model = fermi_hubbard_phs(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=False)
+
+    def test_two_by_two_spinful_aperiodic_rudimentary_phs(self):
+        hubbard_model = fermi_hubbard_phs(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=False, spinless=False)
+
+    def test_two_by_two_spinless_periodic_rudimentary_phs(self):
+        hubbard_model = fermi_hubbard_phs(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+
+    def test_two_by_three_spinless_periodic_rudimentary_phs(self):
+        hubbard_model = fermi_hubbard_phs(
+            2, 3, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True)
+        # Check up top/bottom hopping terms.
+        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
+                               -self.tunneling)
+
+    def test_three_by_two_spinless_periodic_rudimentary_phs(self):
+        hubbard_model = fermi_hubbard_phs(
             3, 2, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
             periodic=True, spinless=True)

--- a/src/openfermion/hamiltonians/_hubbard_test.py
+++ b/src/openfermion/hamiltonians/_hubbard_test.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from openfermion.hamiltonians import fermi_hubbard, fermi_hubbard_phs
+from openfermion.hamiltonians import fermi_hubbard
 
 
 class FermiHubbardTest(unittest.TestCase):
@@ -32,11 +32,11 @@ class FermiHubbardTest(unittest.TestCase):
 
     def test_two_by_two_spinful(self):
 
-        # Initialize the Hamiltonian.
+        # Initialize the Hamiltonians.
         hubbard_model = fermi_hubbard(
             self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            self.periodic, self.spinless)
+            self.periodic, self.spinless, False)
 
         # Check up spin on site terms.
         self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0))], -.75)
@@ -84,122 +84,74 @@ class FermiHubbardTest(unittest.TestCase):
         self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0),
                                                     (7, 1), (7, 0))], 1.)
 
-    def test_two_by_two_spinful_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=False)
-
-    def test_two_by_two_spinful_aperiodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=False, spinless=False)
-
-    def test_two_by_two_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-
-    def test_two_by_three_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            2, 3, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
-                               -self.tunneling)
-
-    def test_three_by_two_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            3, 2, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
-                               -self.tunneling)
-
     def test_two_by_two_spinful_phs(self):
-
-        # Initialize the Hamiltonian.
-        hubbard_model = fermi_hubbard_phs(
+        hubbard_model = fermi_hubbard(
             self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            self.periodic, self.spinless)
+            self.periodic, self.spinless, False)
 
-        # Check up independent terms.
-        self.assertAlmostEqual(hubbard_model.terms[()], 1.0)
+        hubbard_model_phs = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            self.periodic, self.spinless, True)
 
-        # Check up spin on site terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0))], -1.25)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0))], -1.25)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0))], -1.25)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0))], -1.25)
+        # Compute difference between the models with and without
+        # spin symmetry.
+        difference = hubbard_model_phs - hubbard_model
 
-        # Check down spin on site terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (1, 0))], -.25)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (3, 0))], -.25)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (5, 0))], -.25)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (7, 0))], -.25)
+        # Check constant term in difference.
+        self.assertAlmostEqual(difference.terms[()], 1.0)
 
-        # Check up right/left hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (2, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (6, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (4, 0))], -2.)
+        # Check up spin on site terms in difference.
+        self.assertAlmostEqual(difference.terms[((0, 1), (0, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((2, 1), (2, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((4, 1), (4, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((6, 1), (6, 0))], -.50)
 
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (4, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (6, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (2, 0))], -2.)
-
-        # Check down right/left hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (3, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (7, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (5, 0))], -2.)
-
-        # Check down top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (5, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (7, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (3, 0))], -2.)
-
-        # Check on site interaction term.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0),
-                                                    (1, 1), (1, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0),
-                                                    (3, 1), (3, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0),
-                                                    (5, 1), (5, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0),
-                                                    (7, 1), (7, 0))], 1.)
+        # Check down spin on site terms in difference.
+        self.assertAlmostEqual(difference.terms[((1, 1), (1, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((3, 1), (3, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((5, 1), (5, 0))], -.50)
+        self.assertAlmostEqual(difference.terms[((7, 1), (7, 0))], -.50)
 
     def test_two_by_two_spinful_periodic_rudimentary(self):
         hubbard_model = fermi_hubbard(
             self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=False)
+            periodic=True, spinless=False, particle_hole_symmetry=False)
+
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=False, particle_hole_symmetry=True)
 
     def test_two_by_two_spinful_aperiodic_rudimentary(self):
         hubbard_model = fermi_hubbard(
             self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            periodic=False, spinless=False)
+            periodic=False, spinless=False, particle_hole_symmetry=False)
+
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=False, spinless=False, particle_hole_symmetry=True)
 
     def test_two_by_two_spinless_periodic_rudimentary(self):
         hubbard_model = fermi_hubbard(
             self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
+            periodic=True, spinless=True, particle_hole_symmetry=False)
+
+        hubbard_model = fermi_hubbard(
+            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
+            self.chemical_potential, self.magnetic_field,
+            periodic=True, spinless=True, particle_hole_symmetry=True)
 
     def test_two_by_three_spinless_periodic_rudimentary(self):
         hubbard_model = fermi_hubbard(
             2, 3, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
+            periodic=True, spinless=True, particle_hole_symmetry=False)
         # Check up top/bottom hopping terms.
         self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
                                -self.tunneling)
@@ -208,43 +160,7 @@ class FermiHubbardTest(unittest.TestCase):
         hubbard_model = fermi_hubbard(
             3, 2, self.tunneling, self.coulomb,
             self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
-                               -self.tunneling)
-
-    def test_two_by_two_spinful_periodic_rudimentary_phs(self):
-        hubbard_model = fermi_hubbard_phs(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=False)
-
-    def test_two_by_two_spinful_aperiodic_rudimentary_phs(self):
-        hubbard_model = fermi_hubbard_phs(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=False, spinless=False)
-
-    def test_two_by_two_spinless_periodic_rudimentary_phs(self):
-        hubbard_model = fermi_hubbard_phs(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-
-    def test_two_by_three_spinless_periodic_rudimentary_phs(self):
-        hubbard_model = fermi_hubbard_phs(
-            2, 3, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
-                               -self.tunneling)
-
-    def test_three_by_two_spinless_periodic_rudimentary_phs(self):
-        hubbard_model = fermi_hubbard_phs(
-            3, 2, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True)
+            periodic=True, spinless=True, particle_hole_symmetry=False)
         # Check up top/bottom hopping terms.
         self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
                                -self.tunneling)


### PR DESCRIPTION
I added an alternative version of the routine for creating the Fermi Hubbard hamiltonian. In this version the repulsion term U n_{i,\uparrow} n_{i,\downarrow} is replaced by  U (n_{i,\uparrow}-1/2) (n_{i,\downarrow}-1/2), which is unchanged by a particle-hole transformation. This version has the advantage that at chemical potential and magnetic field equal zero, the ground state is always the one at half-filling and the energy is symmetric with respect to chemical potential = 0. This is more convenient for benchmarks than the previous version. Look at the energies for a 2x2 lattice:
 
![image](https://user-images.githubusercontent.com/10538281/31797891-ab032710-b4fe-11e7-90a4-c5b9f49db7ce.png)

For now it is a separate routine. 