### PR TITLE
Fix documentation in MolecularData

### DIFF
--- a/src/openfermion/hamiltonians/_molecular_data.py
+++ b/src/openfermion/hamiltonians/_molecular_data.py
@@ -826,8 +826,6 @@ class MolecularData(object):
         """Output arrays of the second quantized Hamiltonian coefficients.
 
         Args:
-            rotation_matrix: A square numpy array or matrix having dimensions
-                of n_orbitals by n_orbitals. Assumed real and invertible.
             occupied_indices(list): A list of spatial orbital indices
                 indicating which orbitals should be considered doubly occupied.
             active_indices(list): A list of spatial orbital indices indicating


### PR DESCRIPTION
Removed an extraneous argument in the documentation of `get_molecular_hamiltonian`.