### PR TITLE
Ground state preparation circuits for QuadraticHamiltonian

### DIFF
--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -15,13 +15,9 @@ in the fermionic ladder operators."""
 from __future__ import absolute_import
 
 import numpy
-from scipy.linalg import schur
 
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import FermionOperator, PolynomialTensor
-from openfermion.utils import (givens_decomposition,
-                               fermionic_gaussian_decomposition)
-from openfermion.utils._slater_determinants import swap_columns, swap_rows
 
 
 class QuadraticHamiltonianError(Exception):
@@ -151,41 +147,6 @@ class QuadraticHamiltonian(PolynomialTensor):
 
         return majorana_matrix, majorana_constant
 
-    def ground_state_preparation_circuit(self):
-        """Return a description of a circuit which prepares the ground state
-        of the Hamiltonian, which is a Slater determinant."""
-        if self.conserves_particle_number():
-            # The Hamiltonian conserves particle number, so we don't need
-            # to use the most general procedure.
-            hermitian_matrix = self.combined_hermitian_part()
-            # Get the unitary rows which represent the ground state
-            # Slater determinant
-            energies, diagonalizing_unitary = numpy.linalg.eigh(
-                    hermitian_matrix)
-            num_negative_energies = numpy.count_nonzero(
-                    energies < -EQ_TOLERANCE)
-            slater_determinant_matrix = diagonalizing_unitary.T[
-                    :num_negative_energies]
-            # Get the circuit description
-            left_unitary, decomposition, diagonal = givens_decomposition(
-                    slater_determinant_matrix)
-            circuit_description = decomposition
-        else:
-            # The Hamiltonian does not conserve particle number, so we
-            # need to use the most general procedure.
-            majorana_matrix, majorana_constant = self.majorana_form()
-            # Get the unitary rows which represent the ground state
-            # Slater determinant
-            diagonalizing_unitary = diagonalizing_fermionic_unitary(
-                    majorana_matrix)
-            slater_determinant_matrix = diagonalizing_unitary[self.n_qubits:]
-            # Get the circuit description
-            left_unitary, decomposition, diagonal = (
-                    fermionic_gaussian_decomposition(
-                        slater_determinant_matrix))
-            circuit_description = decomposition
-        return circuit_description
-
 
 def majorana_operator(term=None, coefficient=1.):
     """Initialize a Majorana operator.
@@ -230,106 +191,3 @@ def majorana_operator(term=None, coefficient=1.):
     # Invalid input.
     else:
         raise ValueError('Operator specified incorrectly.')
