### PR TITLE
Verstraete cirac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,5 @@ install:
 
 script: export OMP_NUM_THREADS=1 && pytest src/openfermion --cov src/openfermion
 
-
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,6 @@ install:
 
 script: export OMP_NUM_THREADS=1 && pytest src/openfermion --cov src/openfermion
 
+
 after_success:
   - coveralls

--- a/src/openfermion/transforms/__init__.py
+++ b/src/openfermion/transforms/__init__.py
@@ -21,3 +21,4 @@ from ._conversion import (get_fermion_operator,
                           get_sparse_polynomial_tensor)
 from ._jordan_wigner import jordan_wigner
 from ._reverse_jordan_wigner import reverse_jordan_wigner
+from ._verstraete_cirac import verstraete_cirac_2d_square

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -100,25 +100,25 @@ def verstraete_cirac_2d_square(operator, x_dimension, y_dimension,
         # Transform the term to a QubitOperator and add it to the operator
         transformed_operator += jordan_wigner(transformed_term)
 
-        # Add the auxiliary Hamiltonian if requested and compute the
-        # resulting energy shift
-        if add_auxiliary_hamiltonian:
-            # Construct the auxiliary Hamiltonian graph
-            aux_ham_graph = auxiliary_graph_2d_square(x_dimension, y_dimension)
-            # Construct the auxiliary Hamiltonian
-            aux_ham = FermionOperator()
-            for i, j in aux_ham_graph.edges():
-                i_expanded = expand_aux_index(i)
-                j_expanded = expand_aux_index(j)
-                aux_ham -= stabilizer(i_expanded, j_expanded)
-            # Add an identity term to ensure that the auxiliary Hamiltonian
-            # has ground energy equal to zero
-            aux_ham += FermionOperator((), aux_ham_graph.size())
-            # Scale the auxiliary Hamiltonian
-            aux_ham *= aux_ham_coefficient
-            # Add it to the operator
-            transformed_operator += jordan_wigner(aux_ham)
-    
+    # Add the auxiliary Hamiltonian if requested and compute the
+    # resulting energy shift
+    if add_auxiliary_hamiltonian:
+        # Construct the auxiliary Hamiltonian graph
+        aux_ham_graph = auxiliary_graph_2d_square(x_dimension, y_dimension)
+        # Construct the auxiliary Hamiltonian
+        aux_ham = FermionOperator()
+        for i, j in aux_ham_graph.edges():
+            i_expanded = expand_aux_index(i)
+            j_expanded = expand_aux_index(j)
+            aux_ham -= stabilizer(i_expanded, j_expanded)
+        # Add an identity term to ensure that the auxiliary Hamiltonian
+        # has ground energy equal to zero
+        aux_ham += FermionOperator((), aux_ham_graph.size())
+        # Scale the auxiliary Hamiltonian
+        aux_ham *= aux_ham_coefficient
+        # Add it to the operator
+        transformed_operator += jordan_wigner(aux_ham)
+
     return transformed_operator
 
 
@@ -194,21 +194,22 @@ def auxiliary_graph_2d_square(x_dimension, y_dimension):
         graph.add_edge(k + 1, k)
         # Add bottom edge
         graph.add_edge(coordinates_to_snake_index(k, y_dimension - 1,
-                                          x_dimension, y_dimension),
+                                                  x_dimension, y_dimension),
                        coordinates_to_snake_index(k + 1, y_dimension - 1,
-                                          x_dimension, y_dimension))
+                                                  x_dimension, y_dimension))
         for l in range(y_dimension - 1):
             # Add edges between rows l and l + 1
             # Add left edge
-            graph.add_edge(coordinates_to_snake_index(k, l,
-                                              x_dimension, y_dimension),
-                           coordinates_to_snake_index(k, l + 1,
-                                              x_dimension, y_dimension))
+            graph.add_edge(
+                    coordinates_to_snake_index(k, l, x_dimension, y_dimension),
+                    coordinates_to_snake_index(k, l + 1,
+                                               x_dimension, y_dimension))
             # Add right edge
