### PR TITLE
fix for nul description loading

### DIFF
--- a/src/openfermion/hamiltonians/_molecular_data.py
+++ b/src/openfermion/hamiltonians/_molecular_data.py
@@ -236,7 +236,7 @@ class MolecularData(object):
             for this system annotated by the key.
     """
     def __init__(self, geometry=None, basis=None, multiplicity=None,
-                 charge=0, description="", filename="", data_directory=None):
+                 charge=0, description="none", filename="", data_directory=None):
         """Initialize molecular metadata which defines class.
 
         Args:

--- a/src/openfermion/hamiltonians/_molecular_data.py
+++ b/src/openfermion/hamiltonians/_molecular_data.py
@@ -236,7 +236,7 @@ class MolecularData(object):
             for this system annotated by the key.
     """
     def __init__(self, geometry=None, basis=None, multiplicity=None,
-                 charge=0, description="none", filename="", data_directory=None):
+                 charge=0, description="", filename="", data_directory=None):
         """Initialize molecular metadata which defines class.
 
         Args:
@@ -662,7 +662,7 @@ class MolecularData(object):
             # Load charge:
             self.charge = int(f["charge"][...])
             # Load description:
-            self.description = f["description"][...].tobytes().decode('utf-8')
+            self.description = f["description"][...].tobytes().decode('utf-8').rstrip(u'\x00')
             # Load name:
             self.name = f["name"][...].tobytes().decode('utf-8')
             # Load n_atoms:


### PR DESCRIPTION
this is the fix for [issue#14](https://github.com/quantumlib/OpenFermion-Psi4/issues/14) in Openfermion-psi4.

When the hdf5 file is generated from a run_psi4 call with no description, which defaults to '', upon loading at the end of run_psi4, its read as NUL(\x00). 

In the following run, the *.inp file is generated with description='.' that raises a TypeError.