### PR TITLE
Fixes for Slater determinant preparation

### DIFF
--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -120,23 +120,26 @@ def fermionic_gaussian_decomposition(unitary_rows):
         indices_to_zero_out = zip(row_indices, column_indices)
 
         for i, j in indices_to_zero_out:
-            # Compute the Givens rotation to zero out the (i, j) element
-            left_element = current_matrix[i, j - 1].conj()
+            # Compute the Givens rotation to zero out the (i, j) element,
+            # if needed
             right_element = current_matrix[i, j].conj()
-            givens_rotation = givens_matrix_elements(left_element,
-                                                     right_element)
-            # Need to switch the rows to zero out right_element
-            # rather than left_element
-            givens_rotation = givens_rotation[(1, 0), :]
+            if abs(right_element) > EQ_TOLERANCE:
+                # We actually need to perform a Givens rotation
+                left_element = current_matrix[i, j - 1].conj()
+                givens_rotation = givens_matrix_elements(left_element,
+                                                         right_element)
+                # Need to switch the rows to zero out right_element
+                # rather than left_element
+                givens_rotation = givens_rotation[(1, 0), :]
 
-            # Add the parameters to the list
-            theta = numpy.arccos(numpy.real(givens_rotation[0, 0]))
-            phi = numpy.angle(givens_rotation[1, 1])
-            parallel_ops.append((j - 1, j, theta, phi))
+                # Add the parameters to the list
+                theta = numpy.arccos(numpy.real(givens_rotation[0, 0]))
+                phi = numpy.angle(givens_rotation[1, 1])
+                parallel_ops.append((j - 1, j, theta, phi))
 
-            # Update the matrix
-            double_givens_rotate(current_matrix, givens_rotation,
-                                 j - 1, j, which='col')
+                # Update the matrix
+                double_givens_rotate(current_matrix, givens_rotation,
+                                     j - 1, j, which='col')
 
         # Append the current list of parallel rotations to the list
         decomposition.append(tuple(parallel_ops))
@@ -351,8 +354,8 @@ def givens_decomposition(unitary_rows):
                 # if needed
                 right_element = current_matrix[i, j].conj()
                 if abs(right_element) > EQ_TOLERANCE:
-                    left_element = current_matrix[i, j - 1].conj()
                     # We actually need to perform a Givens rotation
+                    left_element = current_matrix[i, j - 1].conj()
                     givens_rotation = givens_matrix_elements(left_element,
                                                              right_element)
                     # Need to switch the rows to zero out right_element

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -41,6 +41,8 @@ def fermionic_gaussian_decomposition(unitary_rows):
     where V and U are unitary matrices and D is a diagonal unitary matrix.
     Furthermore, we can decompose U as a sequence of Givens rotations
     and particle-hole transformations on the last fermionic mode.
+    This particle-hole transformation maps a^\dagger_n to a^n and vice
+    versa, while leaving the other ladder operators invariant.
 
     The decomposition of U is returned as a list of tuples of objects
     describing rotations and particle-hole transformations. The list looks

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -121,17 +121,6 @@ def fermionic_gaussian_decomposition(unitary_rows):
         row_indices = range(end_row, end_row - len(column_indices), -1)
         indices_to_zero_out = zip(row_indices, column_indices)
 
-        ## Get the (row, column) indices of elements to zero out in parallel.
-        #if k < n:
-        #    end_row = k
-        #    end_column = k
-        #else:
-        #    end_row = n - 1
-        #    end_column = 2 * (n - 1) - k
-        #column_indices = range(end_column, 0, -2)
-        #row_indices = range(end_row, end_row - len(column_indices), -1)
-        #indices_to_zero_out = zip(row_indices, column_indices)
-
         for i, j in indices_to_zero_out:
             # Compute the Givens rotation to zero out the (i, j) element,
             # if needed
@@ -145,7 +134,7 @@ def fermionic_gaussian_decomposition(unitary_rows):
                 # Add the parameters to the list
                 theta = numpy.arccos(numpy.real(givens_rotation[0, 0]))
                 phi = numpy.angle(givens_rotation[1, 1])