-
-
-def diagonalizing_fermionic_unitary(antisymmetric_matrix):
-    """Compute the unitary that diagonalizes a quadratic Hamiltonian.
-
-    The input matrix represents a quadratic Hamiltonian in the Majorana basis.
-    The output matrix is a unitary that represents a transformation (mixing)
-    of the fermionic ladder operators. We use the convention that the
-    creation operators are listed before the annihilation operators.
-    The returned unitary has additional structure which ensures
-    that the transformed ladder operators also satisfy the fermionic
-    anticommutation relations.
-
-    Args:
-        antisymmetric_matrix(ndarray): A (2 * n_qubits) x (2 * n_qubits)
-            antisymmetric matrix representing a quadratic Hamiltonian in the
-            Majorana basis.
-    Returns:
-        diagonalizing_unitary(ndarray): A (2 * n_qubits) x (2 * n_qubits)
-            unitary matrix representing a transformation of the fermionic
-            ladder operators.
-    """
-    m, n = antisymmetric_matrix.shape
-    n_qubits = n // 2
-
-    # Get the orthogonal transformation that puts antisymmetric_matrix
-    # into canonical form
-    canonical, orthogonal = antisymmetric_canonical_form(antisymmetric_matrix)
-
-    # Create the matrix that converts between fermionic ladder and
-    # Majorana bases
-    normalized_identity = numpy.eye(n_qubits, dtype=complex) / numpy.sqrt(2.)
-    majorana_basis_change = numpy.eye(
-            2 * n_qubits, dtype=complex) / numpy.sqrt(2.)
-    majorana_basis_change[n_qubits:, n_qubits:] *= -1.j
-    majorana_basis_change[:n_qubits, n_qubits:] = normalized_identity
-    majorana_basis_change[n_qubits:, :n_qubits] = 1.j * normalized_identity
-
-    # Compute the unitary and return
-    diagonalizing_unitary = majorana_basis_change.T.conj().dot(
-            orthogonal.dot(majorana_basis_change))
-
-    return diagonalizing_unitary
-
-
-def antisymmetric_canonical_form(antisymmetric_matrix):
-    """Compute the canonical form of an antisymmetric matrix.
-
-    The input is a real, antisymmetric n x n matrix A, where n is even.
-    Its canonical form is::
-
-        A = R^T C R
-
-    where R is a real, orthogonal matrix and C has the form::
-
-        [  0     D ]
-        [ -D     0 ]
-
-    where D is a diagonal matrix with nonnegative entries.
-
-    Args:
-        antisymmetric_matrix(ndarray): An antisymmetric matrix with even
-            dimension.
-
-    Returns:
-        canonical(ndarray): The canonical form C of antisymmetric_matrix
-        orthogonal(ndarray): The orthogonal transformation R.
-    """
-    m, n = antisymmetric_matrix.shape
-
-    if m != n or n % 2 != 0:
-        raise ValueError('The input matrix must be square with even '
-                         'dimension.')
-
-    # Check that input matrix is antisymmetric
-    matrix_plus_transpose = antisymmetric_matrix + antisymmetric_matrix.T
-    maxval = numpy.max(numpy.abs(matrix_plus_transpose))
-    if maxval > EQ_TOLERANCE:
-        raise ValueError('The input matrix must be antisymmetric.')
-
-    # Compute Schur decomposition
-    canonical, orthogonal = schur(antisymmetric_matrix, output='real')
-
-    # The returned form is block diagonal; we need to permute rows and columns
-    # to put it into the form we want
-    num_blocks = n // 2
-    for i in range(1, num_blocks, 2):
-        swap_rows(canonical, i, num_blocks + i - 1)
-        swap_columns(canonical, i, num_blocks + i - 1)
-        swap_columns(orthogonal, i, num_blocks + i - 1)
-        if num_blocks % 2 != 0:
-            swap_rows(canonical, num_blocks - 1, num_blocks + i)
-            swap_columns(canonical, num_blocks - 1, num_blocks + i)
-            swap_columns(orthogonal, num_blocks - 1, num_blocks + i)
-
-    # Now we permute so that the upper right block is non-negative
-    for i in range(num_blocks):
-        if canonical[i, num_blocks + i] < -EQ_TOLERANCE:
-            swap_rows(canonical, i, num_blocks + i)
-            swap_columns(canonical, i, num_blocks + i)
-            swap_columns(orthogonal, i, num_blocks + i)
-
-    return canonical, orthogonal.T

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -19,6 +19,7 @@ from scipy.linalg import schur
 
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import FermionOperator, PolynomialTensor
+from openfermion.utils._slater_determinants import swap_columns, swap_rows
 
 
 class QuadraticHamiltonianError(Exception):
@@ -295,17 +296,3 @@ def antisymmetric_canonical_form(antisymmetric_matrix):
             swap_columns(orthogonal, i, num_blocks + i)
 
     return canonical, orthogonal.T
-
-
-def swap_rows(M, i, j):
-    """Swap rows i and j of matrix M."""
-    row_i = M[i, :].copy()
-    row_j = M[j, :].copy()
-    M[i, :], M[j, :] = row_j, row_i
-
-
-def swap_columns(M, i, j):
-    """Swap columns i and j of matrix M."""
-    column_i = M[:, i].copy()
-    column_j = M[:, j].copy()
-    M[:, i], M[:, j] = column_j, column_i

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -182,11 +182,15 @@ def majorana_operator(term=None, coefficient=1.):
     elif isinstance(term, tuple):
         mode, operator_type = term
         if operator_type == 1:
