### PR TITLE
added general_basis_rotation to ops init

### DIFF
--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -15,8 +15,8 @@ from ._fermion_operator import (FermionOperator,
                                 majorana_operator,
                                 normal_ordered,
                                 number_operator)
-from ._qubit_operator import QubitOperator
+from ._polynomial_tensor import general_basis_change, PolynomialTensor
 from ._interaction_operator import InteractionOperator
 from ._interaction_rdm import InteractionRDM
-from ._polynomial_tensor import general_basis_change, PolynomialTensor
 from ._quadratic_hamiltonian import QuadraticHamiltonian
+from ._qubit_operator import QubitOperator

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -16,7 +16,7 @@ from ._fermion_operator import (FermionOperator,
                                 normal_ordered,
                                 number_operator)
 from ._qubit_operator import QubitOperator
-from ._polynomial_tensor import PolynomialTensor
 from ._interaction_operator import InteractionOperator
 from ._interaction_rdm import InteractionRDM
+from ._polynomial_tensor import general_basis_change, PolynomialTensor
 from ._quadratic_hamiltonian import QuadraticHamiltonian

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -15,8 +15,8 @@ from ._fermion_operator import (FermionOperator,
                                 majorana_operator,
                                 normal_ordered,
                                 number_operator)
+from ._qubit_operator import QubitOperator
 from ._polynomial_tensor import general_basis_change, PolynomialTensor
 from ._interaction_operator import InteractionOperator
 from ._interaction_rdm import InteractionRDM
 from ._quadratic_hamiltonian import QuadraticHamiltonian
-from ._qubit_operator import QubitOperator

--- a/src/openfermion/ops/_polynomial_tensor.py
+++ b/src/openfermion/ops/_polynomial_tensor.py
@@ -45,7 +45,10 @@ def general_basis_change(general_tensor, rotation_matrix, key):
         rotation_matrix: A square numpy array or matrix having dimensions of
             n_qubits by n_qubits. Assumed to be unitary.
         key: A tuple indicating the type of general_tensor. Assumed to be
-            non-empty.
+            non-empty. For example, a tensor storing coefficients of
+            a^\dagger_p a_q would have a key of (1, 0) whereas a tensor
+            storing coefficients of a^\dagger_p a_q a_r a^\dagger_s would
+            have a key of (1, 0, 0, 1).
 
     Returns:
         transformed_general_tensor: general_tensor in the rotated basis.


### PR DESCRIPTION
There are situations when one may want to use general_basis_change without instantiating a PolynomialTensor object.