-                parallel_ops.append((j , j + 1, theta, phi))
+                parallel_ops.append((j, j + 1, theta, phi))
 
                 # Update the matrix
                 double_givens_rotate(current_matrix, givens_rotation,
@@ -255,9 +244,9 @@ def antisymmetric_canonical_form(antisymmetric_matrix):
     # Now we permute so that the upper right block is non-negative
     for i in range(num_blocks):
         if canonical[i, num_blocks + i] < -EQ_TOLERANCE:
-            swap_rows(canonical, i, num_blocks+ i)
-            swap_columns(canonical, i, num_blocks+ i)
-            swap_columns(orthogonal, i, num_blocks+ i)
+            swap_rows(canonical, i, num_blocks + i)
+            swap_columns(canonical, i, num_blocks + i)
+            swap_columns(orthogonal, i, num_blocks + i)
 
     return canonical, orthogonal.T
 

--- a/src/openfermion/utils/_slater_determinants_test.py
+++ b/src/openfermion/utils/_slater_determinants_test.py
@@ -431,16 +431,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -455,13 +462,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_4(self):
         n = 4
@@ -474,16 +481,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -498,13 +512,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_5(self):
         n = 5
@@ -517,16 +531,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -541,13 +562,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_6(self):
         n = 6
@@ -560,16 +581,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -584,13 +612,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_7(self):
         n = 7
@@ -603,16 +631,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -627,13 +662,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_8(self):
         n = 8
@@ -646,16 +681,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -670,13 +712,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
     def test_n_equals_9(self):
         n = 9
@@ -689,16 +731,23 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         lower_unitary = ferm_unitary[n:]
 
         # Get fermionic Gaussian decomposition of lower_unitary
-        left_unitary, decomposition, antidiagonal = (
+        left_unitary, decomposition, diagonal = (
                 fermionic_gaussian_decomposition(lower_unitary))
+
+        # Check that left_unitary zeroes out the correct entries of
+        # lower_unitary
+        product = left_unitary.dot(lower_unitary)
+        for i in range(n - 1):
+            for j in range(n - 1 - i):
+                self.assertAlmostEqual(product[i, j], 0.)
 
         # Compute right_unitary
         right_unitary = numpy.eye(2 * n, dtype=complex)
         for parallel_set in decomposition:
             combined_op = numpy.eye(2 * n, dtype=complex)
             for op in parallel_set:
-                if op == 'p-h':
-                    swap_rows(combined_op, 0, n)
+                if op == 'pht':
+                    swap_rows(combined_op, n - 1, 2 * n - 1)
                 else:
                     i, j, theta, phi = op
                     c = numpy.cos(theta)
@@ -713,13 +762,13 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Compute left_unitary * lower_unitary * right_unitary^\dagger
         product = left_unitary.dot(lower_unitary.dot(right_unitary.T.conj()))
 
-        # Construct the antidiagonal matrix
-        anti_diag = numpy.zeros((n, 2 * n), dtype=complex)
-        anti_diag[range(n), range(2 * n - 1, n - 1, -1)] = antidiagonal
+        # Construct the diagonal matrix
+        diag = numpy.zeros((n, 2 * n), dtype=complex)
+        diag[range(n), range(n, 2 * n)] = diagonal
 
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
-            self.assertAlmostEqual(anti_diag[i], product[i])
+            self.assertAlmostEqual(diag[i], product[i])
 
 
 class DiagonalizingFermionicUnitaryTest(unittest.TestCase):

--- a/src/openfermion/utils/_slater_determinants_test.py
+++ b/src/openfermion/utils/_slater_determinants_test.py
@@ -810,6 +810,7 @@ class DiagonalizingFermionicUnitaryTest(unittest.TestCase):
             self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
             self.assertAlmostEqual(0., constraint_matrix_2[i])
 
+
 class AntisymmetricCanonicalFormTest(unittest.TestCase):
 
     def test_equality(self):


### PR DESCRIPTION
The main things I changed were:
- The canonical form for antisymmetric matrices should have nonnegative entries in the upper right block; I forgot to do this initially.
- Particle-hole transformations used in the preparation of fermionic Gaussian states are now on the last site, rather than the first. The particle-hole transformation on the last site is easier to implement on an actual device.