-            majorana_op = FermionOperator(((mode, 1),), coefficient / numpy.sqrt(2.))
-            majorana_op += FermionOperator(((mode, 0),), coefficient / numpy.sqrt(2.))
+            majorana_op = FermionOperator(
+                    ((mode, 1),), coefficient / numpy.sqrt(2.))
+            majorana_op += FermionOperator(
+                    ((mode, 0),), coefficient / numpy.sqrt(2.))
         elif operator_type == 0:
-            majorana_op = FermionOperator(((mode, 1),), 1.j * coefficient / numpy.sqrt(2.))
-            majorana_op -= FermionOperator(((mode, 0),), 1.j * coefficient / numpy.sqrt(2.))
+            majorana_op = FermionOperator(
+                    ((mode, 1),), 1.j * coefficient / numpy.sqrt(2.))
+            majorana_op -= FermionOperator(
+                    ((mode, 0),), 1.j * coefficient / numpy.sqrt(2.))
         else:
             raise ValueError('Operator specified incorrectly.')
         return majorana_op

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -82,3 +82,7 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         """Test checking whether Hamiltonian conserves particle number."""
         self.assertTrue(self.quad_ham_pc.conserves_particle_number())
         self.assertFalse(self.quad_ham_npc.conserves_particle_number())
+
+    def test_majorana_form(self):
+        """Test getting the Majorana form."""
+        majorana_matrix = self.quad_ham_npc.majorana_form()

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -27,7 +27,7 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
 
     def setUp(self):
         self.n_qubits = 5
-        self.constant = 1.
+        self.constant = 1.7
         self.chemical_potential = 2.
 
         # Obtain random Hermitian and antisymmetric matrices

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -128,6 +128,23 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
                 self.quad_ham_npc.ground_state_preparation_circuit())
 
 
+class MajoranaOperatorTest(unittest.TestCase):
+
+    def test_none_term(self):
+        majorana_op = majorana_operator()
+        self.assertTrue(majorana_operator().isclose(FermionOperator()))
+
+    def test_bad_coefficient(self):
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator((1, 1), 'a')
+
+    def test_bad_term(self):
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator((2, 2))
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator('a')
+
+
 class DiagonalizingFermionicUnitaryTest(unittest.TestCase):
 
     def test_bad_dimensions(self):

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -35,9 +35,13 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         self.chemical_potential = 2.
 
         # Obtain random Hermitian and antisymmetric matrices
-        rand_mat = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_A = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_B = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat = rand_mat_A + 1.j * rand_mat_B
         self.hermitian_mat = rand_mat + rand_mat.T.conj()
-        rand_mat = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_A = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_B = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat = rand_mat_A + 1.j * rand_mat_B
         self.antisymmetric_mat = rand_mat - rand_mat.T
 
         self.combined_hermitian = (
@@ -113,6 +117,15 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
                 get_fermion_operator(self.quad_ham_npc))
         self.assertTrue(
                 normal_ordered(majorana_op).isclose(fermion_operator))
+
+    def test_ground_state_preparation_circuit(self):
+        """Test obtaining the ground state preparation circuit."""
+        # Test a particle-number-conserving Hamiltonian
+        circuit_description = (
+                self.quad_ham_pc.ground_state_preparation_circuit())
+        # Test a non-particle-number-conserving Hamiltonian
+        circuit_description = (
+                self.quad_ham_npc.ground_state_preparation_circuit())
 
 
 class DiagonalizingFermionicUnitaryTest(unittest.TestCase):

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -20,10 +20,7 @@ from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import (FermionOperator,
                              QuadraticHamiltonian,
                              normal_ordered)
-from openfermion.ops._quadratic_hamiltonian import (
-        antisymmetric_canonical_form,
-        diagonalizing_fermionic_unitary,
-        majorana_operator)
+from openfermion.ops._quadratic_hamiltonian import majorana_operator
 from openfermion.transforms import get_fermion_operator
 
 
@@ -118,15 +115,6 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         self.assertTrue(
                 normal_ordered(majorana_op).isclose(fermion_operator))
 
