### PR TITLE
Sphinx show inheritance in openfermion.ops

### DIFF
--- a/docs/openfermion.rst
+++ b/docs/openfermion.rst
@@ -25,6 +25,7 @@ openfermion.ops
     :members:
     :special-members: __init__
     :imported-members:
+    :show-inheritance:
 
 openfermion.transforms
 ----------------------


### PR DESCRIPTION
Added a Sphinx option which makes it so that base classes appear under class names in the documentation of `openfermion.ops`. I think this helps address @babbush 's comment in #43 .