### PR TITLE
PolynomialTensor dictionary should be accessed through methods

### DIFF
--- a/src/openfermion/ops/_interaction_operator.py
+++ b/src/openfermion/ops/_interaction_operator.py
@@ -64,9 +64,14 @@ class InteractionOperator(PolynomialTensor):
                 {(): constant,
                  (1, 0): one_body_tensor,
                  (1, 1, 0, 0): two_body_tensor})
-        self.constant = self.n_body_tensors[()]
-        self.one_body_tensor = self.n_body_tensors[1, 0]
-        self.two_body_tensor = self.n_body_tensors[1, 1, 0, 0]
+
+    def one_body_tensor(self):
+        """Get the one-body tensor."""
+        return self.n_body_tensors[1, 0]
+
+    def two_body_tensor(self):
+        """Get the two-body tensor."""
+        return self.n_body_tensors[1, 1, 0, 0]
 
     def unique_iter(self, complex_valued=False):
         """
@@ -86,19 +91,19 @@ class InteractionOperator(PolynomialTensor):
             tuple[int]
         """
         # Constant.
-        if self.constant:
+        if self.constant():
             yield ()
 
         # One-body terms.
         for p in range(self.n_qubits):
             for q in range(p + 1):
-                if self.one_body_tensor[p, q]:
+                if self.one_body_tensor()[p, q]:
                     yield (p, 1), (q, 0)
 
         # Two-body terms.
         seen = set()
         for quad in itertools.product(range(self.n_qubits), repeat=4):
-            if self.two_body_tensor[quad] and quad not in seen:
+            if self.two_body_tensor()[quad] and quad not in seen:
                 seen |= set(_symmetric_two_body_terms(quad, complex_valued))
                 yield tuple(zip(quad, (1, 1, 0, 0)))
 

--- a/src/openfermion/ops/_interaction_operator.py
+++ b/src/openfermion/ops/_interaction_operator.py
@@ -67,11 +67,11 @@ class InteractionOperator(PolynomialTensor):
 
     def one_body_tensor(self):
         """Get the one-body tensor."""
-        return self.n_body_tensors[1, 0]
+        return self.n_body_tensors[1, 0].copy()
 
     def two_body_tensor(self):
         """Get the two-body tensor."""
-        return self.n_body_tensors[1, 1, 0, 0]
+        return self.n_body_tensors[1, 1, 0, 0].copy()
 
     def unique_iter(self, complex_valued=False):
         """

--- a/src/openfermion/ops/_interaction_rdm.py
+++ b/src/openfermion/ops/_interaction_rdm.py
@@ -46,8 +46,14 @@ class InteractionRDM(PolynomialTensor):
         """
         super(InteractionRDM, self).__init__(
                 {(1, 0): one_body_tensor, (1, 1, 0, 0): two_body_tensor})