-    def test_ground_state_preparation_circuit(self):
-        """Test obtaining the ground state preparation circuit."""
-        # Test a particle-number-conserving Hamiltonian
-        circuit_description = (
-                self.quad_ham_pc.ground_state_preparation_circuit())
-        # Test a non-particle-number-conserving Hamiltonian
-        circuit_description = (
-                self.quad_ham_npc.ground_state_preparation_circuit())
-
 
 class MajoranaOperatorTest(unittest.TestCase):
 
@@ -143,74 +131,3 @@ class MajoranaOperatorTest(unittest.TestCase):
             majorana_op = majorana_operator((2, 2))
         with self.assertRaises(ValueError):
             majorana_op = majorana_operator('a')
-
-
-class DiagonalizingFermionicUnitaryTest(unittest.TestCase):
-
-    def test_bad_dimensions(self):
-        n, p = (3, 4)
-        ones_mat = numpy.ones((n, p))
-        with self.assertRaises(ValueError):
-            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
-
-    def test_not_antisymmetric(self):
-        n = 4
-        ones_mat = numpy.ones((n, n))
-        with self.assertRaises(ValueError):
-            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
-
-    def test_n_equals_3(self):
-        n = 3
-        # Obtain a random antisymmetric matrix
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-
-        # Get the diagonalizing fermionic unitary
-        ferm_unitary = diagonalizing_fermionic_unitary(antisymmetric_matrix)
-        lower_unitary = ferm_unitary[n:]
-        lower_left = lower_unitary[:, :n]
-        lower_right = lower_unitary[:, n:]
-
-        # Check that lower_left and lower_right satisfy the constraints
-        # necessary for the transformed fermionic operators to satisfy
-        # the fermionic anticommutation relations
-        constraint_matrix_1 = (lower_left.dot(lower_left.T.conj()) +
-                               lower_right.dot(lower_right.T.conj()))
-        constraint_matrix_2 = (lower_left.dot(lower_right.T) +
-                               lower_right.dot(lower_left.T))
-
-        identity = numpy.eye(n, dtype=complex)
-        for i in numpy.ndindex((n, n)):
-            self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
-            self.assertAlmostEqual(0., constraint_matrix_2[i])
-
-
-class AntisymmetricCanonicalFormTest(unittest.TestCase):
-
-    def test_equality(self):
-        """Test that the decomposition is valid."""
-        n = 7
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-        canonical, orthogonal = antisymmetric_canonical_form(
-                antisymmetric_matrix)
-        result_matrix = orthogonal.dot(antisymmetric_matrix.dot(orthogonal.T))
-        for i in numpy.ndindex(result_matrix.shape):
-            self.assertAlmostEqual(result_matrix[i], canonical[i])
-
-    def test_canonical(self):
-        """Test that the returned canonical matrix has the right form."""
-        n = 7
-        # Obtain a random antisymmetric matrix
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-        canonical, orthogonal = antisymmetric_canonical_form(
-                antisymmetric_matrix)
-        for i in range(2 * n):
-            for j in range(2 * n):
-                if i < n and j == n + i:
-                    self.assertTrue(canonical[i, j] > -EQ_TOLERANCE)
-                elif i >= n and j == i - n:
-                    self.assertTrue(canonical[i, j] < -EQ_TOLERANCE)
-                else:
-                    self.assertAlmostEqual(canonical[i, j], 0.)

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -20,8 +20,9 @@ from ._operator_utils import (commutator, count_qubits,
                               get_file_path, inverse_fourier_transform,
                               is_identity, load_operator, save_operator)
 