-            graph.add_edge(coordinates_to_snake_index(k + 1, l + 1,
-                                              x_dimension, y_dimension),
-                           coordinates_to_snake_index(k + 1, l,
-                                              x_dimension, y_dimension))
+            graph.add_edge(
+                    coordinates_to_snake_index(k + 1, l + 1,
+                                               x_dimension, y_dimension),
+                    coordinates_to_snake_index(k + 1, l,
+                                               x_dimension, y_dimension))
 
     return graph
 
@@ -284,6 +285,7 @@ def lexicographic_index_to_snake_index(index, x_dimension, y_dimension):
     snake_index = coordinates_to_snake_index(col, row,
                                              x_dimension, y_dimension)
     return snake_index
+
 
 def expand_sys_index(index):
     """Convert the index of a system fermion to the combined system."""

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -26,8 +26,8 @@ def verstraete_cirac_2d_square(operator, x_dimension, y_dimension,
                                snake=False):
     """Apply the Verstraete-Cirac transform on a 2-d square lattice.
 
-    NOTE: This is just skeleton code and doesn't work yet.
-    NOTE: Currently only even x_dimension is supported.
+    Currently only spinless models are supported. Furthermore, x_dimension
+    should be even.
 
     Args:
         operator (FermionOperator): The operator to transform.
@@ -96,13 +96,10 @@ def verstraete_cirac_2d_square(operator, x_dimension, y_dimension,
 
 
 def stabilizer(i, j):
-    """P_{ij} in the paper.
-
-    NOTE: We may want to flip the sign.
-    """
-    c = majorana_operator((i, 1), numpy.sqrt(2.))
-    d = majorana_operator((j, 0), numpy.sqrt(2.))
-    return 1.j * c * d
+    """P_{ij} in the paper."""
+    c_i = majorana_operator((i, 1), numpy.sqrt(2.))
+    d_j = majorana_operator((j, 0), numpy.sqrt(2.))
+    return 1.j * c_i * d_j
 
 
 def stabilizer_local_2d_square(i, j, x_dimension, y_dimension):
@@ -129,10 +126,10 @@ def stabilizer_local_2d_square(i, j, x_dimension, y_dimension):
         if top_row % 2 == 0:
             # Term is right-closed
             if i_col < x_dimension - 1:
-                extra_term_top = coordinates_to_snake_index_aux(
-                        i_col + 1, top_row, x_dimension, y_dimension)
-                extra_term_bot = coordinates_to_snake_index_aux(
-                        i_col + 1, top_row + 1, x_dimension, y_dimension)
+                extra_term_top = 2 * coordinates_to_snake_index(
+                        i_col + 1, top_row, x_dimension, y_dimension) + 1
+                extra_term_bot = 2 * coordinates_to_snake_index(
+                        i_col + 1, top_row + 1, x_dimension, y_dimension) + 1
                 if (i_col + 1) % 2 == 0:
                     stab *= stabilizer(extra_term_top, extra_term_bot)
                 else:
@@ -140,10 +137,10 @@ def stabilizer_local_2d_square(i, j, x_dimension, y_dimension):
         else:
             # Term is left-closed
             if i_col > 0:
-                extra_term_top = coordinates_to_snake_index_aux(
-                        i_col - 1, top_row, x_dimension, y_dimension)
-                extra_term_bot = coordinates_to_snake_index_aux(
-                        i_col - 1, top_row + 1, x_dimension, y_dimension)
+                extra_term_top = 2 * coordinates_to_snake_index(
+                        i_col - 1, top_row, x_dimension, y_dimension) + 1
+                extra_term_bot = 2 * coordinates_to_snake_index(
+                        i_col - 1, top_row + 1, x_dimension, y_dimension) + 1
                 if (i_col - 1) % 2 == 0:
                     stab *= stabilizer(extra_term_top, extra_term_bot)
                 else:
@@ -253,39 +250,9 @@ def snake_index_to_coordinates(index, x_dimension, y_dimension):
     return column, row
 
 
-def coordinates_to_snake_index_sys(column, row, x_dimension, y_dimension):
-    """Obtain the JWT index of a system qubit in the combined system.
-
-    NOTE: This may need to be modified to handle odd x_dimension.
-    """
-    index = 2 * coordinates_to_snake_index(column, row, x_dimension, y_dimension)
-    return index
-
-
-def coordinates_to_snake_index_aux(column, row, x_dimension, y_dimension):
-    """Obtain the JWT index of an auxiliary qubit in the combined system.
-
-    NOTE: This may need to be modified to handle odd x_dimension.
-    """
-    index = 2 * coordinates_to_snake_index(column, row, x_dimension, y_dimension) + 1
-    return index
-
-
-def snake_index_to_coordinates_sys(index, x_dimension, y_dimension):
-    """Obtain the column and row coordinates of a system qubit from its
-    JWT index in the combined system.
-    
-    NOTE: This may need to be modified to handle odd x_dimension.
-    """
-    sys_graph_index = index // 2
-    return snake_index_to_coordinates(sys_graph_index, x_dimension, y_dimension)
-
-
-def snake_index_to_coordinates_aux(index, x_dimension, y_dimension):
-    """Obtain the column and row coordinates of an auxiliary qubit from its
-    JWT index in the combined system.
-    
-    NOTE: This may need to be modified to handle odd x_dimension.
-    """
-    aux_graph_index = (index - 1) // 2
-    return snake_index_to_coordinates(aux_graph_index, x_dimension, y_dimension)
+def lexicographic_index_to_snake_index(index, x_dimension, y_dimension):
+    """Convert an index from lexicographic (row, col) order to snake order."""
+    row = index // x_dimension
+    col = index % x_dimension
+    snake_index = coordinates_to_snake_index(col, row,
+                                             x_dimension, y_dimension)

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -23,9 +23,10 @@ from openfermion.transforms import jordan_wigner
 
 
 def verstraete_cirac_2d_square(operator, x_dimension, y_dimension):
-    """ Apply the Verstraete-Cirac transform on a 2-d square lattice.
+    """Apply the Verstraete-Cirac transform on a 2-d square lattice.
 
     NOTE: This is just skeleton code and doesn't work yet.
+    NOTE: Currently only even x_dimension is supported.
 
     Args:
         operator (FermionOperator): The operator to transform.

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -159,17 +159,21 @@ def stabilizer_local_2d_square(i, j, x_dimension, y_dimension):
             abs(i_col - j_col) == 1 and i_row == j_row):
         raise ValueError("Vertices i and j are not adjacent")
 
-    stab = stabilizer(i, j)
+    # Get the JWT indices in the combined system
+    i_combined = 2 * i + 1
+    j_combined = 2 * j + 1
+
+    stab = stabilizer(i_combined, j_combined)
     if abs(i_row - j_row) == 1:
         # Term is vertical, so we may need to multiply by extra stabilizers
         top_row = min(i_row, j_row)
         if top_row % 2 == 0:
             # Term is right-closed
             if i_col < x_dimension - 1:
-                extra_term_top = jw_index_2d_square(i_col + 1, top_row,
-                                                    x_dimension, y_dimension)
-                extra_term_bot = jw_index_2d_square(i_col + 1, top_row + 1,
-                                                    x_dimension, y_dimension)
+                extra_term_top = jw_index_2d_square_aux(
+                        i_col + 1, top_row, x_dimension, y_dimension)
+                extra_term_bot = jw_index_2d_square_aux(
+                        i_col + 1, top_row + 1, x_dimension, y_dimension)
                 if (i_col + 1) % 2 == 0:
                     stab *= stabilizer(extra_term_top, extra_term_bot)
                 else:
@@ -177,10 +181,10 @@ def stabilizer_local_2d_square(i, j, x_dimension, y_dimension):
         else:
             # Term is left-closed
             if i_col > 0:
-                extra_term_top = jw_index_2d_square(i_col - 1, top_row,
-                                                    x_dimension, y_dimension)
-                extra_term_bot = jw_index_2d_square(i_col - 1, top_row + 1,
-                                                    x_dimension, y_dimension)
+                extra_term_top = jw_index_2d_square_aux(
+                        i_col - 1, top_row, x_dimension, y_dimension)
+                extra_term_bot = jw_index_2d_square_aux(
+                        i_col - 1, top_row + 1, x_dimension, y_dimension)
                 if (i_col - 1) % 2 == 0:
                     stab *= stabilizer(extra_term_top, extra_term_bot)
                 else:

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""Jordan-Wigner transform on fermionic operators."""
+"""Verstraete-Cirac transform on fermionic operators."""
 from __future__ import absolute_import
 
 import itertools

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -42,6 +42,10 @@ def verstraete_cirac_2d_square(operator, x_dimension, y_dimension,
     Returns:
         transformed_operator: A QubitOperator.
     """
+    if x_dimension % 2 != 0:
+        raise NotImplementedError('Currently only even x_dimension '
+                                  'is supported.')
+
     # Obtain the vertical edges of the snake ordering
     vert_edges = vertical_edges_snake(x_dimension, y_dimension)
 

--- a/src/openfermion/transforms/_verstraete_cirac_test.py
+++ b/src/openfermion/transforms/_verstraete_cirac_test.py
@@ -58,10 +58,6 @@ class VerstraeteCirac2dSquareGroundStateTest(unittest.TestCase):
         self.assertAlmostEqual(self.transformed_ground_energy,
                                self.ferm_op_ground_energy)
 
-    def test_ground_state(self):
-        """Test that the ground state is a tensor product state between
-        the system qubits and the auxiliary qubits."""
-
 
 class VerstraeteCirac2dSquareOperatorLocalityTest(unittest.TestCase):
     """Test that the transform results in local qubit operators."""

--- a/src/openfermion/transforms/_verstraete_cirac_test.py
+++ b/src/openfermion/transforms/_verstraete_cirac_test.py
@@ -1,0 +1,119 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for _verstraete_cirac.py."""
+from __future__ import absolute_import
+
+import unittest
+
+import numpy
+
+from openfermion.hamiltonians import fermi_hubbard
+from openfermion.transforms import (get_sparse_operator,
+                                    verstraete_cirac_2d_square)
+from openfermion.transforms._verstraete_cirac import (
+        coordinates_to_snake_index,
+        snake_index_to_coordinates,
+        stabilizer_local_2d_square)
+from openfermion.utils import get_ground_state
+
+
+class VerstraeteCirac2dSquareGroundStateTest(unittest.TestCase):
+    """Test that the transform preserves desired ground state properties."""
+
+    def setUp(self):
+        self.x_dimension = 2
+        self.y_dimension = 3
+
+        # Create a Hamiltonian with nearest-neighbor hopping terms
+        self.ferm_op = fermi_hubbard(self.x_dimension, self.y_dimension,
+                                     1., 0., None, None, False, True)
+
+        # Get the ground energy and ground state
+        self.ferm_op_sparse = get_sparse_operator(self.ferm_op)
+        self.ferm_op_ground_energy, self.ferm_op_ground_state = (
+            get_ground_state(self.ferm_op_sparse))
+
+        # Transform the FermionOperator to a QubitOperator
+        self.transformed_op = verstraete_cirac_2d_square(
+            self.ferm_op, self.x_dimension, self.y_dimension,
+            add_auxiliary_hamiltonian=True, snake=False)
+
+        # Get the ground energy and state of the transformed operator
+        self.transformed_sparse = get_sparse_operator(self.transformed_op)
+        self.transformed_ground_energy, self.transformed_ground_state = (
+                get_ground_state(self.transformed_sparse))
+
+    def test_ground_energy(self):
+        """Test that the transformation preserves the ground energy."""
+        self.assertAlmostEqual(self.transformed_ground_energy,
+                               self.ferm_op_ground_energy)
+
+    def test_ground_state(self):
+        """Test that the ground state is a tensor product state between
+        the system qubits and the auxiliary qubits."""
+
+
+class VerstraeteCirac2dSquareOperatorLocalityTest(unittest.TestCase):
+    """Test that the transform results in local qubit operators."""
+
+    def setUp(self):
+        self.x_dimension = 6
+        self.y_dimension = 6
+
+        # Create a Hubbard Hamiltonian
+        self.ferm_op = fermi_hubbard(self.x_dimension, self.y_dimension,
+                                     1., 4., None, None, False, True)
+
+        # Transform the FermionOperator to a QubitOperator without including
+        # the auxiliary Hamiltonian
+        self.transformed_op_no_aux = verstraete_cirac_2d_square(
+            self.ferm_op, self.x_dimension, self.y_dimension,
+            add_auxiliary_hamiltonian=False, snake=False)
+        self.transformed_op_no_aux.compress()
+
+        # Transform the FermionOperator to a QubitOperator, including
+        # the auxiliary Hamiltonian
+        self.transformed_op_aux = verstraete_cirac_2d_square(
+            self.ferm_op, self.x_dimension, self.y_dimension,
+            add_auxiliary_hamiltonian=True, snake=False)
+        self.transformed_op_aux.compress()
+
+    def test_operator_locality_no_aux(self):
+        """Test that the operators without the auxiliary Hamiltonian
+        are at most 4-local."""
+        for term in self.transformed_op_no_aux.terms:
+            self.assertTrue(len(term) <= 4)
+
+    def test_operator_locality_aux(self):
+        """Test that the operators with the auxiliary Hamiltonian
+        are at most 6-local."""
+        for term in self.transformed_op_aux.terms:
+            self.assertTrue(len(term) <= 6)
+
+
+class BadInputTest(unittest.TestCase):
+    """Test that exceptions are raised for bad inputs."""
+
+    def test_stabilizer_local_2d_square(self):
+        with self.assertRaises(ValueError):
+            index = stabilizer_local_2d_square(0, 2, 4, 4)
+
+    def test_coordinates_to_snake_index(self):
+        with self.assertRaises(ValueError):
+            index = coordinates_to_snake_index(4, 4, 4, 5)
+        with self.assertRaises(ValueError):
+            index = coordinates_to_snake_index(4, 4, 5, 4)
+
+    def test_snake_index_to_coordinates(self):
+        with self.assertRaises(ValueError):
+            row, col = snake_index_to_coordinates(20, 4, 5)

--- a/src/openfermion/transforms/_verstraete_cirac_test.py
+++ b/src/openfermion/transforms/_verstraete_cirac_test.py
@@ -97,8 +97,13 @@ class VerstraeteCirac2dSquareOperatorLocalityTest(unittest.TestCase):
             self.assertTrue(len(term) <= 6)
 
 
-class BadInputTest(unittest.TestCase):
-    """Test that exceptions are raised for bad inputs."""
+class ExceptionTest(unittest.TestCase):
+    """Test that exceptions are raised correctly."""
+
+    def test_verstraete_cirac_2d_square(self):
+        ferm_op = fermi_hubbard(3, 2, 1., 0., spinless=True)
+        with self.assertRaises(NotImplementedError):
+            operator = verstraete_cirac_2d_square(ferm_op, 3, 2)
 
     def test_stabilizer_local_2d_square(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Partially addresses #100. I think we should leave the issue open if this PR is merged as is.
My implementation works for 2-d square grids with an even number of columns.
Some further work that I leave for the future:
- I only made the transformation work for an even number of columns, but it can straightforwardly be extended to an odd number, as explained in the paper
- It would be great if we could check that the ground state decomposes as a tensor product, but I don't know how to do this. I don't think it works to check that the qubit state vector is a tensor product, since the tensor product structure of the Hilbert space of qubits is different from that of the Hilbert space of fermionic modes.
- The general idea of the transform is to multiply some operators by stabilizer operators to to cancel out Jordan-Wigner strings. Right now, I only handle quadratic operators corresponding to vertical edges, as described in the paper. I haven't thought about whether it's necessary to handle other operators, and how we would do so.
- My implementation works only for spinless models. I think the way to handle spin varies depending on the particular interactions between orbitals of different spin which are present in the Hamiltonian we want to transform, so this might be a little complicated.
- It would be cool to generalize to different 2-d lattice geometries and also higher dimensions.
- I use one particular graph for the auxiliary Hamiltonian, corresponding to Fig. 2a in the paper, but other auxiliary graphs are possible, and we may want to explore them.