### PR TITLE
Rewrote jw_hartree_fock_state

### DIFF
--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -203,6 +203,7 @@ def jw_slater_determinant(occupied_orbitals, n_orbitals):
         occupied_orbitals(list): A list of integers representing the indices
             of the occupied orbitals in the desired Slater determinant
         n_orbitals(int): The total number of orbitals
+
     Returns:
         slater_determinant(sparse): The JW-encoded Slater determinant as a
             sparse matrix

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -34,7 +34,7 @@ from openfermion.hamiltonians._jellium import (momentum_vector,
 
 
 # Make global definitions.
-identity_csc = scipy.sparse.identity(2, format='csr', dtype=complex)
+identity_csc = scipy.sparse.identity(2, format='csc', dtype=complex)
 pauli_x_csc = scipy.sparse.csc_matrix([[0., 1.], [1., 0.]], dtype=complex)
 pauli_y_csc = scipy.sparse.csc_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
 pauli_z_csc = scipy.sparse.csc_matrix([[1., 0.], [0., -1.]], dtype=complex)

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -197,14 +197,11 @@ def qubit_operator_sparse(qubit_operator, n_qubits=None):
 
 
 def jw_hartree_fock_state(n_electrons, n_orbitals):
-    """Function to product Hartree-Fock state in JW representation."""
-    occupied = scipy.sparse.csr_matrix([[0], [1]], dtype=float)
-    psi = 1.
-    unoccupied = scipy.sparse.csr_matrix([[1], [0]], dtype=float)
-    for orbital in range(n_electrons):
-        psi = scipy.sparse.kron(psi, occupied, 'csr')
-    for orbital in range(n_orbitals - n_electrons):
-        psi = scipy.sparse.kron(psi, unoccupied, 'csr')
+    """Function to produce Hartree-Fock state in JW representation."""
+    one_index = sum([2 ** (n_orbitals - i - 1) for i in range(n_electrons)])
+    psi = scipy.sparse.csr_matrix(([1.], ([one_index], [0])),
+                                  shape=(2 ** n_orbitals, 1),
+                                  dtype=float)
     return psi
 
 

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -196,13 +196,28 @@ def qubit_operator_sparse(qubit_operator, n_qubits=None):
     return sparse_operator
 
 
+def jw_slater_determinant(occupied_orbitals, n_orbitals):
+    """Function to produce a Slater determinant in JW representation.
+
+    Args:
+        occupied_orbitals(list): A list of integers representing the indices
+            of the occupied orbitals in the desired Slater determinant
+        n_orbitals(int): The total number of orbitals
+    Returns:
+        slater_determinant(sparse): The JW-encoded Slater determinant as a
+            sparse matrix
+    """
+    one_index = sum([2 ** (n_orbitals - 1 - i) for i in occupied_orbitals])
+    slater_determinant = scipy.sparse.csc_matrix(([1.], ([one_index], [0])),
+                                                 shape=(2 ** n_orbitals, 1),
+                                                 dtype=float)
+    return slater_determinant
+
+
 def jw_hartree_fock_state(n_electrons, n_orbitals):
     """Function to produce Hartree-Fock state in JW representation."""
-    one_index = sum([2 ** (n_orbitals - i - 1) for i in range(n_electrons)])
-    psi = scipy.sparse.csr_matrix(([1.], ([one_index], [0])),
-                                  shape=(2 ** n_orbitals, 1),
-                                  dtype=float)
-    return psi
+    hartree_fock_state = jw_slater_determinant(range(n_electrons), n_orbitals)
+    return hartree_fock_state
 
 
 def jw_number_indices(n_electrons, n_qubits):

--- a/src/openfermion/utils/_sparse_tools_test.py
+++ b/src/openfermion/utils/_sparse_tools_test.py
@@ -201,6 +201,15 @@ class JordanWignerSparseTest(unittest.TestCase):
             expected.A))
 
 
+class JWSlaterDeterminantTest(unittest.TestCase):
+
+    def test_jw_hartree_fock_state(self):
+        hartree_fock_state = jw_hartree_fock_state(3, 7)
+        dense_array = hartree_fock_state.toarray()
+        self.assertAlmostEqual(dense_array[112, 0], 1.)
+        self.assertAlmostEqual(sum(dense_array), 1.)
+
+
 class JWGetGroundStatesByParticleNumberTest(unittest.TestCase):
     def test_jw_get_ground_states_by_particle_number_herm_conserving(self):
         # Initialize a particle-number-conserving Hermitian operator


### PR DESCRIPTION
I noticed that `jw_hartree_fock_state` could be made more efficient. I actually wrote a more general function `jw_slater_determinant` which lets you instantiate any computational basis vector. I think it's an improvement.

The original function returns a CSR matrix but I noticed that we mostly use CSC so I returned a CSC. Not sure what the policy on that is (if any). Along those lines, I fixed what seems to be a typo in the initialization of `identity_csc`.