-from ._slater_determinants import (givens_decomposition,
-                                   fermionic_gaussian_decomposition)
+from ._slater_determinants import (fermionic_gaussian_decomposition,
+                                   givens_decomposition,
+                                   ground_state_preparation_circuit)
 
 from ._sparse_tools import (expectation,
                             expectation_computational_basis_state,

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -15,7 +15,6 @@ Slater determinants and fermionic Gaussian states."""
 from __future__ import absolute_import
 
 import numpy
-from scipy.linalg import schur
 
 from openfermion.config import EQ_TOLERANCE
 
@@ -146,109 +145,6 @@ def fermionic_gaussian_decomposition(unitary_rows):
     # Get the diagonal entries
     diagonal = current_matrix[range(n), range(n, 2 * n)]
     return left_unitary, decomposition, diagonal
-
-
-def diagonalizing_fermionic_unitary(antisymmetric_matrix):
-    """Compute the unitary that diagonalizes a quadratic Hamiltonian.
-
-    The input matrix represents a quadratic Hamiltonian in the Majorana basis.
-    The output matrix is a unitary that represents a transformation (mixing)
-    of the fermionic ladder operators. We use the convention that the
-    creation operators are listed before the annihilation operators.
-    The returned unitary has additional structure which ensures
-    that the transformed ladder operators also satisfy the fermionic
-    anticommutation relations.
-
-    Args:
-        antisymmetric_matrix(ndarray): A (2 * n_qubits) x (2 * n_qubits)
-            antisymmetric matrix representing a quadratic Hamiltonian in the
-            Majorana basis.
-    Returns:
-        diagonalizing_unitary(ndarray): A (2 * n_qubits) x (2 * n_qubits)
-            unitary matrix representing a transformation of the fermionic
-            ladder operators.
-    """
-    m, n = antisymmetric_matrix.shape
-    n_qubits = n // 2
-
-    # Get the orthogonal transformation that puts antisymmetric_matrix
-    # into canonical form
-    canonical, orthogonal = antisymmetric_canonical_form(antisymmetric_matrix)
-
-    # Create the matrix that converts between fermionic ladder and
-    # Majorana bases
-    normalized_identity = numpy.eye(n_qubits, dtype=complex) / numpy.sqrt(2.)
-    majorana_basis_change = numpy.eye(
-            2 * n_qubits, dtype=complex) / numpy.sqrt(2.)
-    majorana_basis_change[n_qubits:, n_qubits:] *= -1.j
-    majorana_basis_change[:n_qubits, n_qubits:] = normalized_identity
-    majorana_basis_change[n_qubits:, :n_qubits] = 1.j * normalized_identity
-
-    # Compute the unitary and return
-    diagonalizing_unitary = majorana_basis_change.T.conj().dot(
-            orthogonal.dot(majorana_basis_change))
-
-    return diagonalizing_unitary
-
-
-def antisymmetric_canonical_form(antisymmetric_matrix):
-    """Compute the canonical form of an antisymmetric matrix.
-
-    The input is a real, antisymmetric n x n matrix A, where n is even.
-    Its canonical form is::
-
-        A = R^T C R
-
-    where R is a real, orthogonal matrix and C has the form::
-
-        [  0     D ]
-        [ -D     0 ]
-
-    where D is a diagonal matrix with nonnegative entries.
-
-    Args:
-        antisymmetric_matrix(ndarray): An antisymmetric matrix with even
-            dimension.
-
-    Returns:
-        canonical(ndarray): The canonical form C of antisymmetric_matrix
-        orthogonal(ndarray): The orthogonal transformation R.
-    """
-    m, n = antisymmetric_matrix.shape
-
-    if m != n or n % 2 != 0:
-        raise ValueError('The input matrix must be square with even '
-                         'dimension.')
-
-    # Check that input matrix is antisymmetric
-    matrix_plus_transpose = antisymmetric_matrix + antisymmetric_matrix.T
-    maxval = numpy.max(numpy.abs(matrix_plus_transpose))
-    if maxval > EQ_TOLERANCE:
-        raise ValueError('The input matrix must be antisymmetric.')
-
-    # Compute Schur decomposition
-    canonical, orthogonal = schur(antisymmetric_matrix, output='real')
-
-    # The returned form is block diagonal; we need to permute rows and columns
-    # to put it into the form we want
-    num_blocks = n // 2
-    for i in range(1, num_blocks, 2):
-        swap_rows(canonical, i, num_blocks + i - 1)
-        swap_columns(canonical, i, num_blocks + i - 1)
-        swap_columns(orthogonal, i, num_blocks + i - 1)
-        if num_blocks % 2 != 0:
-            swap_rows(canonical, num_blocks - 1, num_blocks + i)
-            swap_columns(canonical, num_blocks - 1, num_blocks + i)
-            swap_columns(orthogonal, num_blocks - 1, num_blocks + i)
-
-    # Now we permute so that the upper right block is non-negative
-    for i in range(num_blocks):
-        if canonical[i, num_blocks + i] < -EQ_TOLERANCE:
-            swap_rows(canonical, i, num_blocks + i)
-            swap_columns(canonical, i, num_blocks + i)
-            swap_columns(orthogonal, i, num_blocks + i)
-
-    return canonical, orthogonal.T
 
 
 def givens_decomposition(unitary_rows):

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -23,7 +23,22 @@ from openfermion.ops import QuadraticHamiltonian
 
 def ground_state_preparation_circuit(quadratic_hamiltonian):
     """Obtain a description of a circuit which prepares the ground state
-    of a quadratic Hamiltonian."""
+    of a quadratic Hamiltonian.
+
+    Args:
+        quadratic_hamiltonian(QuadraticHamiltonian):
+            The Hamiltonian whose ground state is desired.
+
+    Returns:
+        circuit_description(list[tuple]):
+            A list of operations describing the circuit. Each operation
+            is a tuple of objects describing elementary operations that
+            can be performed in parallel. Each elementary operation
+            is either the string 'pht', indicating a particle-hole
+            transformation on the last fermionic mode, or a tuple of
+            the form (i, j, theta, phi), indicating a Givens rotation
+            of qubits i and j by angles theta and phi.
+    """
     if not isinstance(quadratic_hamiltonian, QuadraticHamiltonian):
         raise ValueError('Input must be an instance of QuadraticHamiltonian.')
 
@@ -91,7 +106,7 @@ def fermionic_gaussian_decomposition(unitary_rows):
     something like [('pht', ), (G_1, ), ('pht', G_2), ... ].
     The objects within a tuple are either the string 'pht', which indicates
     a particle-hole transformation on the last fermionic mode, or a tuple
-    of the form (i, j, theta, phi), which indicates a Givens roation
+    of the form (i, j, theta, phi), which indicates a Givens rotation
     of rows i and j by angles theta and phi.
 
     Args:

--- a/src/openfermion/utils/_slater_determinants_test.py
+++ b/src/openfermion/utils/_slater_determinants_test.py
@@ -18,15 +18,56 @@ import unittest
 from scipy.linalg import qr
 
 from openfermion.config import EQ_TOLERANCE
-from openfermion.ops._quadratic_hamiltonian import (
-        antisymmetric_canonical_form,
-        diagonalizing_fermionic_unitary)
+from openfermion.ops import QuadraticHamiltonian
 from openfermion.utils import (fermionic_gaussian_decomposition,
-                               givens_decomposition)
+                               givens_decomposition,
+                               ground_state_preparation_circuit)
 from openfermion.utils._slater_determinants import (
+        antisymmetric_canonical_form,
+        diagonalizing_fermionic_unitary,
         double_givens_rotate,
         givens_rotate,
         swap_rows)