-        self.one_body_tensor = self.n_body_tensors[1, 0]
-        self.two_body_tensor = self.n_body_tensors[1, 1, 0, 0]
+
+    def one_body_tensor(self):
+        """Get the one-body tensor."""
+        return self.n_body_tensors[1, 0]
+
+    def two_body_tensor(self):
+        """Get the two-body tensor."""
+        return self.n_body_tensors[1, 1, 0, 0]
 
     def expectation(self, operator):
         """Return expectation value of an InteractionRDM with an operator.
@@ -68,11 +74,11 @@ class InteractionRDM(PolynomialTensor):
                 expectation += (operator.terms[qubit_term] *
                                 expectation_op.terms[qubit_term])
         elif isinstance(operator, InteractionOperator):
-            expectation = operator.constant
-            expectation += numpy.sum(self.one_body_tensor *
-                                     operator.one_body_tensor)
-            expectation += numpy.sum(self.two_body_tensor *
-                                     operator.two_body_tensor)
+            expectation = operator.constant()
+            expectation += numpy.sum(self.one_body_tensor() *
+                                     operator.one_body_tensor())
+            expectation += numpy.sum(self.two_body_tensor() *
+                                     operator.two_body_tensor())
         else:
             raise InteractionRDMError('Invalid operator type provided.')
         return expectation

--- a/src/openfermion/ops/_polynomial_tensor.py
+++ b/src/openfermion/ops/_polynomial_tensor.py
@@ -126,6 +126,29 @@ class PolynomialTensor(object):
             key = next(key_iterator)
         self.n_qubits = n_body_tensors[key].shape[0]
 
+    def constant(self):
+        """Get the constant term of the tensor."""
+        if () in self.n_body_tensors:
+            return self.n_body_tensors[()]
+        else:
+            return 0.
+
+    def rotate_basis(self, rotation_matrix):
+        """
+        Rotate the orbital basis of the PolynomialTensor.
+
+        Args:
+            rotation_matrix: A square numpy array or matrix having
+                dimensions of n_qubits by n_qubits. Assumed to be real and
+                invertible.
+        """
+        if (1, 0) in self.n_body_tensors:
+            self.n_body_tensors[1, 0] = one_body_basis_change(
+                self.n_body_tensors[1, 0], rotation_matrix)
+        if (1, 1, 0, 0) in self.n_body_tensors:
+            self.n_body_tensors[1, 1, 0, 0] = two_body_basis_change(
+                self.n_body_tensors[1, 1, 0, 0], rotation_matrix)
+
     def __getitem__(self, args):
         """Look up matrix element.
 
@@ -266,22 +289,6 @@ class PolynomialTensor(object):
         for key in self:
             strings.append('{} {}\n'.format(key, self[key]))
         return ''.join(strings) if strings else '0'
-
-    def rotate_basis(self, rotation_matrix):
-        """
-        Rotate the orbital basis of the PolynomialTensor.
-
-        Args:
-            rotation_matrix: A square numpy array or matrix having
-                dimensions of n_qubits by n_qubits. Assumed to be real and
-                invertible.
-        """
-        if (1, 0) in self.n_body_tensors:
-            self.n_body_tensors[1, 0] = one_body_basis_change(
-                self.n_body_tensors[1, 0], rotation_matrix)
-        if (1, 1, 0, 0) in self.n_body_tensors:
-            self.n_body_tensors[1, 1, 0, 0] = two_body_basis_change(
-                self.n_body_tensors[1, 1, 0, 0], rotation_matrix)
 
     def __repr__(self):
         return str(self)

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -84,7 +84,6 @@ class QuadraticHamiltonian(PolynomialTensor):
                      (0, 0): -.5 * antisymmetric_part.conj()})
 
         # Add remaining attributes
-        self.constant = self.n_body_tensors[()]
         self.chemical_potential = chemical_potential
 
     def combined_hermitian_part(self):

--- a/src/openfermion/tests/_hydrogen_integration_test.py
+++ b/src/openfermion/tests/_hydrogen_integration_test.py
@@ -45,9 +45,9 @@ class HydrogenIntegrationTest(unittest.TestCase):
         self.fci_rdm = self.molecule.get_molecular_rdm(use_fci=1)
 
         # Get explicit coefficients.
