### PR TITLE
Ordered data files

### DIFF
--- a/cloud_library/HF_diatomic_sto-3g
+++ b/cloud_library/HF_diatomic_sto-3g
@@ -2,19 +2,18 @@
 # bond distances are contrained in this file.
 # Calculations in these files contain FCI, MP2,
 # HF, CISD, CCSD and all integerals.
-H1-F1_sto-3g_singlet_2.6.hdf5
-H1-F1_sto-3g_singlet_2.0.hdf5
 H1-F1_sto-3g_singlet_0.2.hdf5
-H1-F1_sto-3g_singlet_1.0.hdf5
-H1-F1_sto-3g_singlet_1.4.hdf5
-H1-F1_sto-3g_singlet_2.2.hdf5
-H1-F1_sto-3g_singlet_1.8.hdf5
-H1-F1_sto-3g_singlet_0.7414.hdf5
-H1-F1_sto-3g_singlet_0.6.hdf5
-H1-F1_sto-3g_singlet_1.6.hdf5
 H1-F1_sto-3g_singlet_0.4.hdf5
-H1-F1_sto-3g_singlet_3.0.hdf5
-H1-F1_sto-3g_singlet_1.2.hdf5
-H1-F1_sto-3g_singlet_2.8.hdf5
+H1-F1_sto-3g_singlet_0.6.hdf5
 H1-F1_sto-3g_singlet_0.8.hdf5
+H1-F1_sto-3g_singlet_1.0.hdf5
+H1-F1_sto-3g_singlet_1.2.hdf5
+H1-F1_sto-3g_singlet_1.4.hdf5
+H1-F1_sto-3g_singlet_1.6.hdf5
+H1-F1_sto-3g_singlet_1.8.hdf5
+H1-F1_sto-3g_singlet_2.0.hdf5
+H1-F1_sto-3g_singlet_2.2.hdf5
 H1-F1_sto-3g_singlet_2.4.hdf5
+H1-F1_sto-3g_singlet_2.6.hdf5
+H1-F1_sto-3g_singlet_2.8.hdf5
+H1-F1_sto-3g_singlet_3.0.hdf5


### PR DESCRIPTION
* Put file names in a logical order.
* Deleted the file at bond length 0.7414 since that is the equilibrium bond length of H2, not HF.

If you accept this PR, please delete the 0.7414 file from the Cloud prior to merging.