+
+
+class GroundStatePreparationCircuitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.n_qubits = 5
+        self.constant = 1.7
+        self.chemical_potential = 2.
+
+        # Obtain random Hermitian and antisymmetric matrices
+        rand_mat_A = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_B = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat = rand_mat_A + 1.j * rand_mat_B
+        self.hermitian_mat = rand_mat + rand_mat.T.conj()
+        rand_mat_A = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat_B = numpy.random.randn(self.n_qubits, self.n_qubits)
+        rand_mat = rand_mat_A + 1.j * rand_mat_B
+        self.antisymmetric_mat = rand_mat - rand_mat.T
+
+        self.combined_hermitian = (
+                self.hermitian_mat -
+                self.chemical_potential * numpy.eye(self.n_qubits))
+
+        # Initialize a particle-number-conserving Hamiltonian
+        self.quad_ham_pc = QuadraticHamiltonian(
+                self.constant, self.hermitian_mat)
+
+        # Initialize a non-particle-number-conserving Hamiltonian
+        self.quad_ham_npc = QuadraticHamiltonian(
+                self.constant, self.hermitian_mat, self.antisymmetric_mat,
+                self.chemical_potential)
+
+    def test_no_error(self):
+        """Test that the procedure runs without error."""
+        # Test a particle-number-conserving Hamiltonian
+        circuit_description = (
+                ground_state_preparation_circuit(self.quad_ham_pc))
+        # Test a non-particle-number-conserving Hamiltonian
+        circuit_description = (
+                ground_state_preparation_circuit(self.quad_ham_npc))
 
 
 class GivensDecompositionTest(unittest.TestCase):
