### PR TITLE
Fix Sphinx rendering of return values

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,9 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+# Napoleon settings
+napoleon_use_rtype = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/src/openfermion/transforms/_conversion.py
+++ b/src/openfermion/transforms/_conversion.py
@@ -311,7 +311,8 @@ def get_molecular_data(interaction_operator,
             spatial (x) spin structure generically.
 
     Returns:
-        molecule(MolecularData): Instance that captures the
+        molecule(MolecularData):
+            Instance that captures the
             interaction_operator converted into the format that would come
             from an electronic structure package adorned with some meta-data
             that may be useful.


### PR DESCRIPTION
I added a line to the Sphinx configuration. For instance, it changes the documentation of `openfermion.transforms.bravyi_kitaev` to say

>Returns: transformed_operator – An instance of the QubitOperator class

instead of

>Returns: An instance of the QubitOperator class.
>Return type: transformed_operator

which is obviously wrong. I think this is the option we're "supposed" to use according to the way we have been documenting return types. I will add that there are still other issues, like the way the phrase "Instance that captures the" is rendered here: http://openfermion.readthedocs.io/en/latest/openfermion.html#openfermion.transforms.get_molecular_data. This is fixed by starting the description of return values on a new line (I fixed this particular one in this PR). Another thing I'll add here is that apparently the proper way to make multiple return values look nice is by using this style:
```
Returns
-------
return_value_1(type)
    Description of return_value_1
return_value_2(type)
    Description of return_value_2
```
The way we've been doing it now makes Sphinx render it badly (see http://openfermion.readthedocs.io/en/latest/openfermion.html#openfermion.utils.get_ground_state) for an example.