### PR TITLE
Allow "from openfermion import *"

### DIFF
--- a/src/openfermion/__init__.py
+++ b/src/openfermion/__init__.py
@@ -19,3 +19,9 @@ www.openfermion.org
 """
 
 from ._version import __version__
+
+from openfermion.hamiltonians import *
+from openfermion.measurements import *
+from openfermion.ops import *
+from openfermion.transforms import *
+from openfermion.utils import *


### PR DESCRIPTION
I don't know if this would be controversial or if this is the best way to achieve this. But when I'm messing around with Jupyter notebooks or on IPython sometimes I find I want to say `from openfermion import *` or `import openfermion`. Of course I would _never_ do such a thing when actually writing a contribution.