@@ -770,3 +811,74 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
             self.assertAlmostEqual(diag[i], product[i])
+
+
+class DiagonalizingFermionicUnitaryTest(unittest.TestCase):
+
+    def test_bad_dimensions(self):
+        n, p = (3, 4)
+        ones_mat = numpy.ones((n, p))
+        with self.assertRaises(ValueError):
+            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
+
+    def test_not_antisymmetric(self):
+        n = 4
+        ones_mat = numpy.ones((n, n))
+        with self.assertRaises(ValueError):
+            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
+
+    def test_n_equals_3(self):
+        n = 3
+        # Obtain a random antisymmetric matrix
+        rand_mat = numpy.random.randn(2 * n, 2 * n)
+        antisymmetric_matrix = rand_mat - rand_mat.T
+
+        # Get the diagonalizing fermionic unitary
+        ferm_unitary = diagonalizing_fermionic_unitary(antisymmetric_matrix)
+        lower_unitary = ferm_unitary[n:]
+        lower_left = lower_unitary[:, :n]
+        lower_right = lower_unitary[:, n:]
+
+        # Check that lower_left and lower_right satisfy the constraints
+        # necessary for the transformed fermionic operators to satisfy
+        # the fermionic anticommutation relations
+        constraint_matrix_1 = (lower_left.dot(lower_left.T.conj()) +
+                               lower_right.dot(lower_right.T.conj()))
+        constraint_matrix_2 = (lower_left.dot(lower_right.T) +
+                               lower_right.dot(lower_left.T))
+
+        identity = numpy.eye(n, dtype=complex)
+        for i in numpy.ndindex((n, n)):
+            self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
+            self.assertAlmostEqual(0., constraint_matrix_2[i])
+
+
+class AntisymmetricCanonicalFormTest(unittest.TestCase):
+
+    def test_equality(self):
+        """Test that the decomposition is valid."""
+        n = 7
+        rand_mat = numpy.random.randn(2 * n, 2 * n)
+        antisymmetric_matrix = rand_mat - rand_mat.T
+        canonical, orthogonal = antisymmetric_canonical_form(
+                antisymmetric_matrix)
+        result_matrix = orthogonal.dot(antisymmetric_matrix.dot(orthogonal.T))
+        for i in numpy.ndindex(result_matrix.shape):
+            self.assertAlmostEqual(result_matrix[i], canonical[i])
+
+    def test_canonical(self):
+        """Test that the returned canonical matrix has the right form."""
+        n = 7
+        # Obtain a random antisymmetric matrix
+        rand_mat = numpy.random.randn(2 * n, 2 * n)
+        antisymmetric_matrix = rand_mat - rand_mat.T
+        canonical, orthogonal = antisymmetric_canonical_form(
+                antisymmetric_matrix)
+        for i in range(2 * n):
+            for j in range(2 * n):
+                if i < n and j == n + i:
+                    self.assertTrue(canonical[i, j] > -EQ_TOLERANCE)
+                elif i >= n and j == i - n:
+                    self.assertTrue(canonical[i, j] < -EQ_TOLERANCE)
+                else:
+                    self.assertAlmostEqual(canonical[i, j], 0.)

--- a/src/openfermion/utils/_slater_determinants_test.py
+++ b/src/openfermion/utils/_slater_determinants_test.py
@@ -18,11 +18,12 @@ import unittest
 from scipy.linalg import qr
 
 from openfermion.config import EQ_TOLERANCE