-        self.nuclear_repulsion = self.molecular_hamiltonian.constant
-        self.one_body = self.molecular_hamiltonian.one_body_tensor
-        self.two_body = self.molecular_hamiltonian.two_body_tensor
+        self.nuclear_repulsion = self.molecular_hamiltonian.constant()
+        self.one_body = self.molecular_hamiltonian.one_body_tensor()
+        self.two_body = self.molecular_hamiltonian.two_body_tensor()
 
         # Get fermion Hamiltonian.
         self.fermion_hamiltonian = normal_ordered(get_fermion_operator(
@@ -186,10 +186,12 @@ class HydrogenIntegrationTest(unittest.TestCase):
 
         # Test energy of RDM.
         fci_rdm_energy = self.nuclear_repulsion
-        fci_rdm_energy += numpy.sum(self.fci_rdm.one_body_tensor *
-                                    self.molecular_hamiltonian.one_body_tensor)
-        fci_rdm_energy += numpy.sum(self.fci_rdm.two_body_tensor *
-                                    self.molecular_hamiltonian.two_body_tensor)
+        fci_rdm_energy += numpy.sum(
+                self.fci_rdm.one_body_tensor() *
+                self.molecular_hamiltonian.one_body_tensor())
+        fci_rdm_energy += numpy.sum(
+                self.fci_rdm.two_body_tensor() *
+                self.molecular_hamiltonian.two_body_tensor())
         self.assertAlmostEqual(fci_rdm_energy, self.molecule.fci_energy)
 
         # Confirm expectation on qubit Hamiltonian using reverse JW matches.

--- a/src/openfermion/tests/_lih_integration_test.py
+++ b/src/openfermion/tests/_lih_integration_test.py
@@ -51,9 +51,9 @@ class LiHIntegrationTest(unittest.TestCase):
         self.fci_rdm = self.molecule.get_molecular_rdm(use_fci=1)
 
         # Get explicit coefficients.
-        self.nuclear_repulsion = self.molecular_hamiltonian.constant
-        self.one_body = self.molecular_hamiltonian.one_body_tensor
-        self.two_body = self.molecular_hamiltonian.two_body_tensor
+        self.nuclear_repulsion = self.molecular_hamiltonian.constant()
+        self.one_body = self.molecular_hamiltonian.one_body_tensor()
+        self.two_body = self.molecular_hamiltonian.two_body_tensor()
 
         # Get fermion Hamiltonian.
         self.fermion_hamiltonian = normal_ordered(get_fermion_operator(
@@ -63,9 +63,9 @@ class LiHIntegrationTest(unittest.TestCase):
         self.qubit_hamiltonian = jordan_wigner(self.fermion_hamiltonian)
 
         # Get explicit coefficients.
-        self.nuclear_repulsion = self.molecular_hamiltonian.constant
-        self.one_body = self.molecular_hamiltonian.one_body_tensor
-        self.two_body = self.molecular_hamiltonian.two_body_tensor
+        self.nuclear_repulsion = self.molecular_hamiltonian.constant()
+        self.one_body = self.molecular_hamiltonian.one_body_tensor()
+        self.two_body = self.molecular_hamiltonian.two_body_tensor()
 
         # Get matrix form.
         self.hamiltonian_matrix = get_sparse_operator(
@@ -87,9 +87,9 @@ class LiHIntegrationTest(unittest.TestCase):
 
         # Test RDM energy.
         fci_rdm_energy = self.nuclear_repulsion
-        fci_rdm_energy += numpy.sum(self.fci_rdm.one_body_tensor *
+        fci_rdm_energy += numpy.sum(self.fci_rdm.one_body_tensor() *
                                     self.one_body)
-        fci_rdm_energy += numpy.sum(self.fci_rdm.two_body_tensor *
+        fci_rdm_energy += numpy.sum(self.fci_rdm.two_body_tensor() *
                                     self.two_body)
         self.assertAlmostEqual(fci_rdm_energy, self.molecule.fci_energy)
 

--- a/src/openfermion/transforms/_bksf.py
+++ b/src/openfermion/transforms/_bksf.py
@@ -80,7 +80,7 @@ def bravyi_kitaev_fast_interaction_op(iop):
     n_qubits = count_qubits(iop)
 
     # Initialize qubit operator as constant.
-    qubit_operator = QubitOperator((), iop.constant)
+    qubit_operator = QubitOperator((), iop.constant())
     edge_matrix = bravyi_kitaev_fast_edge_matrix(iop)
     edge_matrix_indices = numpy.array(numpy.nonzero(numpy.triu(edge_matrix) -
                                       numpy.diag(numpy.diag(edge_matrix))))

--- a/src/openfermion/transforms/_bksf_test.py
+++ b/src/openfermion/transforms/_bksf_test.py
@@ -252,7 +252,7 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         one_body[(1, 1)] = .5
         one_body[(2, 2)] = .6
         one_body[(3, 3)] = .7
-        two_body = self.molecular_hamiltonian.two_body_tensor
+        two_body = self.molecular_hamiltonian.two_body_tensor()
         # initiating number operator terms for all the possible cases
         two_body[(1, 2, 3, 1)] = 0.1
         two_body[(1, 3, 2, 1)] = 0.1

--- a/src/openfermion/transforms/_conversion.py
+++ b/src/openfermion/transforms/_conversion.py
@@ -329,9 +329,9 @@ def get_molecular_data(interaction_operator,
 
     molecule.n_orbitals = len(reduction_indices)
 
-    molecule.one_body_integrals = interaction_operator.one_body_tensor[
+    molecule.one_body_integrals = interaction_operator.one_body_tensor()[
         numpy.ix_(reduction_indices, reduction_indices)]
-    molecule.two_body_integrals = interaction_operator.two_body_tensor[
+    molecule.two_body_integrals = interaction_operator.two_body_tensor()[
         numpy.ix_(reduction_indices, reduction_indices,
                   reduction_indices, reduction_indices)]
 

--- a/src/openfermion/transforms/_conversion.py
+++ b/src/openfermion/transforms/_conversion.py
@@ -319,7 +319,7 @@ def get_molecular_data(interaction_operator,
                              multiplicity=multiplicity,
                              data_directory=data_directory)
 
-    molecule.nuclear_repulsion = interaction_operator.constant
+    molecule.nuclear_repulsion = interaction_operator.constant()
 
     # Remove spin from integrals and put into molecular operator
     if reduce_spin:

--- a/src/openfermion/transforms/_jordan_wigner.py
+++ b/src/openfermion/transforms/_jordan_wigner.py
@@ -78,7 +78,7 @@ def jordan_wigner_interaction_op(iop, n_qubits=None):
         raise ValueError('Invalid number of qubits specified.')
 
     # Initialize qubit operator as constant.
-    qubit_operator = QubitOperator((), iop.constant)
+    qubit_operator = QubitOperator((), iop.constant())
 
     # Loop through all indices.
     for p in range(n_qubits):

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -280,7 +280,6 @@ class InteractionOperatorsJWTest(unittest.TestCase):
         test_op += hermitian_conjugated(test_op)
 
         interaction_op = get_interaction_operator(test_op)
-        interaction_op.constant = 0.0
 
         retransformed_test_op = reverse_jordan_wigner(jordan_wigner(
             interaction_op))

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -111,7 +111,7 @@ def jw_get_quadratic_hamiltonian_ground_state(quadratic_hamiltonian):
                 energies < -EQ_TOLERANCE)
         negative_energies = energies[:num_negative_energies]
         ground_energy = (numpy.sum(negative_energies) +
-                         quadratic_hamiltonian.constant)
+                         quadratic_hamiltonian.constant())
     else:
         majorana_matrix, majorana_constant = (
                 quadratic_hamiltonian.majorana_form())


### PR DESCRIPTION
When I was rewriting PolynomialTensor, I forgot to make it so that the attributes `one_body_tensor` and `two_body_tensor` of InteractionOperator are updated after a call to `rotate_basis`. After thinking a little about the best way to fix this, I concluded that `one_body_tensor` should actually be a method, rather than an attribute. More generally, for any subclass of PolynomialTensor, information tied to the dictionary `n_body_tensors` should be  retrieved using methods. That way any functions that manipulate PolynomialTensor objects don't need to worry about updating related attributes in subclasses.

What do people think of this? I probably should have made an issue first, but it didn't take long to just implement the change. The one thing I wasn't sure about was whether the method should return a copy or not; for now I made it return a copy because it seems less likely to cause bugs.