### PR TITLE
Improved documentation of Hamiltonian models, fix bug in spinless Hubbard model

### DIFF
--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -35,35 +35,47 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
     """Return symbolic representation of a Fermi-Hubbard Hamiltonian.
 
     The idea of this model is that some fermions move around on a grid and the
-    energy of the model depends on where the fermions are. In the standard
-    Fermi-Hubbard model (which we call the "spinful" model), there is room
-    for an "up" fermion and a "down" fermion at each site on the grid.
-    Accordingly, the Hamiltonian is
+    energy of the model depends on where the fermions are.
+    The Hamiltonians of this model live on a grid of dimensions
+    `x_dimension` x `y_dimension`.
+    The grid can have periodic boundary conditions or not.
+    In the standard Fermi-Hubbard model (which we call the "spinful" model),
+    there is room for an "up" fermion and a "down" fermion at each site on the
+    grid. In this model, there are a total of `2N` spin-orbitals,
+    where `N = x_dimension * y_dimension` is the number of sites.
+    In the spinless model, there is only one spin-orbital per site
+    for a total of `N`.
+
+    The Hamiltonian for the spinful model has the form
 
     .. math::
 
         \\begin{align}
         H = &- t \sum_{\langle i,j \\rangle} \sum_{\sigma}
                      (a^\dagger_{i, \sigma} a_{j, \sigma} +
-                     a^\dagger_{j, \sigma} a_{i, \sigma})
+                      a^\dagger_{j, \sigma} a_{i, \sigma})
              + U \sum_{i} a^\dagger_{i, \\uparrow} a_{i, \\uparrow}
                          a^\dagger_{j, \downarrow} a_{j, \downarrow}
             \\\\
             &- \mu \sum_i (a^\dagger_{i, \\uparrow} a_{i, \\uparrow} +
                          a^\dagger_{i, \downarrow} a_{i, \downarrow})
              - h \sum_i (a^\dagger_{i, \\uparrow} a_{i, \\uparrow} -
-                       a^\dagger_{i, \downarrow} a_{i, \downarrow}).
+                       a^\dagger_{i, \downarrow} a_{i, \downarrow})
         \\end{align}
 
     where
 
+        - The indices :math:`\langle i, j \\rangle` run over pairs
+          :math:`i` and :math:`j` of sites that are connected to each other
+          in the grid
         - :math:`\sigma \in \\{\\uparrow, \downarrow\\}` is the spin
         - :math:`t` is the tunneling amplitude
         - :math:`U` is the Coulomb potential
         - :math:`\mu` is the chemical potential
         - :math:`h` is the magnetic field
 
-    The code also allows one to construct the spinless Fermi-Hubbard model:
+    One can also construct the Hamiltonian for the spinless model, which
+    has the form
 
     .. math::
 
@@ -71,9 +83,6 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
             + U \sum_{k=1}^{N-1} a_k^\dagger a_k a_{k+1}^\dagger a_{k+1}
             + h \sum_{k=1}^N (-1)^k a_k^\dagger a_k
             - \mu \sum_{k=1}^N a_k^\dagger a_k.
-
-    These Hamiltonians live on a grid of dimensions x_dimension by y_dimension.
-    They can have periodic boundary conditions or not.
 
     Args:
         x_dimension (int): The width of the grid.

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -140,9 +140,7 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
                 n_spin_orbitals, site, coefficient)
 
         if magnetic_field and spinless:
-            x_index = site % x_dimension
-            y_index = site // x_dimension
-            sign = (-1.) ** (x_index + y_index)
+            sign = (-1.) ** (site)
             coefficient = sign * magnetic_field
             hubbard_model += number_operator(
                 n_spin_orbitals, site, coefficient)

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -135,10 +135,15 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
 
         # Add chemical potential and magnetic field terms.
         if chemical_potential and spinless:
+            coefficient = -1. * chemical_potential
+            hubbard_model += number_operator(
+                n_spin_orbitals, site, coefficient)
+
+        if magnetic_field and spinless:
             x_index = site % x_dimension
-            y_index = (site - 1) // x_dimension
+            y_index = site // x_dimension
             sign = (-1.) ** (x_index + y_index)
-            coefficient = sign * chemical_potential
+            coefficient = sign * magnetic_field
             hubbard_model += number_operator(
                 n_spin_orbitals, site, coefficient)
 

--- a/src/openfermion/hamiltonians/_mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/_mean_field_dwave.py
@@ -10,29 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""This module contains constructions for mean-field Hamiltonian models.
-
-The mean-field d-wave model has the form
-
-H = - tunneling sum_{<i,j>} sum_sigma (a^dagger_{i, sigma} a_{j, sigma}
-  + a^dagger_{j, sigma} a_{i, sigma})
-  - sum_{<i,j>} Delta_{ij}
-  (a^dagger_{i, up} a^dagger_{j, down} - a^dagger_{i, down} a^dagger_{j, up}
-  + a_{j, down} a_{i, up} - a_{j, up} a_{i, down})
-
-where Delta_{ij} = +sc_gap/2 for horizontal edges and -sc_gap/2 for vertical
-edges.
-
-There are N sites and 2*N spin-orbitals. The operators a^dagger_i and a_i are
-fermionic creation and annihilation operators. One can transform these
-operators to qubit operator using the Jordan-Wigner transmation:
-
-a^dagger_j = 0.5 (X - i Y) prod_{k = 1}^{j - 1} Z_k
-a_j = 0.5 (X + i Y) prod_{k = 1}^{j - 1} Z_k
-
-These Hamiltonians live on a square lattice which has dimensions of
-x_dimension by y_dimension. They can have periodic boundary conditions or not.
-"""
+"""This module constructs Hamiltonians for the BCS mean-field d-wave model."""
 from __future__ import absolute_import
 
 from openfermion.hamiltonians._hubbard import up_index, down_index