+from openfermion.ops._quadratic_hamiltonian import (
+        antisymmetric_canonical_form,
+        diagonalizing_fermionic_unitary)
 from openfermion.utils import (fermionic_gaussian_decomposition,
                                givens_decomposition)
 from openfermion.utils._slater_determinants import (
-        antisymmetric_canonical_form,
-        diagonalizing_fermionic_unitary,
         double_givens_rotate,
         givens_rotate,
         swap_rows)
@@ -769,74 +770,3 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         # Assert that W and D are the same
         for i in numpy.ndindex((n, 2 * n)):
             self.assertAlmostEqual(diag[i], product[i])
-
-
-class DiagonalizingFermionicUnitaryTest(unittest.TestCase):
-
-    def test_bad_dimensions(self):
-        n, p = (3, 4)
-        ones_mat = numpy.ones((n, p))
-        with self.assertRaises(ValueError):
-            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
-
-    def test_not_antisymmetric(self):
-        n = 4
-        ones_mat = numpy.ones((n, n))
-        with self.assertRaises(ValueError):
-            ferm_unitary = diagonalizing_fermionic_unitary(ones_mat)
-
-    def test_n_equals_3(self):
-        n = 3
-        # Obtain a random antisymmetric matrix
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-
-        # Get the diagonalizing fermionic unitary
-        ferm_unitary = diagonalizing_fermionic_unitary(antisymmetric_matrix)
-        lower_unitary = ferm_unitary[n:]
-        lower_left = lower_unitary[:, :n]
-        lower_right = lower_unitary[:, n:]
-
-        # Check that lower_left and lower_right satisfy the constraints
-        # necessary for the transformed fermionic operators to satisfy
-        # the fermionic anticommutation relations
-        constraint_matrix_1 = (lower_left.dot(lower_left.T.conj()) +
-                               lower_right.dot(lower_right.T.conj()))
-        constraint_matrix_2 = (lower_left.dot(lower_right.T) +
-                               lower_right.dot(lower_left.T))
-
-        identity = numpy.eye(n, dtype=complex)
-        for i in numpy.ndindex((n, n)):
-            self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
-            self.assertAlmostEqual(0., constraint_matrix_2[i])
-
-
-class AntisymmetricCanonicalFormTest(unittest.TestCase):
-
-    def test_equality(self):
-        """Test that the decomposition is valid."""
-        n = 7
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-        canonical, orthogonal = antisymmetric_canonical_form(
-                antisymmetric_matrix)
-        result_matrix = orthogonal.dot(antisymmetric_matrix.dot(orthogonal.T))
-        for i in numpy.ndindex(result_matrix.shape):
-            self.assertAlmostEqual(result_matrix[i], canonical[i])
-
-    def test_canonical(self):
-        """Test that the returned canonical matrix has the right form."""
-        n = 7
-        # Obtain a random antisymmetric matrix
-        rand_mat = numpy.random.randn(2 * n, 2 * n)
-        antisymmetric_matrix = rand_mat - rand_mat.T
-        canonical, orthogonal = antisymmetric_canonical_form(
-                antisymmetric_matrix)
-        for i in range(2 * n):
-            for j in range(2 * n):
-                if i < n and j == n + i:
-                    self.assertTrue(canonical[i, j] > -EQ_TOLERANCE)
-                elif i >= n and j == i - n:
-                    self.assertTrue(canonical[i, j] < -EQ_TOLERANCE)
-                else:
-                    self.assertAlmostEqual(canonical[i, j], 0.)


### PR DESCRIPTION
- Added method to obtain circuits for preparation of ground states of quadratic Hamiltonians
- Slightly changed initialization of QuadraticHamiltonian so it doesn't store the antisymmetric part if it's not given

Fixes #94 .

Also, I must admit that I cheated on the tests for the ground state circuits; the test only checks that they run without producing errors, and not that the circuit actually produces the ground state. I plan to write code to produce the ground state from the circuit so that this can be tested, but I'm still thinking about the best way to do this; it might involve using ProjectQ, which I'm not familiar with yet. Specifically, I don't want to write extra code that converts the circuit to sparse matrix operations if there's a more elegant way to do it. I'm okay with this PR not being merged until that is figured out.

On a related note, the circuit should probably eventually be output in a format that's more amenable to use in other programs.