@@ -41,17 +19,47 @@ from openfermion.ops import (FermionOperator,
 
 
 def mean_field_dwave(x_dimension, y_dimension, tunneling, sc_gap,
-                     periodic=True, verbose=False):
+                     periodic=True):
     """Return symbolic representation of a BCS mean-field d-wave Hamiltonian.
 
+    The Hamiltonians of this model live on a grid of dimensions
+    `x_dimension` x `y_dimension`.
+    The grid can have periodic boundary conditions or not.
+    Each site on the grid can have an "up" fermion and a "down" fermion.
+    Therefore, there are a total of `2N` spin-orbitals,
+    where `N = x_dimension * y_dimension` is the number of sites.
+
+    The Hamiltonian for this model has the form
+
+    .. math::
+
+        H = - t \sum_{\langle i,j \\rangle} \sum_\sigma
+                (a^\dagger_{i, \sigma} a_{j, \sigma} +
+                 a^\dagger_{j, \sigma} a_{i, \sigma})
+            - \sum_{\langle i,j \\rangle} \Delta_{ij}
+              (a^\dagger_{i, \\uparrow} a^\dagger_{j, \downarrow} -
+               a^\dagger_{i, \downarrow} a^\dagger_{j, \\uparrow} +
+               a_{j, \downarrow} a_{i, \\uparrow} -
+               a_{j, \\uparrow} a_{i, \downarrow})
+
+    where
+
+        - The indices :math:`\langle i, j \\rangle` run over pairs
+          :math:`i` and :math:`j` of sites that are connected to each other
+          in the grid
+        - :math:`\sigma \in \\{\\uparrow, \downarrow\\}` is the spin
+        - :math:`t` is the tunneling amplitude
+        - :math:`\Delta_{ij}` is equal to :math:`+\Delta/2` for
+          horizontal edges and :math:`-\Delta/2` for vertical edges,
+          where :math:`\Delta` is the superconducting gap.
+
     Args:
-        x_dimension: An integer giving the number of sites in width.
-        y_dimension: An integer giving the number of sites in height.
-        tunneling: A float giving the tunneling amplitude.
-        sc_gap: A float giving the magnitude of the superconducting gap.
-        periodic: If True, add periodic boundary conditions.
-        verbose: An optional Boolean. If True, print all second quantized
-            terms.
+        x_dimension (int): The width of the grid.
+        y_dimension (int): The height of the grid.
+        tunneling (float): The tunneling amplitude :math:`t`.
+        sc_gap (float): The superconducting gap :math:`\Delta`
+        periodic (bool, optional): If True, add periodic boundary conditions.
+            Default is True.
 
     Returns:
         mean_field_dwave_model: An instance of the FermionOperator class.

--- a/src/openfermion/utils/_trotter_exp_to_qgates_test.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates_test.py
@@ -13,7 +13,8 @@
 
 import unittest
 from openfermion.utils._trotter_exp_to_qgates import *
-from openfermion.utils._trotter_exp_to_qgates import _third_order_trotter_helper
+from openfermion.utils._trotter_exp_to_qgates import (
+        _third_order_trotter_helper)
 from openfermion.utils import count_qubits
 
 


### PR DESCRIPTION
- Edited the documentation of the Hubbard and mean-field models and moved them from the module header to the actual function so it shows up in the online documentation.
- Fixed what seems to be a bug in the spinless Hubbard model in which the chemical and magnetic potentials aren't added as described in the model description.