### PR TITLE
Add SymbolicOperator and tests

### DIFF
--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -16,9 +16,7 @@ import itertools
 
 import numpy
 from abc import abstractmethod
-
-
-EQ_TOLERANCE = 1e-12
+from openfermion.config import EQ_TOLERANCE
 
 
 class SymbolicOperatorError(Exception):
@@ -28,25 +26,28 @@ class SymbolicOperatorError(Exception):
 class SymbolicOperator(object):
     """
     The base class for QubitOperator and FermionOperator. All methods defined
-    here can be accessed from FermionOperator or QubitOperator objects.
-    This is an abstract class and objects of this type cannot be created,
-    only those of subclasses.
-
-    Subclasses are sums of terms of operators for a particular category of
-    particle. Subclasses support addition and multiplication with objects of
-    the same type.
+    here can be accessed from FermionOperator or QubitOperator objects. This
+    class and subclasses are sums of terms of operators for a particular 
+    category of particle. Subclasses support addition and multiplication with
+    objects of the same type.
 
     Attributes:
         terms (dict):
-            **key** (tuple of tuples): Each tuple represents a fermion term,
-            i.e. a tensor product of fermion ladder operators with a
-            coefficient. The first element is an integer indicating the
-            mode on which a ladder operator acts and the second element is
-            a bool, either '0' indicating annihilation, or '1' indicating
-            creation in that mode; for example, '2^ 5' is ((2, 1), (5, 0)).
+            **key** (tuple of tuples): Each tuple represents a term,
+            i.e. an (action, index) pair. The action can be any from a 
+            specified tuple of base operators that can be obtained in the
+            from the class method `actions()`.
             **value** (complex float): The coefficient of term represented by
             key.
     """
+
+    # Class attribute, I set it at random for testing right now
+    _actions = ("I", "A", "B", "C")
+
+    @classmethod
+    def actions(cls):
+        # _actions  should not be changed so only provide a getter
+        return _actions
 
     @abstractmethod
     def __init__(self):
@@ -72,8 +73,6 @@ class SymbolicOperator(object):
                 A symbolic operator o with the property that o+x = x+o = x for
                 all fermion operators x.
         """
-        # Maybe throw a TypeError if called using SymbolicOperator? Or maybe
-        # just don't expose SymbolicOperator to users
 
         return cls(term=None)
 
@@ -81,7 +80,7 @@ class SymbolicOperator(object):
     def identity(cls):
         """
         Returns:
-            multiplicative_identity (FermionOperator):
+            multiplicative_identity (SymbolicOperator):
                 A symbolic operator u with the property that u*x = x*u = x for
                 all fermion operators x.
         """

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -309,14 +309,15 @@ class SymbolicOperator(object):
             for term in addend.terms:
                 if term in self.terms:
                     if abs(addend.terms[term] +
-                           self.terms[term]) > 0:
-                        self.terms[term] += addend.terms[term]
-                    else:
+                           self.terms[term]) < EQ_TOLERANCE:
                         del self.terms[term]
+                    else:
+                        self.terms[term] += addend.terms[term]
                 else:
                     self.terms[term] = addend.terms[term]
         else:
-            raise TypeError('Cannot add invalid type to ' + type(self) + '.')
+            raise TypeError('Cannot add invalid type to '
+                            '{}.'.format(type(self)))
         return self
 
     def __add__(self, addend):

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""SymbolicOperator is a base class for QubitOperator and FermionOperator"""
+"""SymbolicOperator is the base class for FermionOperator and QubitOperator"""
 import copy
 import itertools
 
@@ -26,36 +26,35 @@ class SymbolicOperator(object):
     """Base class for FermionOperator and QubitOperator.
     
     A SymbolicOperator stores an object which represents a weighted
-    sum of terms, where each term is a product of individual factors
-    of the form (`index`, `action`),
-    where `index` is a nonnegative integer and the possible values
-    for `action` are determined by the subclass. For instance, for
-    FermionOperator, `action` can be 1 or 0, indicating raising or lowering,
-    and for QubitOperator, `action` is from the set {'X', 'Y', 'Z'}.
+    sum of terms; each term is a product of individual factors
+    of the form (`index`, `action`), where `index` is a nonnegative integer
+    and the possible values for `action` are determined by the subclass.
+    For instance, for the subclass FermionOperator, `action` can be 1 or 0,
+    indicating raising or lowering, and for QubitOperator, `action` is from
+    the set {'X', 'Y', 'Z'}.
     The coefficients of the terms are stored in a dictionary whose
     keys are the terms.
-    Subclasses should support addition and multiplication with
-    objects of the same type.
+    SymbolicOperators of the same type can be added or multiplied together.
 
     Attributes:
         actions (tuple): A tuple of objects representing the possible actions.
             This should be defined in the subclass.
-            e.g. for FermionOperator, this is (1, 0)
+            e.g. for FermionOperator, this is (1, 0).
         action_strings (tuple): A tuple of string representations of actions.
             These should be in one-to-one correspondence with actions and
             listed in the same order.
-            e.g. for FermionOperator, this is ('^', '')
+            e.g. for FermionOperator, this is ('^', '').
         action_before_index (bool): A boolean indicating whether in string
             representations, the action should come before the index.
         different_indices_commute (bool): A boolean indicating whether
             factors acting on different indices commute.
         terms (dict):
-            **key** (tuple of tuples): Each key is a term which
-            is a product of individual factors; each factor
-            has the form (`action`, `index`), and the factors of
-            the product are collected into a tuple representing the term.
-            The values stored in the dictionary are the coefficients of
-            the terms.
+            **key** (tuple of tuples): A dictionary storing the coefficients
+            of the terms in the operator. The keys are the terms.
+            A term is a product of individual factors; each factor is
+            represented by a tuple of the form (`index`, `action`), and
+            these tuples are collected into a larger tuple which represents
+            the term as the product of its factors.
     """
     actions = ()
     action_strings = ()
@@ -72,24 +71,25 @@ class SymbolicOperator(object):
             self._long_string_init(term, coefficient)
             return
 
+        # Initialize the terms dictionary
         self.terms = {}
 
-        # Zero operator
+        # Zero operator: leave the terms dictionary empty
         if term is None:
             return
 
+        # Parse the term
         # Sequence input
         elif isinstance(term, tuple) or isinstance(term, list):
             term = self._parse_sequence(term)
-
         # String input
         elif isinstance(term, str):
             term = self._parse_string(term)
-
         # Invalid input type
         else:
             raise ValueError('term specified incorrectly.')
 
+        # Add the term to the dictionary
         self.terms[term] = coefficient
 
     def _long_string_init(self, term, coefficient):

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -1,0 +1,301 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""SymbolicOperator is a base class for QubitOperator and FermionOperator"""
+import copy
+import itertools
+
+import numpy
+from abc import abstractmethod
+
+
+EQ_TOLERANCE = 1e-12
+
+
+class SymbolicOperatorError(Exception):
+    pass
+
+
+class SymbolicOperator(object):
+    """
+    The base class for QubitOperator and FermionOperator. All methods defined
+    here can be accessed from FermionOperator or QubitOperator objects.
+    This is an abstract class and objects of this type cannot be created,
+    only those of subclasses.
+
+    Subclasses are sums of terms of operators for a particular category of
+    particle. Subclasses support addition and multiplication with objects of
+    the same type.
+
+    Attributes:
+        terms (dict):
+            **key** (tuple of tuples): Each tuple represents a fermion term,
+            i.e. a tensor product of fermion ladder operators with a
+            coefficient. The first element is an integer indicating the
+            mode on which a ladder operator acts and the second element is
+            a bool, either '0' indicating annihilation, or '1' indicating
+            creation in that mode; for example, '2^ 5' is ((2, 1), (5, 0)).
+            **value** (complex float): The coefficient of term represented by
+            key.
+    """
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def __imul__(self):
+        pass
+
+    @abstractmethod
+    def __str__(self):
+        pass
+
+    @abstractmethod
+    def __repr__(self):
+        pass
+
+    @classmethod
+    def zero(cls):
+        """
+        Returns:
+            additive_identity (SymbolicOperator):
+                A symbolic operator o with the property that o+x = x+o = x for
+                all fermion operators x.
+        """
+        # Maybe throw a TypeError if called using SymbolicOperator? Or maybe
+        # just don't expose SymbolicOperator to users
+
+        return cls(term=None)
+
+    @classmethod
+    def identity(cls):
+        """
+        Returns:
+            multiplicative_identity (FermionOperator):
+                A symbolic operator u with the property that u*x = x*u = x for
+                all fermion operators x.
+        """
+        return cls(term=())
+
+    def compress(self, abs_tol=EQ_TOLERANCE):
+        """
+        Eliminates all terms with coefficients close to zero and removes
+        imaginary parts of coefficients that are close to zero.
+
+        Args:
+            abs_tol(float): Absolute tolerance, must be at least 0.0
+        """
+        new_terms = {}
+        for term in self.terms:
+            coeff = self.terms[term]
+            if abs(coeff.imag) <= abs_tol:
+                coeff = coeff.real
+            if abs(coeff) > abs_tol:
+                new_terms[term] = coeff
+        self.terms = new_terms
+
+    def isclose(self, other, rel_tol=EQ_TOLERANCE, abs_tol=EQ_TOLERANCE):
+        """
+        Returns True if other (SymbolicOperator) is close to self.
+
+        Comparison is done for each term individually. Return True
+        if the difference between each term in self and other is
+        less than the relative tolerance w.r.t. either other or self
+        (symmetric test) or if the difference is less than the absolute
+        tolerance.
+
+        Args:
+            other(SymbolicOperator): SymbolicOperator to compare against.
+            rel_tol(float): Relative tolerance, must be greater than 0.0
+            abs_tol(float): Absolute tolerance, must be at least 0.0
+        """
+        # terms which are in both:
+        for term in set(self.terms).intersection(set(other.terms)):
+            a = self.terms[term]
+            b = other.terms[term]
+            # math.isclose does this in Python >=3.5
+            if not abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol):
+                return False
+        # terms only in one (compare to 0.0 so only abs_tol)
+        for term in set(self.terms).symmetric_difference(set(other.terms)):
+            if term in self.terms:
+                if not abs(self.terms[term]) <= abs_tol:
+                    return False
+            elif not abs(other.terms[term]) <= abs_tol:
+                return False
+        return True
+
+    def __mul__(self, multiplier):
+        """Return self * multiplier for a scalar, or a SymbolicOperator.
+
+        Args:
+            multiplier: A scalar, or a SymbolicOperator.
+
+        Returns:
+            product (SymbolicOperator)
+
+        Raises:
+            TypeError: Invalid type cannot be multiply with SymbolicOperator.
+        """
+        if isinstance(multiplier, (int, float, complex, type(self))):
+            product = copy.deepcopy(self)
+            product *= multiplier
+            return product
+        else:
+            raise TypeError(
+                'Object of invalid type cannot multiply with ' +
+                type(self) + '.')
+
+    def __iadd__(self, addend):
+        """In-place method for += addition of SymbolicOperator.
+
+        Args:
+            addend (SymbolicOperator): The operator to add.
+
+        Returns:
+            sum (SymbolicOperator): Mutated self.
+
+        Raises:
+            TypeError: Cannot add invalid type.
+        """
+        if isinstance(addend, type(self)):
+            for term in addend.terms:
+                if term in self.terms:
+                    if abs(addend.terms[term] +
+                           self.terms[term]) > 0:
+                        self.terms[term] += addend.terms[term]
+                    else:
+                        del self.terms[term]
+                else:
+                    self.terms[term] = addend.terms[term]
+        else:
+            raise TypeError('Cannot add invalid type to ' + type(self) + '.')
+        return self
+
+    def __add__(self, addend):
+        """
+        Args:
+            addend (SymbolicOperator): The operator to add.
+
+        Returns:
+            sum (SymbolicOperator)
+        """
+        summand = copy.deepcopy(self)
+        summand += addend
+        return summand
+
+    def __isub__(self, subtrahend):
+        """In-place method for -= subtraction of SymbolicOperator.
+
+        Args:
+            subtrahend (A SymbolicOperator): The operator to subtract.
+
+        Returns:
+            difference (SymbolicOperator): Mutated self.
+
+        Raises:
+            TypeError: Cannot subtract invalid type.
+        """
+        if isinstance(subtrahend, type(self)):
+            for term in subtrahend.terms:
+                if term in self.terms:
+                    if abs(self.terms[term] -
+                           subtrahend.terms[term]) < EQ_TOLERANCE:
+                        del self.terms[term]
+                    else:
+                        self.terms[term] -= subtrahend.terms[term]
+                else:
+                    self.terms[term] = -subtrahend.terms[term]
+        else:
+            raise TypeError('Cannot subtract invalid type from ' +
+                            type(self) + '.')
+        return self
+
+    def __sub__(self, subtrahend):
+        """
+        Args:
+            subtrahend (SymbolicOperator): The operator to subtract.
+
+        Returns:
+            difference (SymbolicOperator)
+        """
+        minuend = copy.deepcopy(self)
+        minuend -= subtrahend
+        return minuend
+
+    def __rmul__(self, multiplier):
+        """
+        Return multiplier * self for a scalar.
+
+        We only define __rmul__ for scalars because the left multiply
+        exist for  SymbolicOperator and left multiply
+        is also queried as the default behavior.
+
+        Args:
+          multiplier: A scalar to multiply by.
+
+        Returns:
+          product: A new instance of SymbolicOperator.
+
+        Raises:
+          TypeError: Object of invalid type cannot multiply SymbolicOperator.
+        """
+        if not isinstance(multiplier, (int, float, complex)):
+            raise TypeError(
+                'Object of invalid type cannot multiply with ' +
+                type(self) + '.')
+        return self * multiplier
+
+    def __truediv__(self, divisor):
+        """
+        Return self / divisor for a scalar.
+
+        Note:
+            This is always floating point division.
+
+        Args:
+          divisor: A scalar to divide by.
+
+        Returns:
+          A new instance of SymbolicOperator.
+
+        Raises:
+          TypeError: Cannot divide local operator by non-scalar type.
+
+        """
+        if not isinstance(divisor, (int, float, complex)):
+            raise TypeError('Cannot divide ' + type(self) +
+                            ' by non-scalar type.')
+        return self * (1.0 / divisor)
+
+    def __div__(self, divisor):
+        """ For compatibility with Python 2. """
+        return self.__truediv__(divisor)
+
+    def __itruediv__(self, divisor):
+        if not isinstance(divisor, (int, float, complex)):
+            raise TypeError('Cannot divide ' + type(self) +
+                            ' by non-scalar type.')
+        self *= (1.0 / divisor)
+        return self
+
+    def __idiv__(self, divisor):
+        """ For compatibility with Python 2. """
+        return self.__itruediv__(divisor)
+
+    def __neg__(self):
+        """
+        Returns:
+            negation (SymbolicOperator)
+        """
+        return -1 * self

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -24,7 +24,7 @@ class SymbolicOperatorError(Exception):
 
 class SymbolicOperator(object):
     """Base class for FermionOperator and QubitOperator.
-    
+
     A SymbolicOperator stores an object which represents a weighted
     sum of terms; each term is a product of individual factors
     of the form (`index`, `action`), where `index` is a nonnegative integer
@@ -130,7 +130,7 @@ class SymbolicOperator(object):
             # If factors with different indices commute, sort the factors
             # by index
             if self.different_indices_commute:
-                term = sorted(term, key = lambda factor: factor[0])
+                term = sorted(term, key=lambda factor: factor[0])
 
             # Return a tuple
             return tuple(term)

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -169,6 +169,11 @@ class SymbolicOperator(object):
 
                 index = int(factor[:index_end])
                 action_string = factor[index_end:]
+            # Check that the index is valid
+            if index < 0:
+                raise ValueError('Invalid index in factor {}. '
+                                 'The index should be a non-negative '
+                                 'integer.'.format(factor))
             # Convert the action string to an action
             if action_string in self.action_strings:
                 action = self.actions[self.action_strings.index(action_string)]
@@ -180,10 +185,14 @@ class SymbolicOperator(object):
             # Add the factor to the list as a tuple
             processed_term.append((index, action))
 
-        # Process the factors
-        processed_term = self._parse_sequence(processed_term)
+        # If factors with different indices commute, sort the factors
+        # by index
+        if self.different_indices_commute:
+            processed_term = sorted(processed_term,
+                                    key=lambda factor: factor[0])
 
-        return processed_term
+        # Return a tuple
+        return tuple(processed_term)
 
     @classmethod
     def zero(cls):

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -101,7 +101,7 @@ class SymbolicOperator(object):
     def _parse_sequence(self, term):
         """Parse a term given as a sequence type (i.e., list, tuple, etc.).
 
-        i.e. For QubitOperator:
+        e.g. For QubitOperator:
             [('X', 2), ('Y', 0), ('Z', 3)] -> (('Y', 0), ('X', 2), ('Z', 3))
         """
         if not term:
@@ -136,7 +136,7 @@ class SymbolicOperator(object):
     def _parse_string(self, term):
         """Parse a term given as a string.
 
-        i.e. For FermionOperator:
+        e.g. For FermionOperator:
             "2^ 3" -> ((2, 1), (3, 0))
         """
         factors = term.split()

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -145,8 +145,8 @@ class SymbolicOperator(object):
 
         # Convert the string representations of the factors to tuples
         processed_term = []
-
         for factor in factors:
+            # Get the index and action string
             if self.action_before_index:
                 # The index is at the end of the string; find where it starts.
                 if not factor[-1].isdigit():
@@ -169,7 +169,6 @@ class SymbolicOperator(object):
 
                 index = int(factor[:index_end])
                 action_string = factor[index_end:]
-
             # Convert the action string to an action
             if action_string in self.action_strings:
                 action = self.actions[self.action_strings.index(action_string)]

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -28,7 +28,7 @@ class SymbolicOperator(object, metaclass=ABCMeta):
     
     A SymbolicOperator stores an object which represents a weighted
     sum of terms, where each term is a product of individual terms
-    of the form (`action`, `index`),
+    of the form (`index`, `action`),
     where `index` is a nonnegative integer and the possible values
     for `action` are determined by the subclass. For instance, for
     FermionOperator, `action` can be 1 or 0, indicating raising or lowering,
@@ -41,6 +41,10 @@ class SymbolicOperator(object, metaclass=ABCMeta):
     Attributes:
         actions (set): A set of objects representing the possible actions.
             This should be defined in the subclass
+        action_strings (dict): A dictionary that maps an action to its
+            string representation.
+        action_before_index(bool): A boolean indicating whether in string
+            representations, the action should come before the index.
         terms (dict):
             **key** (tuple of tuples): Each key is a term which
             is a product of individual terms; each individual
@@ -50,6 +54,8 @@ class SymbolicOperator(object, metaclass=ABCMeta):
             the terms.
     """
     actions = set()
+    action_strings = {}
+    action_before_index = False
 
     def __init__(self, term=None, coefficient=1.):
         if not isinstance(coefficient, (int, float, complex)):
@@ -111,6 +117,14 @@ class SymbolicOperator(object, metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def __str__(self):
+        pass
+
+    @abstractmethod
+    def __repr__(self):
+        pass
+
     @classmethod
     def zero(cls):
         """
@@ -130,14 +144,6 @@ class SymbolicOperator(object, metaclass=ABCMeta):
                 all operators x of the same class.
         """
         return cls(term=())
-
-    @abstractmethod
-    def __str__(self):
-        pass
-
-    @abstractmethod
-    def __repr__(self):
-        pass
 
     def compress(self, abs_tol=EQ_TOLERANCE):
         """

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -12,9 +12,7 @@
 
 """SymbolicOperator is the base class for FermionOperator and QubitOperator"""
 import copy
-import itertools
 
-import numpy
 from openfermion.config import EQ_TOLERANCE
 
 

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -1,0 +1,807 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests  _fermion_operator.py."""
+import copy
+import numpy
+import unittest
+
+from openfermion.ops._symbolic_operator import (SymbolicOperator,
+                                                SymbolicOperatorError)
+ 
+
+class DummyOperator(SymbolicOperator):
+    """Subclass of SymbolicOperator created for testing purposes."""
+    actions = {'a', 'b', 'c'}
+    
+    def parse_sequence(term):
+        return tuple(term)
+
+    def parse_string(term):
+        """I.e. 'a0 b4 c3' -> (('a', 0), ('b', 4), ('c', 3))"""
+        factor_strings = term.split()
+        factors = []
+        for factor in factor_strings:
+            factors.append((factor[0], int(factor[1])))
+        return tuple(factors)
+
+
+class SymbolicOperatorTest(unittest.TestCase):
+
+    def test_init_defaults(self):
+        loc_op = FermionOperator()
+        self.assertEqual(len(loc_op.terms), 0)
+
+    def test_init_tuple_real_coefficient(self):
+        loc_op = ((0, 1), (5, 0), (6, 1))
+        coefficient = 0.5
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_tuple_complex_coefficient(self):
+        loc_op = ((0, 1), (5, 0), (6, 1))
+        coefficient = 0.6j
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_tuple_npfloat64_coefficient(self):
+        loc_op = ((0, 1), (5, 0), (6, 1))
+        coefficient = numpy.float64(2.303)
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_tuple_npcomplex128_coefficient(self):
+        loc_op = ((0, 1), (5, 0), (6, 1))
+        coefficient = numpy.complex128(-1.123j + 43.7)
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_list_real_coefficient(self):
+        loc_op = [(0, 1), (5, 0), (6, 1)]
+        coefficient = 1. / 3
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_list_complex_coefficient(self):
+        loc_op = [(0, 1), (5, 0), (6, 1)]
+        coefficient = 2j / 3.
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_list_npfloat64_coefficient(self):
+        loc_op = [(0, 1), (5, 0), (6, 1)]
+        coefficient = numpy.float64(2.3037)
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_init_list_npcomplex128_coefficient(self):
+        loc_op = [(0, 1), (5, 0), (6, 1)]
+        coefficient = numpy.complex128(-1.1237j + 43.37)
+        fermion_op = FermionOperator(loc_op, coefficient)
+        self.assertEqual(len(fermion_op.terms), 1)
+        self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
+
+    def test_identity_is_multiplicative_identity(self):
+        u = FermionOperator.identity()
+        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        h = f + g
+        self.assertTrue(f.isclose(u * f))
+        self.assertTrue(f.isclose(f * u))
+        self.assertTrue(g.isclose(u * g))
+        self.assertTrue(g.isclose(g * u))
+        self.assertTrue(h.isclose(u * h))
+        self.assertTrue(h.isclose(h * u))
+
+        u *= h
+        self.assertTrue(h.isclose(u))
+        self.assertFalse(f.isclose(u))
+
+        # Method always returns new instances.
+        self.assertFalse(FermionOperator.identity().isclose(u))
+
+    def test_zero_is_additive_identity(self):
+        o = FermionOperator.zero()
+        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        h = f + g
+        self.assertTrue(f.isclose(o + f))
+        self.assertTrue(f.isclose(f + o))
+        self.assertTrue(g.isclose(o + g))
+        self.assertTrue(g.isclose(g + o))
+        self.assertTrue(h.isclose(o + h))
+        self.assertTrue(h.isclose(h + o))
+
+        o += h
+        self.assertTrue(h.isclose(o))
+        self.assertFalse(f.isclose(o))
+
+        # Method always returns new instances.
+        self.assertFalse(FermionOperator.zero().isclose(o))
+
+    def test_zero_is_multiplicative_nil(self):
+        o = FermionOperator.zero()
+        u = FermionOperator.identity()
+        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        self.assertTrue(o.isclose(o * u))
+        self.assertTrue(o.isclose(o * f))
+        self.assertTrue(o.isclose(o * g))
+        self.assertTrue(o.isclose(o * (f + g)))
+
+    def test_init_str(self):
+        fermion_op = FermionOperator('0^ 5 12^', -1.)
+        correct = ((0, 1), (5, 0), (12, 1))
+        self.assertIn(correct, fermion_op.terms)
+        self.assertEqual(fermion_op.terms[correct], -1.0)
+
+    def test_merges_multiple_whitespace(self):
+        fermion_op = FermionOperator('        \n ')
+        self.assertEqual(fermion_op.terms, {(): 1})
+
+    def test_init_str_identity(self):
+        fermion_op = FermionOperator('')
+        self.assertIn((), fermion_op.terms)
+
+    def test_init_bad_term(self):
+        with self.assertRaises(ValueError):
+            FermionOperator(2)
+
+    def test_init_bad_coefficient(self):
+        with self.assertRaises(ValueError):
+            FermionOperator('0^', "0.5")
+
+    def test_init_bad_action_str(self):
+        with self.assertRaises(FermionOperatorError):
+            FermionOperator('0-')
+
+    def test_init_bad_action_tuple(self):
+        with self.assertRaises(ValueError):
+            FermionOperator(((0, 2),))
+
+    def test_init_bad_tuple(self):
+        with self.assertRaises(ValueError):
+            FermionOperator(((0, 1, 1),))
+
+    def test_init_bad_str(self):
+        with self.assertRaises(FermionOperatorError):
+            FermionOperator('^')
+
+    def test_init_bad_mode_num(self):
+        with self.assertRaises(FermionOperatorError):
+            FermionOperator('-1^')
+
+    def test_init_invalid_tensor_factor(self):
+        with self.assertRaises(FermionOperatorError):
+            FermionOperator(((-2, 1), (1, 0)))
+
+    def test_FermionOperator(self):
+        op = FermionOperator((), 3.)
+        self.assertTrue(op.isclose(FermionOperator(()) * 3.))
+
+    def test_number_operator_site(self):
+        op = number_operator(3, 2, 1j)
+        self.assertTrue(op.isclose(FermionOperator(((2, 1), (2, 0))) * 1j))
+
+    def test_number_operator_nosite(self):
+        op = number_operator(4)
+        expected = (FermionOperator(((0, 1), (0, 0))) +
+                    FermionOperator(((1, 1), (1, 0))) +
+                    FermionOperator(((2, 1), (2, 0))) +
+                    FermionOperator(((3, 1), (3, 0))))
+        self.assertTrue(op.isclose(expected))
+
+
+    def test_isclose_abs_tol(self):
+        a = FermionOperator('0^', -1.)
+        b = FermionOperator('0^', -1.05)
+        c = FermionOperator('0^', -1.11)
+        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
+        self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+        a = FermionOperator('0^', -1.0j)
+        b = FermionOperator('0^', -1.05j)
+        c = FermionOperator('0^', -1.11j)
+        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
+        self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+
+    def test_isclose_rel_tol(self):
+        a = FermionOperator('0', 1)
+        b = FermionOperator('0', 2)
+        self.assertTrue(a.isclose(b, rel_tol=2.5, abs_tol=0.1))
+        # Test symmetry
+        self.assertTrue(a.isclose(b, rel_tol=1, abs_tol=0.1))
+        self.assertTrue(b.isclose(a, rel_tol=1, abs_tol=0.1))
+
+    def test_isclose_zero_terms(self):
+        op = FermionOperator('1^ 0', -1j) * 0
+        self.assertTrue(op.isclose(FermionOperator((), 0.0),
+                                   rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(FermionOperator().isclose(
+            op, rel_tol=1e-12, abs_tol=1e-12))
+
+    def test_isclose_different_terms(self):
+        a = FermionOperator(((1, 0),), -0.1j)
+        b = FermionOperator(((1, 1),), -0.1j)
+        self.assertTrue(a.isclose(b, rel_tol=1e-12, abs_tol=0.2))
+        self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(b.isclose(a, rel_tol=1e-12, abs_tol=0.2))
+        self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+
+    def test_isclose_different_num_terms(self):
+        a = FermionOperator(((1, 0),), -0.1j)
+        a += FermionOperator(((1, 1),), -0.1j)
+        b = FermionOperator(((1, 0),), -0.1j)
+        self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+        self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+
+    def test_imul_inplace(self):
+        fermion_op = FermionOperator("1^")
+        prev_id = id(fermion_op)
+        fermion_op *= 3.
+        self.assertEqual(id(fermion_op), prev_id)
+        self.assertEqual(fermion_op.terms[((1, 1),)], 3.)
+
+    def test_imul_scalar_real(self):
+        loc_op = ((1, 0), (2, 1))
+        multiplier = 0.5
+        fermion_op = FermionOperator(loc_op)
+        fermion_op *= multiplier
+        self.assertEqual(fermion_op.terms[loc_op], multiplier)
+
+    def test_imul_scalar_complex(self):
+        loc_op = ((1, 0), (2, 1))
+        multiplier = 0.6j
+        fermion_op = FermionOperator(loc_op)
+        fermion_op *= multiplier
+        self.assertEqual(fermion_op.terms[loc_op], multiplier)
+
+    def test_imul_scalar_npfloat64(self):
+        loc_op = ((1, 0), (2, 1))
+        multiplier = numpy.float64(2.303)
+        fermion_op = FermionOperator(loc_op)
+        fermion_op *= multiplier
+        self.assertEqual(fermion_op.terms[loc_op], multiplier)
+
+    def test_imul_scalar_npcomplex128(self):
+        loc_op = ((1, 0), (2, 1))
+        multiplier = numpy.complex128(-1.123j + 1.7911)
+        fermion_op = FermionOperator(loc_op)
+        fermion_op *= multiplier
+        self.assertEqual(fermion_op.terms[loc_op], multiplier)
+
+    def test_imul_fermion_op(self):
+        op1 = FermionOperator(((0, 1), (3, 0), (8, 1), (8, 0), (11, 1)), 3.j)
+        op2 = FermionOperator(((1, 1), (3, 1), (8, 0)), 0.5)
+        op1 *= op2
+        correct_coefficient = 1.j * 3.0j * 0.5
+        correct_term = ((0, 1), (3, 0), (8, 1), (8, 0), (11, 1),
+                        (1, 1), (3, 1), (8, 0))
+        self.assertEqual(len(op1.terms), 1)
+        self.assertIn(correct_term, op1.terms)
+
+    def test_imul_fermion_op_2(self):
+        op3 = FermionOperator(((1, 1), (0, 0)), -1j)
+        op4 = FermionOperator(((1, 0), (0, 1), (2, 1)), -1.5)
+        op3 *= op4
+        op4 *= op3
+        self.assertIn(((1, 1), (0, 0), (1, 0), (0, 1), (2, 1)), op3.terms)
+        self.assertEqual(op3.terms[((1, 1), (0, 0), (1, 0), (0, 1), (2, 1))],
+                         1.5j)
+
+    def test_imul_bidir(self):
+        op_a = FermionOperator(((1, 1), (0, 0)), -1j)
+        op_b = FermionOperator(((1, 1), (0, 1), (2, 1)), -1.5)
+        op_a *= op_b
+        op_b *= op_a
+        self.assertIn(((1, 1), (0, 0), (1, 1), (0, 1), (2, 1)), op_a.terms)
+        self.assertEqual(op_a.terms[((1, 1), (0, 0), (1, 1), (0, 1), (2, 1))],
+                         1.5j)
+        self.assertIn(((1, 1), (0, 1), (2, 1),
+                       (1, 1), (0, 0), (1, 1), (0, 1), (2, 1)), op_b.terms)
+        self.assertEqual(op_b.terms[((1, 1), (0, 1), (2, 1),
+                                     (1, 1), (0, 0),
+                                     (1, 1), (0, 1), (2, 1))], -2.25j)
+
+    def test_imul_bad_multiplier(self):
+        op = FermionOperator(((1, 1), (0, 1)), -1j)
+        with self.assertRaises(TypeError):
+            op *= "1"
+
+    def test_mul_by_scalarzero(self):
+        op = FermionOperator(((1, 1), (0, 1)), -1j) * 0
+        self.assertNotIn(((0, 1), (1, 1)), op.terms)
+        self.assertIn(((1, 1), (0, 1)), op.terms)
+        self.assertEqual(op.terms[((1, 1), (0, 1))], 0.0)
+
+    def test_mul_bad_multiplier(self):
+        op = FermionOperator(((1, 1), (0, 1)), -1j)
+        with self.assertRaises(TypeError):
+            op = op * "0.5"
+
+    def test_mul_out_of_place(self):
+        op1 = FermionOperator(((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)
+        op2 = FermionOperator(((1, 1), (3, 1), (8, 0)), 0.5)
+        op3 = op1 * op2
+        correct_coefficient = 3.0j * 0.5
+        correct_term = ((0, 1), (3, 1), (3, 0), (11, 1),
+                        (1, 1), (3, 1), (8, 0))
+        self.assertTrue(op1.isclose(FermionOperator(
+            ((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)))
+        self.assertTrue(op2.isclose(FermionOperator(((1, 1), (3, 1), (8, 0)),
+                                                    0.5)))
+        self.assertTrue(op3.isclose(FermionOperator(correct_term,
+                                                    correct_coefficient)))
+
+    def test_mul_npfloat64(self):
+        op = FermionOperator(((1, 0), (3, 1)), 0.5)
+        res = op * numpy.float64(0.5)
+        self.assertTrue(res.isclose(FermionOperator(((1, 0), (3, 1)),
+                                                    0.5 * 0.5)))
+
+    def test_mul_multiple_terms(self):
+        op = FermionOperator(((1, 0), (8, 1)), 0.5)
+        op += FermionOperator(((1, 1), (9, 1)), 1.4j)
+        res = op * op
+        correct = FermionOperator(((1, 0), (8, 1), (1, 0), (8, 1)), 0.5 ** 2)
+        correct += (FermionOperator(((1, 0), (8, 1), (1, 1), (9, 1)), 0.7j) +
+                    FermionOperator(((1, 1), (9, 1), (1, 0), (8, 1)), 0.7j))
+        correct += FermionOperator(((1, 1), (9, 1), (1, 1), (9, 1)), 1.4j ** 2)
+        self.assertTrue(res.isclose(correct))
+
+    def test_rmul_scalar_real(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        multiplier = 0.5
+        res1 = op * multiplier
+        res2 = multiplier * op
+        self.assertTrue(res1.isclose(res2))
+
+    def test_rmul_scalar_complex(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        multiplier = 0.6j
+        res1 = op * multiplier
+        res2 = multiplier * op
+        self.assertTrue(res1.isclose(res2))
+
+    def test_rmul_scalar_npfloat64(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        multiplier = numpy.float64(2.303)
+        res1 = op * multiplier
+        res2 = multiplier * op
+        self.assertTrue(res1.isclose(res2))
+
+    def test_rmul_scalar_npcomplex128(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        multiplier = numpy.complex128(-1.5j + 7.7)
+        res1 = op * multiplier
+        res2 = multiplier * op
+        self.assertTrue(res1.isclose(res2))
+
+    def test_rmul_bad_multiplier(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        with self.assertRaises(TypeError):
+            op = "0.5" * op
+
+    def test_truediv_and_div_real(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = 0.5
+        original = copy.deepcopy(op)
+        res = op / divisor
+        correct = op * (1. / divisor)
+        self.assertTrue(res.isclose(correct))
+        # Test if done out of place
+        self.assertTrue(op.isclose(original))
+
+    def test_truediv_and_div_complex(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = 0.6j
+        original = copy.deepcopy(op)
+        res = op / divisor
+        correct = op * (1. / divisor)
+        self.assertTrue(res.isclose(correct))
+        # Test if done out of place
+        self.assertTrue(op.isclose(original))
+
+    def test_truediv_and_div_npfloat64(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = numpy.float64(2.303)
+        original = copy.deepcopy(op)
+        res = op / divisor
+        correct = op * (1. / divisor)
+        self.assertTrue(res.isclose(correct))
+        # Test if done out of place
+        self.assertTrue(op.isclose(original))
+
+    def test_truediv_and_div_npcomplex128(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = numpy.complex128(566.4j + 0.3)
+        original = copy.deepcopy(op)
+        res = op / divisor
+        correct = op * (1. / divisor)
+        self.assertTrue(res.isclose(correct))
+        # Test if done out of place
+        self.assertTrue(op.isclose(original))
+
+    def test_truediv_bad_divisor(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        with self.assertRaises(TypeError):
+            op = op / "0.5"
+
+    def test_itruediv_and_idiv_real(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = 0.5
+        original = copy.deepcopy(op)
+        correct = op * (1. / divisor)
+        op /= divisor
+        self.assertTrue(op.isclose(correct))
+        # Test if done in-place
+        self.assertFalse(op.isclose(original))
+
+    def test_itruediv_and_idiv_complex(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = 0.6j
+        original = copy.deepcopy(op)
+        correct = op * (1. / divisor)
+        op /= divisor
+        self.assertTrue(op.isclose(correct))
+        # Test if done in-place
+        self.assertFalse(op.isclose(original))
+
+    def test_itruediv_and_idiv_npfloat64(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = numpy.float64(2.3030)
+        original = copy.deepcopy(op)
+        correct = op * (1. / divisor)
+        op /= divisor
+        self.assertTrue(op.isclose(correct))
+        # Test if done in-place
+        self.assertFalse(op.isclose(original))
+
+    def test_itruediv_and_idiv_npcomplex128(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        divisor = numpy.complex128(12.3 + 7.4j)
+        original = copy.deepcopy(op)
+        correct = op * (1. / divisor)
+        op /= divisor
+        self.assertTrue(op.isclose(correct))
+        # Test if done in-place
+        self.assertFalse(op.isclose(original))
+
+    def test_itruediv_bad_divisor(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        with self.assertRaises(TypeError):
+            op /= "0.5"
+
+    def test_iadd_different_term(self):
+        term_a = ((1, 1), (3, 0), (8, 1))
+        term_b = ((1, 1), (3, 1), (8, 0))
+        a = FermionOperator(term_a, 1.0)
+        a += FermionOperator(term_b, 0.5)
+        self.assertEqual(len(a.terms), 2)
+        self.assertEqual(a.terms[term_a], 1.0)
+        self.assertEqual(a.terms[term_b], 0.5)
+        a += FermionOperator(term_b, 0.5)
+        self.assertEqual(len(a.terms), 2)
+        self.assertEqual(a.terms[term_a], 1.0)
+        self.assertEqual(a.terms[term_b], 1.0)
+
+    def test_iadd_bad_addend(self):
+        op = FermionOperator((), 1.0)
+        with self.assertRaises(TypeError):
+            op += "0.5"
+
+    def test_add(self):
+        term_a = ((1, 1), (3, 0), (8, 1))
+        term_b = ((1, 0), (3, 0), (8, 1))
+        a = FermionOperator(term_a, 1.0)
+        b = FermionOperator(term_b, 0.5)
+        res = a + b + b
+        self.assertEqual(len(res.terms), 2)
+        self.assertEqual(res.terms[term_a], 1.0)
+        self.assertEqual(res.terms[term_b], 1.0)
+        # Test out of place
+        self.assertTrue(a.isclose(FermionOperator(term_a, 1.0)))
+        self.assertTrue(b.isclose(FermionOperator(term_b, 0.5)))
+
+    def test_add_bad_addend(self):
+        op = FermionOperator((), 1.0)
+        with self.assertRaises(TypeError):
+            _ = op + "0.5"
+
+    def test_sub(self):
+        term_a = ((1, 1), (3, 1), (8, 1))
+        term_b = ((1, 0), (3, 1), (8, 1))
+        a = FermionOperator(term_a, 1.0)
+        b = FermionOperator(term_b, 0.5)
+        res = a - b
+        self.assertEqual(len(res.terms), 2)
+        self.assertEqual(res.terms[term_a], 1.0)
+        self.assertEqual(res.terms[term_b], -0.5)
+        res2 = b - a
+        self.assertEqual(len(res2.terms), 2)
+        self.assertEqual(res2.terms[term_a], -1.0)
+        self.assertEqual(res2.terms[term_b], 0.5)
+
+    def test_sub_bad_subtrahend(self):
+        op = FermionOperator((), 1.0)
+        with self.assertRaises(TypeError):
+            _ = op - "0.5"
+
+    def test_isub_different_term(self):
+        term_a = ((1, 1), (3, 1), (8, 0))
+        term_b = ((1, 0), (3, 1), (8, 1))
+        a = FermionOperator(term_a, 1.0)
+        a -= FermionOperator(term_b, 0.5)
+        self.assertEqual(len(a.terms), 2)
+        self.assertEqual(a.terms[term_a], 1.0)
+        self.assertEqual(a.terms[term_b], -0.5)
+        a -= FermionOperator(term_b, 0.5)
+        self.assertEqual(len(a.terms), 2)
+        self.assertEqual(a.terms[term_a], 1.0)
+        self.assertEqual(a.terms[term_b], -1.0)
+
+    def test_isub_bad_addend(self):
+        op = FermionOperator((), 1.0)
+        with self.assertRaises(TypeError):
+            op -= "0.5"
+
+    def test_neg(self):
+        op = FermionOperator(((1, 1), (3, 1), (8, 1)), 0.5)
+        _ = -op
+        # out of place
+        self.assertTrue(op.isclose(FermionOperator(((1, 1), (3, 1), (8, 1)),
+                                                   0.5)))
+        correct = -1.0 * op
+        self.assertTrue(correct.isclose(-op))
+
+    def test_pow_square_term(self):
+        coeff = 6.7j
+        ops = ((3, 1), (1, 0), (4, 1))
+        term = FermionOperator(ops, coeff)
+        squared = term ** 2
+        expected = FermionOperator(ops + ops, coeff ** 2)
+        self.assertTrue(squared.isclose(term * term))
+        self.assertTrue(squared.isclose(expected))
+
+    def test_pow_zero_term(self):
+        coeff = 6.7j
+        ops = ((3, 1), (1, 0), (4, 1))
+        term = FermionOperator(ops, coeff)
+        zerod = term ** 0
+        expected = FermionOperator(())
+        self.assertTrue(expected.isclose(zerod))
+
+    def test_pow_one_term(self):
+        coeff = 6.7j
+        ops = ((3, 1), (1, 0), (4, 1))
+        term = FermionOperator(ops, coeff)
+        self.assertTrue(term.isclose(term ** 1))
+
+    def test_pow_high_term(self):
+        coeff = 6.7j
+        ops = ((3, 1), (1, 0), (4, 1))
+        term = FermionOperator(ops, coeff)
+        high = term ** 10
+        expected = FermionOperator(ops * 10, coeff ** 10)
+        self.assertTrue(expected.isclose(high))
+
+    def test_pow_neg_error(self):
+        with self.assertRaises(ValueError):
+            FermionOperator() ** -1
+
+    def test_pow_nonint_error(self):
+        with self.assertRaises(ValueError):
+            FermionOperator('3 2^') ** 0.5
+
+    def test_hermitian_conjugate_empty(self):
+        op = FermionOperator()
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(FermionOperator()))
+
+    def test_hermitian_conjugate_simple(self):
+        op = FermionOperator('1^')
+        op_hc = FermionOperator('1')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_complex_const(self):
+        op = FermionOperator('1^ 3', 3j)
+        op_hc = -3j * FermionOperator('3^ 1')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_notordered(self):
+        op = FermionOperator('1 3^ 3 3^', 3j)
+        op_hc = -3j * FermionOperator('3 3^ 3 1^')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_semihermitian(self):
+        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
+              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
+        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
+                 FermionOperator('3^ 1', -2j) +
+                 FermionOperator('2^ 2', -0.1j))
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugated_empty(self):
+        op = FermionOperator()
+        self.assertTrue(op.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_simple(self):
+        op = FermionOperator('0')
+        op_hc = FermionOperator('0^')
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_complex_const(self):
+        op = FermionOperator('2^ 2', 3j)
+        op_hc = FermionOperator('2^ 2', -3j)
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_multiterm(self):
+        op = FermionOperator('1^ 2') + FermionOperator('2 3 4')
+        op_hc = FermionOperator('2^ 1') + FermionOperator('4^ 3^ 2^')
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_semihermitian(self):
+        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
+              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
+        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
+                 FermionOperator('3^ 1', -2j) +
+                 FermionOperator('2^ 2', -0.1j))
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_compress_terms(self):
+        op = (FermionOperator('3^ 1', 0.3 + 3e-11j) +
+              FermionOperator('2^ 3', 5e-10) +
+              FermionOperator('1^ 3', 1e-3))
+        op_compressed = (FermionOperator('3^ 1', 0.3) +
+                         FermionOperator('1^ 3', 1e-3))
+        op.compress(1e-7)
+        self.assertTrue(op_compressed.isclose(op))
+
+    def test_is_normal_ordered_empty(self):
+        op = FermionOperator() * 2
+        self.assertTrue(op.is_normal_ordered())
+
+    def test_is_normal_ordered_number(self):
+        op = FermionOperator('2^ 2') * -1j
+        self.assertTrue(op.is_normal_ordered())
+
+    def test_is_normal_ordered_reversed(self):
+        self.assertFalse(FermionOperator('2 2^').is_normal_ordered())
+
+    def test_is_normal_ordered_create(self):
+        self.assertTrue(FermionOperator('11^').is_normal_ordered())
+
+    def test_is_normal_ordered_annihilate(self):
+        self.assertTrue(FermionOperator('0').is_normal_ordered())
+
+    def test_is_normal_ordered_long_not(self):
+        self.assertFalse(FermionOperator('0 5^ 3^ 2^ 1^').is_normal_ordered())
+
+    def test_is_normal_ordered_outoforder(self):
+        self.assertFalse(FermionOperator('0 1').is_normal_ordered())
+
+    def test_is_normal_ordered_long_descending(self):
+        self.assertTrue(FermionOperator('5^ 3^ 2^ 1^ 0').is_normal_ordered())
+
+    def test_is_normal_ordered_multi(self):
+        op = FermionOperator('4 3 2^ 2') + FermionOperator('1 2')
+        self.assertFalse(op.is_normal_ordered())
+
+    def test_is_normal_ordered_multiorder(self):
+        op = FermionOperator('4 3 2 1') + FermionOperator('3 2')
+        self.assertTrue(op.is_normal_ordered())
+
+    def test_normal_ordered_single_term(self):
+        op = FermionOperator('4 3 2 1') + FermionOperator('3 2')
+        self.assertTrue(op.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_two_term(self):
+        op_b = FermionOperator(((2, 0), (4, 0), (2, 1)), -88.)
+        normal_ordered_b = normal_ordered(op_b)
+        expected = (FermionOperator(((4, 0),), 88.) +
+                    FermionOperator(((2, 1), (4, 0), (2, 0)), 88.))
+        self.assertTrue(normal_ordered_b.isclose(expected))
+
+    def test_normal_ordered_number(self):
+        number_op2 = FermionOperator(((2, 1), (2, 0)))
+        self.assertTrue(number_op2.isclose(normal_ordered(number_op2)))
+
+    def test_normal_ordered_number_reversed(self):
+        n_term_rev2 = FermionOperator(((2, 0), (2, 1)))
+        number_op2 = number_operator(3, 2)
+        expected = FermionOperator(()) - number_op2
+        self.assertTrue(normal_ordered(n_term_rev2).isclose(expected))
+
+    def test_normal_ordered_offsite(self):
+        op = FermionOperator(((3, 1), (2, 0)))
+        self.assertTrue(op.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_offsite_reversed(self):
+        op = FermionOperator(((3, 0), (2, 1)))
+        expected = -FermionOperator(((2, 1), (3, 0)))
+        self.assertTrue(expected.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_double_create(self):
+        op = FermionOperator(((2, 0), (3, 1), (3, 1)))
+        expected = FermionOperator((), 0.0)
+        self.assertTrue(expected.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_double_create_separated(self):
+        op = FermionOperator(((3, 1), (2, 0), (3, 1)))
+        expected = FermionOperator((), 0.0)
+        self.assertTrue(expected.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_multi(self):
+        op = FermionOperator(((2, 0), (1, 1), (2, 1)))
+        expected = (-FermionOperator(((2, 1), (1, 1), (2, 0))) -
+                    FermionOperator(((1, 1),)))
+        self.assertTrue(expected.isclose(normal_ordered(op)))
+
+    def test_normal_ordered_triple(self):
+        op_132 = FermionOperator(((1, 1), (3, 0), (2, 0)))
+        op_123 = FermionOperator(((1, 1), (2, 0), (3, 0)))
+        op_321 = FermionOperator(((3, 0), (2, 0), (1, 1)))
+
+        self.assertTrue(op_132.isclose(normal_ordered(-op_123)))
+        self.assertTrue(op_132.isclose(normal_ordered(op_132)))
+        self.assertTrue(op_132.isclose(normal_ordered(op_321)))
+
+    def test_is_molecular_term_FermionOperator(self):
+        op = FermionOperator()
+        self.assertTrue(op.is_molecular_term())
+
+    def test_is_molecular_term_number(self):
+        op = number_operator(n_orbitals=5, orbital=3)
+        self.assertTrue(op.is_molecular_term())
+
+    def test_is_molecular_term_updown(self):
+        op = FermionOperator(((2, 1), (4, 0)))
+        self.assertTrue(op.is_molecular_term())
+
+    def test_is_molecular_term_downup(self):
+        op = FermionOperator(((2, 0), (4, 1)))
+        self.assertTrue(op.is_molecular_term())
+
+    def test_is_molecular_term_downup_badspin(self):
+        op = FermionOperator(((2, 0), (3, 1)))
+        self.assertFalse(op.is_molecular_term())
+
+    def test_is_molecular_term_three(self):
+        op = FermionOperator(((0, 1), (2, 1), (4, 0)))
+        self.assertFalse(op.is_molecular_term())
+
+    def test_is_molecular_term_out_of_order(self):
+        op = FermionOperator(((0, 1), (2, 0), (1, 1), (3, 0)))
+        self.assertTrue(op.is_molecular_term())
+
+    def test_str(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        self.assertEqual(str(op), "0.5 [1^ 3 8^]")
+        op2 = FermionOperator((), 2)
+        self.assertEqual(str(op2), "2 []")
+        op3 = FermionOperator()
+        self.assertEqual(str(op3), "0")
+
+    def test_rep(self):
+        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        # Not necessary, repr could do something in addition
+        self.assertEqual(repr(op), str(op))

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""Tests  _fermion_operator.py."""
+"""Tests  _symbolic_operator.py."""
 import copy
 import numpy
 import unittest
@@ -19,88 +19,89 @@ from openfermion.ops._symbolic_operator import (SymbolicOperator,
                                                 SymbolicOperatorError)
  
 
-class DummyOperator(SymbolicOperator):
+class DummyOperator1(SymbolicOperator):
     """Subclass of SymbolicOperator created for testing purposes."""
-    actions = {'a', 'b', 'c'}
-    
-    def parse_sequence(term):
-        return tuple(term)
-
-    def parse_string(term):
-        """I.e. 'a0 b4 c3' -> (('a', 0), ('b', 4), ('c', 3))"""
-        factor_strings = term.split()
-        factors = []
-        for factor in factor_strings:
-            factors.append((factor[0], int(factor[1])))
-        return tuple(factors)
+    actions = (1, 0)
+    action_strings = ('^', '')
+    action_before_index = False
+    different_indices_commute = False
 
 
-class SymbolicOperatorTest(unittest.TestCase):
+class DummyOperator2(SymbolicOperator):
+    """Subclass of SymbolicOperator created for testing purposes."""
+    actions = ('X', 'Y', 'Z')
+    action_strings = ('X', 'Y', 'Z')
+    action_before_index = True
+    different_indices_commute = True
+
+
+class SymbolicOperatorTest1(unittest.TestCase):
+    """Test the subclass DummyOperator1."""
 
     def test_init_defaults(self):
-        loc_op = FermionOperator()
+        loc_op = DummyOperator1()
         self.assertEqual(len(loc_op.terms), 0)
 
     def test_init_tuple_real_coefficient(self):
         loc_op = ((0, 1), (5, 0), (6, 1))
         coefficient = 0.5
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_tuple_complex_coefficient(self):
         loc_op = ((0, 1), (5, 0), (6, 1))
         coefficient = 0.6j
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_tuple_npfloat64_coefficient(self):
         loc_op = ((0, 1), (5, 0), (6, 1))
         coefficient = numpy.float64(2.303)
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_tuple_npcomplex128_coefficient(self):
         loc_op = ((0, 1), (5, 0), (6, 1))
         coefficient = numpy.complex128(-1.123j + 43.7)
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_list_real_coefficient(self):
         loc_op = [(0, 1), (5, 0), (6, 1)]
         coefficient = 1. / 3
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_list_complex_coefficient(self):
         loc_op = [(0, 1), (5, 0), (6, 1)]
         coefficient = 2j / 3.
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_list_npfloat64_coefficient(self):
         loc_op = [(0, 1), (5, 0), (6, 1)]
         coefficient = numpy.float64(2.3037)
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_init_list_npcomplex128_coefficient(self):
         loc_op = [(0, 1), (5, 0), (6, 1)]
         coefficient = numpy.complex128(-1.1237j + 43.37)
-        fermion_op = FermionOperator(loc_op, coefficient)
+        fermion_op = DummyOperator1(loc_op, coefficient)
         self.assertEqual(len(fermion_op.terms), 1)
         self.assertEqual(fermion_op.terms[tuple(loc_op)], coefficient)
 
     def test_identity_is_multiplicative_identity(self):
-        u = FermionOperator.identity()
-        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
-        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        u = DummyOperator1.identity()
+        f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
         h = f + g
         self.assertTrue(f.isclose(u * f))
         self.assertTrue(f.isclose(f * u))
@@ -114,12 +115,12 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(f.isclose(u))
 
         # Method always returns new instances.
-        self.assertFalse(FermionOperator.identity().isclose(u))
+        self.assertFalse(DummyOperator1.identity().isclose(u))
 
     def test_zero_is_additive_identity(self):
-        o = FermionOperator.zero()
-        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
-        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        o = DummyOperator1.zero()
+        f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
         h = f + g
         self.assertTrue(f.isclose(o + f))
         self.assertTrue(f.isclose(f + o))
@@ -133,125 +134,112 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(f.isclose(o))
 
         # Method always returns new instances.
-        self.assertFalse(FermionOperator.zero().isclose(o))
+        self.assertFalse(DummyOperator1.zero().isclose(o))
 
     def test_zero_is_multiplicative_nil(self):
-        o = FermionOperator.zero()
-        u = FermionOperator.identity()
-        f = FermionOperator(((0, 1), (5, 0), (6, 1)), 0.6j)
-        g = FermionOperator(((0, 0), (5, 0), (6, 1)), 0.3j)
+        o = DummyOperator1.zero()
+        u = DummyOperator1.identity()
+        f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
+        g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
         self.assertTrue(o.isclose(o * u))
         self.assertTrue(o.isclose(o * f))
         self.assertTrue(o.isclose(o * g))
         self.assertTrue(o.isclose(o * (f + g)))
 
     def test_init_str(self):
-        fermion_op = FermionOperator('0^ 5 12^', -1.)
+        fermion_op = DummyOperator1('0^ 5 12^', -1.)
         correct = ((0, 1), (5, 0), (12, 1))
         self.assertIn(correct, fermion_op.terms)
         self.assertEqual(fermion_op.terms[correct], -1.0)
 
     def test_merges_multiple_whitespace(self):
-        fermion_op = FermionOperator('        \n ')
+        fermion_op = DummyOperator1('        \n ')
         self.assertEqual(fermion_op.terms, {(): 1})
 
     def test_init_str_identity(self):
-        fermion_op = FermionOperator('')
+        fermion_op = DummyOperator1('')
         self.assertIn((), fermion_op.terms)
 
     def test_init_bad_term(self):
         with self.assertRaises(ValueError):
-            FermionOperator(2)
+            DummyOperator1(2)
 
     def test_init_bad_coefficient(self):
         with self.assertRaises(ValueError):
-            FermionOperator('0^', "0.5")
+            DummyOperator1('0^', "0.5")
 
     def test_init_bad_action_str(self):
-        with self.assertRaises(FermionOperatorError):
-            FermionOperator('0-')
+        with self.assertRaises(ValueError):
+            DummyOperator1('0-')
 
     def test_init_bad_action_tuple(self):
         with self.assertRaises(ValueError):
-            FermionOperator(((0, 2),))
+            DummyOperator1(((0, 2),))
 
     def test_init_bad_tuple(self):
         with self.assertRaises(ValueError):
-            FermionOperator(((0, 1, 1),))
+            DummyOperator1(((0, 1, 1),))
 
     def test_init_bad_str(self):
-        with self.assertRaises(FermionOperatorError):
-            FermionOperator('^')
+        with self.assertRaises(ValueError):
+            DummyOperator1('^')
 
     def test_init_bad_mode_num(self):
-        with self.assertRaises(FermionOperatorError):
-            FermionOperator('-1^')
+        with self.assertRaises(ValueError):
+            DummyOperator1('-1^')
 
     def test_init_invalid_tensor_factor(self):
-        with self.assertRaises(FermionOperatorError):
-            FermionOperator(((-2, 1), (1, 0)))
+        with self.assertRaises(ValueError):
+            DummyOperator1(((-2, 1), (1, 0)))
 
-    def test_FermionOperator(self):
-        op = FermionOperator((), 3.)
-        self.assertTrue(op.isclose(FermionOperator(()) * 3.))
-
-    def test_number_operator_site(self):
-        op = number_operator(3, 2, 1j)
-        self.assertTrue(op.isclose(FermionOperator(((2, 1), (2, 0))) * 1j))
-
-    def test_number_operator_nosite(self):
-        op = number_operator(4)
-        expected = (FermionOperator(((0, 1), (0, 0))) +
-                    FermionOperator(((1, 1), (1, 0))) +
-                    FermionOperator(((2, 1), (2, 0))) +
-                    FermionOperator(((3, 1), (3, 0))))
-        self.assertTrue(op.isclose(expected))
-
+    def test_DummyOperator1(self):
+        op = DummyOperator1((), 3.)
+        self.assertTrue(op.isclose(DummyOperator1(()) * 3.))
 
     def test_isclose_abs_tol(self):
-        a = FermionOperator('0^', -1.)
-        b = FermionOperator('0^', -1.05)
-        c = FermionOperator('0^', -1.11)
+        a = DummyOperator1('0^', -1.)
+        b = DummyOperator1('0^', -1.05)
+        c = DummyOperator1('0^', -1.11)
         self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
         self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
-        a = FermionOperator('0^', -1.0j)
-        b = FermionOperator('0^', -1.05j)
-        c = FermionOperator('0^', -1.11j)
+        a = DummyOperator1('0^', -1.0j)
+        b = DummyOperator1('0^', -1.05j)
+        c = DummyOperator1('0^', -1.11j)
         self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
         self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
 
     def test_isclose_rel_tol(self):
-        a = FermionOperator('0', 1)
-        b = FermionOperator('0', 2)
+        a = DummyOperator1('0', 1)
+        b = DummyOperator1('0', 2)
         self.assertTrue(a.isclose(b, rel_tol=2.5, abs_tol=0.1))
         # Test symmetry
         self.assertTrue(a.isclose(b, rel_tol=1, abs_tol=0.1))
         self.assertTrue(b.isclose(a, rel_tol=1, abs_tol=0.1))
 
     def test_isclose_zero_terms(self):
-        op = FermionOperator('1^ 0', -1j) * 0
-        self.assertTrue(op.isclose(FermionOperator((), 0.0),
+        op = DummyOperator1('1^ 0', -1j) * 0
+        self.assertTrue(op.isclose(DummyOperator1((), 0.0),
                                    rel_tol=1e-12, abs_tol=1e-12))
-        self.assertTrue(FermionOperator().isclose(
+        self.assertTrue(DummyOperator1().isclose(
             op, rel_tol=1e-12, abs_tol=1e-12))
 
     def test_isclose_different_terms(self):
-        a = FermionOperator(((1, 0),), -0.1j)
-        b = FermionOperator(((1, 1),), -0.1j)
+        a = DummyOperator1(((1, 0),), -0.1j)
+        b = DummyOperator1(((1, 1),), -0.1j)
         self.assertTrue(a.isclose(b, rel_tol=1e-12, abs_tol=0.2))
         self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
         self.assertTrue(b.isclose(a, rel_tol=1e-12, abs_tol=0.2))
         self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
 
     def test_isclose_different_num_terms(self):
-        a = FermionOperator(((1, 0),), -0.1j)
-        a += FermionOperator(((1, 1),), -0.1j)
-        b = FermionOperator(((1, 0),), -0.1j)
+        a = DummyOperator1(((1, 0),), -0.1j)
+        a += DummyOperator1(((1, 1),), -0.1j)
+        b = DummyOperator1(((1, 0),), -0.1j)
         self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
         self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
 
     def test_imul_inplace(self):
-        fermion_op = FermionOperator("1^")
+        fermion_op = DummyOperator1("1^")
         prev_id = id(fermion_op)
         fermion_op *= 3.
         self.assertEqual(id(fermion_op), prev_id)
@@ -260,34 +248,34 @@ class SymbolicOperatorTest(unittest.TestCase):
     def test_imul_scalar_real(self):
         loc_op = ((1, 0), (2, 1))
         multiplier = 0.5
-        fermion_op = FermionOperator(loc_op)
+        fermion_op = DummyOperator1(loc_op)
         fermion_op *= multiplier
         self.assertEqual(fermion_op.terms[loc_op], multiplier)
 
     def test_imul_scalar_complex(self):
         loc_op = ((1, 0), (2, 1))
         multiplier = 0.6j
-        fermion_op = FermionOperator(loc_op)
+        fermion_op = DummyOperator1(loc_op)
         fermion_op *= multiplier
         self.assertEqual(fermion_op.terms[loc_op], multiplier)
 
     def test_imul_scalar_npfloat64(self):
         loc_op = ((1, 0), (2, 1))
         multiplier = numpy.float64(2.303)
-        fermion_op = FermionOperator(loc_op)
+        fermion_op = DummyOperator1(loc_op)
         fermion_op *= multiplier
         self.assertEqual(fermion_op.terms[loc_op], multiplier)
 
     def test_imul_scalar_npcomplex128(self):
         loc_op = ((1, 0), (2, 1))
         multiplier = numpy.complex128(-1.123j + 1.7911)
-        fermion_op = FermionOperator(loc_op)
+        fermion_op = DummyOperator1(loc_op)
         fermion_op *= multiplier
         self.assertEqual(fermion_op.terms[loc_op], multiplier)
 
     def test_imul_fermion_op(self):
-        op1 = FermionOperator(((0, 1), (3, 0), (8, 1), (8, 0), (11, 1)), 3.j)
-        op2 = FermionOperator(((1, 1), (3, 1), (8, 0)), 0.5)
+        op1 = DummyOperator1(((0, 1), (3, 0), (8, 1), (8, 0), (11, 1)), 3.j)
+        op2 = DummyOperator1(((1, 1), (3, 1), (8, 0)), 0.5)
         op1 *= op2
         correct_coefficient = 1.j * 3.0j * 0.5
         correct_term = ((0, 1), (3, 0), (8, 1), (8, 0), (11, 1),
@@ -296,8 +284,8 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertIn(correct_term, op1.terms)
 
     def test_imul_fermion_op_2(self):
-        op3 = FermionOperator(((1, 1), (0, 0)), -1j)
-        op4 = FermionOperator(((1, 0), (0, 1), (2, 1)), -1.5)
+        op3 = DummyOperator1(((1, 1), (0, 0)), -1j)
+        op4 = DummyOperator1(((1, 0), (0, 1), (2, 1)), -1.5)
         op3 *= op4
         op4 *= op3
         self.assertIn(((1, 1), (0, 0), (1, 0), (0, 1), (2, 1)), op3.terms)
@@ -305,8 +293,8 @@ class SymbolicOperatorTest(unittest.TestCase):
                          1.5j)
 
     def test_imul_bidir(self):
-        op_a = FermionOperator(((1, 1), (0, 0)), -1j)
-        op_b = FermionOperator(((1, 1), (0, 1), (2, 1)), -1.5)
+        op_a = DummyOperator1(((1, 1), (0, 0)), -1j)
+        op_b = DummyOperator1(((1, 1), (0, 1), (2, 1)), -1.5)
         op_a *= op_b
         op_b *= op_a
         self.assertIn(((1, 1), (0, 0), (1, 1), (0, 1), (2, 1)), op_a.terms)
@@ -319,86 +307,86 @@ class SymbolicOperatorTest(unittest.TestCase):
                                      (1, 1), (0, 1), (2, 1))], -2.25j)
 
     def test_imul_bad_multiplier(self):
-        op = FermionOperator(((1, 1), (0, 1)), -1j)
+        op = DummyOperator1(((1, 1), (0, 1)), -1j)
         with self.assertRaises(TypeError):
             op *= "1"
 
     def test_mul_by_scalarzero(self):
-        op = FermionOperator(((1, 1), (0, 1)), -1j) * 0
+        op = DummyOperator1(((1, 1), (0, 1)), -1j) * 0
         self.assertNotIn(((0, 1), (1, 1)), op.terms)
         self.assertIn(((1, 1), (0, 1)), op.terms)
         self.assertEqual(op.terms[((1, 1), (0, 1))], 0.0)
 
     def test_mul_bad_multiplier(self):
-        op = FermionOperator(((1, 1), (0, 1)), -1j)
+        op = DummyOperator1(((1, 1), (0, 1)), -1j)
         with self.assertRaises(TypeError):
             op = op * "0.5"
 
     def test_mul_out_of_place(self):
-        op1 = FermionOperator(((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)
-        op2 = FermionOperator(((1, 1), (3, 1), (8, 0)), 0.5)
+        op1 = DummyOperator1(((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)
+        op2 = DummyOperator1(((1, 1), (3, 1), (8, 0)), 0.5)
         op3 = op1 * op2
         correct_coefficient = 3.0j * 0.5
         correct_term = ((0, 1), (3, 1), (3, 0), (11, 1),
                         (1, 1), (3, 1), (8, 0))
-        self.assertTrue(op1.isclose(FermionOperator(
+        self.assertTrue(op1.isclose(DummyOperator1(
             ((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)))
-        self.assertTrue(op2.isclose(FermionOperator(((1, 1), (3, 1), (8, 0)),
+        self.assertTrue(op2.isclose(DummyOperator1(((1, 1), (3, 1), (8, 0)),
                                                     0.5)))
-        self.assertTrue(op3.isclose(FermionOperator(correct_term,
+        self.assertTrue(op3.isclose(DummyOperator1(correct_term,
                                                     correct_coefficient)))
 
     def test_mul_npfloat64(self):
-        op = FermionOperator(((1, 0), (3, 1)), 0.5)
+        op = DummyOperator1(((1, 0), (3, 1)), 0.5)
         res = op * numpy.float64(0.5)
-        self.assertTrue(res.isclose(FermionOperator(((1, 0), (3, 1)),
+        self.assertTrue(res.isclose(DummyOperator1(((1, 0), (3, 1)),
                                                     0.5 * 0.5)))
 
     def test_mul_multiple_terms(self):
-        op = FermionOperator(((1, 0), (8, 1)), 0.5)
-        op += FermionOperator(((1, 1), (9, 1)), 1.4j)
+        op = DummyOperator1(((1, 0), (8, 1)), 0.5)
+        op += DummyOperator1(((1, 1), (9, 1)), 1.4j)
         res = op * op
-        correct = FermionOperator(((1, 0), (8, 1), (1, 0), (8, 1)), 0.5 ** 2)
-        correct += (FermionOperator(((1, 0), (8, 1), (1, 1), (9, 1)), 0.7j) +
-                    FermionOperator(((1, 1), (9, 1), (1, 0), (8, 1)), 0.7j))
-        correct += FermionOperator(((1, 1), (9, 1), (1, 1), (9, 1)), 1.4j ** 2)
+        correct = DummyOperator1(((1, 0), (8, 1), (1, 0), (8, 1)), 0.5 ** 2)
+        correct += (DummyOperator1(((1, 0), (8, 1), (1, 1), (9, 1)), 0.7j) +
+                    DummyOperator1(((1, 1), (9, 1), (1, 0), (8, 1)), 0.7j))
+        correct += DummyOperator1(((1, 1), (9, 1), (1, 1), (9, 1)), 1.4j ** 2)
         self.assertTrue(res.isclose(correct))
 
     def test_rmul_scalar_real(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = 0.5
         res1 = op * multiplier
         res2 = multiplier * op
         self.assertTrue(res1.isclose(res2))
 
     def test_rmul_scalar_complex(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = 0.6j
         res1 = op * multiplier
         res2 = multiplier * op
         self.assertTrue(res1.isclose(res2))
 
     def test_rmul_scalar_npfloat64(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = numpy.float64(2.303)
         res1 = op * multiplier
         res2 = multiplier * op
         self.assertTrue(res1.isclose(res2))
 
     def test_rmul_scalar_npcomplex128(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = numpy.complex128(-1.5j + 7.7)
         res1 = op * multiplier
         res2 = multiplier * op
         self.assertTrue(res1.isclose(res2))
 
     def test_rmul_bad_multiplier(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         with self.assertRaises(TypeError):
             op = "0.5" * op
 
     def test_truediv_and_div_real(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = 0.5
         original = copy.deepcopy(op)
         res = op / divisor
@@ -408,7 +396,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertTrue(op.isclose(original))
 
     def test_truediv_and_div_complex(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = 0.6j
         original = copy.deepcopy(op)
         res = op / divisor
@@ -418,7 +406,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertTrue(op.isclose(original))
 
     def test_truediv_and_div_npfloat64(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = numpy.float64(2.303)
         original = copy.deepcopy(op)
         res = op / divisor
@@ -428,7 +416,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertTrue(op.isclose(original))
 
     def test_truediv_and_div_npcomplex128(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = numpy.complex128(566.4j + 0.3)
         original = copy.deepcopy(op)
         res = op / divisor
@@ -438,12 +426,12 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertTrue(op.isclose(original))
 
     def test_truediv_bad_divisor(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         with self.assertRaises(TypeError):
             op = op / "0.5"
 
     def test_itruediv_and_idiv_real(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = 0.5
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
@@ -453,7 +441,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(op.isclose(original))
 
     def test_itruediv_and_idiv_complex(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = 0.6j
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
@@ -463,7 +451,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(op.isclose(original))
 
     def test_itruediv_and_idiv_npfloat64(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = numpy.float64(2.3030)
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
@@ -473,7 +461,7 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(op.isclose(original))
 
     def test_itruediv_and_idiv_npcomplex128(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         divisor = numpy.complex128(12.3 + 7.4j)
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
@@ -483,51 +471,51 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertFalse(op.isclose(original))
 
     def test_itruediv_bad_divisor(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         with self.assertRaises(TypeError):
             op /= "0.5"
 
     def test_iadd_different_term(self):
         term_a = ((1, 1), (3, 0), (8, 1))
         term_b = ((1, 1), (3, 1), (8, 0))
-        a = FermionOperator(term_a, 1.0)
-        a += FermionOperator(term_b, 0.5)
+        a = DummyOperator1(term_a, 1.0)
+        a += DummyOperator1(term_b, 0.5)
         self.assertEqual(len(a.terms), 2)
         self.assertEqual(a.terms[term_a], 1.0)
         self.assertEqual(a.terms[term_b], 0.5)
-        a += FermionOperator(term_b, 0.5)
+        a += DummyOperator1(term_b, 0.5)
         self.assertEqual(len(a.terms), 2)
         self.assertEqual(a.terms[term_a], 1.0)
         self.assertEqual(a.terms[term_b], 1.0)
 
     def test_iadd_bad_addend(self):
-        op = FermionOperator((), 1.0)
+        op = DummyOperator1((), 1.0)
         with self.assertRaises(TypeError):
             op += "0.5"
 
     def test_add(self):
         term_a = ((1, 1), (3, 0), (8, 1))
         term_b = ((1, 0), (3, 0), (8, 1))
-        a = FermionOperator(term_a, 1.0)
-        b = FermionOperator(term_b, 0.5)
+        a = DummyOperator1(term_a, 1.0)
+        b = DummyOperator1(term_b, 0.5)
         res = a + b + b
         self.assertEqual(len(res.terms), 2)
         self.assertEqual(res.terms[term_a], 1.0)
         self.assertEqual(res.terms[term_b], 1.0)
         # Test out of place
-        self.assertTrue(a.isclose(FermionOperator(term_a, 1.0)))
-        self.assertTrue(b.isclose(FermionOperator(term_b, 0.5)))
+        self.assertTrue(a.isclose(DummyOperator1(term_a, 1.0)))
+        self.assertTrue(b.isclose(DummyOperator1(term_b, 0.5)))
 
     def test_add_bad_addend(self):
-        op = FermionOperator((), 1.0)
+        op = DummyOperator1((), 1.0)
         with self.assertRaises(TypeError):
             _ = op + "0.5"
 
     def test_sub(self):
         term_a = ((1, 1), (3, 1), (8, 1))
         term_b = ((1, 0), (3, 1), (8, 1))
-        a = FermionOperator(term_a, 1.0)
-        b = FermionOperator(term_b, 0.5)
+        a = DummyOperator1(term_a, 1.0)
+        b = DummyOperator1(term_b, 0.5)
         res = a - b
         self.assertEqual(len(res.terms), 2)
         self.assertEqual(res.terms[term_a], 1.0)
@@ -538,33 +526,33 @@ class SymbolicOperatorTest(unittest.TestCase):
         self.assertEqual(res2.terms[term_b], 0.5)
 
     def test_sub_bad_subtrahend(self):
-        op = FermionOperator((), 1.0)
+        op = DummyOperator1((), 1.0)
         with self.assertRaises(TypeError):
             _ = op - "0.5"
 
     def test_isub_different_term(self):
         term_a = ((1, 1), (3, 1), (8, 0))
         term_b = ((1, 0), (3, 1), (8, 1))
-        a = FermionOperator(term_a, 1.0)
-        a -= FermionOperator(term_b, 0.5)
+        a = DummyOperator1(term_a, 1.0)
+        a -= DummyOperator1(term_b, 0.5)
         self.assertEqual(len(a.terms), 2)
         self.assertEqual(a.terms[term_a], 1.0)
         self.assertEqual(a.terms[term_b], -0.5)
-        a -= FermionOperator(term_b, 0.5)
+        a -= DummyOperator1(term_b, 0.5)
         self.assertEqual(len(a.terms), 2)
         self.assertEqual(a.terms[term_a], 1.0)
         self.assertEqual(a.terms[term_b], -1.0)
 
     def test_isub_bad_addend(self):
-        op = FermionOperator((), 1.0)
+        op = DummyOperator1((), 1.0)
         with self.assertRaises(TypeError):
             op -= "0.5"
 
     def test_neg(self):
-        op = FermionOperator(((1, 1), (3, 1), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 1), (8, 1)), 0.5)
         _ = -op
         # out of place
-        self.assertTrue(op.isclose(FermionOperator(((1, 1), (3, 1), (8, 1)),
+        self.assertTrue(op.isclose(DummyOperator1(((1, 1), (3, 1), (8, 1)),
                                                    0.5)))
         correct = -1.0 * op
         self.assertTrue(correct.isclose(-op))
@@ -572,236 +560,359 @@ class SymbolicOperatorTest(unittest.TestCase):
     def test_pow_square_term(self):
         coeff = 6.7j
         ops = ((3, 1), (1, 0), (4, 1))
-        term = FermionOperator(ops, coeff)
+        term = DummyOperator1(ops, coeff)
         squared = term ** 2
-        expected = FermionOperator(ops + ops, coeff ** 2)
+        expected = DummyOperator1(ops + ops, coeff ** 2)
         self.assertTrue(squared.isclose(term * term))
         self.assertTrue(squared.isclose(expected))
 
     def test_pow_zero_term(self):
         coeff = 6.7j
         ops = ((3, 1), (1, 0), (4, 1))
-        term = FermionOperator(ops, coeff)
+        term = DummyOperator1(ops, coeff)
         zerod = term ** 0
-        expected = FermionOperator(())
+        expected = DummyOperator1(())
         self.assertTrue(expected.isclose(zerod))
 
     def test_pow_one_term(self):
         coeff = 6.7j
         ops = ((3, 1), (1, 0), (4, 1))
-        term = FermionOperator(ops, coeff)
+        term = DummyOperator1(ops, coeff)
         self.assertTrue(term.isclose(term ** 1))
 
     def test_pow_high_term(self):
         coeff = 6.7j
         ops = ((3, 1), (1, 0), (4, 1))
-        term = FermionOperator(ops, coeff)
+        term = DummyOperator1(ops, coeff)
         high = term ** 10
-        expected = FermionOperator(ops * 10, coeff ** 10)
+        expected = DummyOperator1(ops * 10, coeff ** 10)
         self.assertTrue(expected.isclose(high))
 
     def test_pow_neg_error(self):
         with self.assertRaises(ValueError):
-            FermionOperator() ** -1
+            DummyOperator1() ** -1
 
     def test_pow_nonint_error(self):
         with self.assertRaises(ValueError):
-            FermionOperator('3 2^') ** 0.5
-
-    def test_hermitian_conjugate_empty(self):
-        op = FermionOperator()
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(FermionOperator()))
-
-    def test_hermitian_conjugate_simple(self):
-        op = FermionOperator('1^')
-        op_hc = FermionOperator('1')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_complex_const(self):
-        op = FermionOperator('1^ 3', 3j)
-        op_hc = -3j * FermionOperator('3^ 1')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_notordered(self):
-        op = FermionOperator('1 3^ 3 3^', 3j)
-        op_hc = -3j * FermionOperator('3 3^ 3 1^')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_semihermitian(self):
-        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
-              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
-        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
-                 FermionOperator('3^ 1', -2j) +
-                 FermionOperator('2^ 2', -0.1j))
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugated_empty(self):
-        op = FermionOperator()
-        self.assertTrue(op.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_simple(self):
-        op = FermionOperator('0')
-        op_hc = FermionOperator('0^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_complex_const(self):
-        op = FermionOperator('2^ 2', 3j)
-        op_hc = FermionOperator('2^ 2', -3j)
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_multiterm(self):
-        op = FermionOperator('1^ 2') + FermionOperator('2 3 4')
-        op_hc = FermionOperator('2^ 1') + FermionOperator('4^ 3^ 2^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_semihermitian(self):
-        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
-              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
-        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
-                 FermionOperator('3^ 1', -2j) +
-                 FermionOperator('2^ 2', -0.1j))
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+            DummyOperator1('3 2^') ** 0.5
 
     def test_compress_terms(self):
-        op = (FermionOperator('3^ 1', 0.3 + 3e-11j) +
-              FermionOperator('2^ 3', 5e-10) +
-              FermionOperator('1^ 3', 1e-3))
-        op_compressed = (FermionOperator('3^ 1', 0.3) +
-                         FermionOperator('1^ 3', 1e-3))
+        op = (DummyOperator1('3^ 1', 0.3 + 3e-11j) +
+              DummyOperator1('2^ 3', 5e-10) +
+              DummyOperator1('1^ 3', 1e-3))
+        op_compressed = (DummyOperator1('3^ 1', 0.3) +
+                         DummyOperator1('1^ 3', 1e-3))
         op.compress(1e-7)
         self.assertTrue(op_compressed.isclose(op))
 
-    def test_is_normal_ordered_empty(self):
-        op = FermionOperator() * 2
-        self.assertTrue(op.is_normal_ordered())
-
-    def test_is_normal_ordered_number(self):
-        op = FermionOperator('2^ 2') * -1j
-        self.assertTrue(op.is_normal_ordered())
-
-    def test_is_normal_ordered_reversed(self):
-        self.assertFalse(FermionOperator('2 2^').is_normal_ordered())
-
-    def test_is_normal_ordered_create(self):
-        self.assertTrue(FermionOperator('11^').is_normal_ordered())
-
-    def test_is_normal_ordered_annihilate(self):
-        self.assertTrue(FermionOperator('0').is_normal_ordered())
-
-    def test_is_normal_ordered_long_not(self):
-        self.assertFalse(FermionOperator('0 5^ 3^ 2^ 1^').is_normal_ordered())
-
-    def test_is_normal_ordered_outoforder(self):
-        self.assertFalse(FermionOperator('0 1').is_normal_ordered())
-
-    def test_is_normal_ordered_long_descending(self):
-        self.assertTrue(FermionOperator('5^ 3^ 2^ 1^ 0').is_normal_ordered())
-
-    def test_is_normal_ordered_multi(self):
-        op = FermionOperator('4 3 2^ 2') + FermionOperator('1 2')
-        self.assertFalse(op.is_normal_ordered())
-
-    def test_is_normal_ordered_multiorder(self):
-        op = FermionOperator('4 3 2 1') + FermionOperator('3 2')
-        self.assertTrue(op.is_normal_ordered())
-
-    def test_normal_ordered_single_term(self):
-        op = FermionOperator('4 3 2 1') + FermionOperator('3 2')
-        self.assertTrue(op.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_two_term(self):
-        op_b = FermionOperator(((2, 0), (4, 0), (2, 1)), -88.)
-        normal_ordered_b = normal_ordered(op_b)
-        expected = (FermionOperator(((4, 0),), 88.) +
-                    FermionOperator(((2, 1), (4, 0), (2, 0)), 88.))
-        self.assertTrue(normal_ordered_b.isclose(expected))
-
-    def test_normal_ordered_number(self):
-        number_op2 = FermionOperator(((2, 1), (2, 0)))
-        self.assertTrue(number_op2.isclose(normal_ordered(number_op2)))
-
-    def test_normal_ordered_number_reversed(self):
-        n_term_rev2 = FermionOperator(((2, 0), (2, 1)))
-        number_op2 = number_operator(3, 2)
-        expected = FermionOperator(()) - number_op2
-        self.assertTrue(normal_ordered(n_term_rev2).isclose(expected))
-
-    def test_normal_ordered_offsite(self):
-        op = FermionOperator(((3, 1), (2, 0)))
-        self.assertTrue(op.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_offsite_reversed(self):
-        op = FermionOperator(((3, 0), (2, 1)))
-        expected = -FermionOperator(((2, 1), (3, 0)))
-        self.assertTrue(expected.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_double_create(self):
-        op = FermionOperator(((2, 0), (3, 1), (3, 1)))
-        expected = FermionOperator((), 0.0)
-        self.assertTrue(expected.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_double_create_separated(self):
-        op = FermionOperator(((3, 1), (2, 0), (3, 1)))
-        expected = FermionOperator((), 0.0)
-        self.assertTrue(expected.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_multi(self):
-        op = FermionOperator(((2, 0), (1, 1), (2, 1)))
-        expected = (-FermionOperator(((2, 1), (1, 1), (2, 0))) -
-                    FermionOperator(((1, 1),)))
-        self.assertTrue(expected.isclose(normal_ordered(op)))
-
-    def test_normal_ordered_triple(self):
-        op_132 = FermionOperator(((1, 1), (3, 0), (2, 0)))
-        op_123 = FermionOperator(((1, 1), (2, 0), (3, 0)))
-        op_321 = FermionOperator(((3, 0), (2, 0), (1, 1)))
-
-        self.assertTrue(op_132.isclose(normal_ordered(-op_123)))
-        self.assertTrue(op_132.isclose(normal_ordered(op_132)))
-        self.assertTrue(op_132.isclose(normal_ordered(op_321)))
-
-    def test_is_molecular_term_FermionOperator(self):
-        op = FermionOperator()
-        self.assertTrue(op.is_molecular_term())
-
-    def test_is_molecular_term_number(self):
-        op = number_operator(n_orbitals=5, orbital=3)
-        self.assertTrue(op.is_molecular_term())
-
-    def test_is_molecular_term_updown(self):
-        op = FermionOperator(((2, 1), (4, 0)))
-        self.assertTrue(op.is_molecular_term())
-
-    def test_is_molecular_term_downup(self):
-        op = FermionOperator(((2, 0), (4, 1)))
-        self.assertTrue(op.is_molecular_term())
-
-    def test_is_molecular_term_downup_badspin(self):
-        op = FermionOperator(((2, 0), (3, 1)))
-        self.assertFalse(op.is_molecular_term())
-
-    def test_is_molecular_term_three(self):
-        op = FermionOperator(((0, 1), (2, 1), (4, 0)))
-        self.assertFalse(op.is_molecular_term())
-
-    def test_is_molecular_term_out_of_order(self):
-        op = FermionOperator(((0, 1), (2, 0), (1, 1), (3, 0)))
-        self.assertTrue(op.is_molecular_term())
-
     def test_str(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         self.assertEqual(str(op), "0.5 [1^ 3 8^]")
-        op2 = FermionOperator((), 2)
+        op2 = DummyOperator1((), 2)
         self.assertEqual(str(op2), "2 []")
-        op3 = FermionOperator()
+        op3 = DummyOperator1()
         self.assertEqual(str(op3), "0")
 
     def test_rep(self):
-        op = FermionOperator(((1, 1), (3, 0), (8, 1)), 0.5)
+        op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
+        # Not necessary, repr could do something in addition
+        self.assertEqual(repr(op), str(op))
+
+
+class SymbolicOperatorTest2(unittest.TestCase):
+    """Test the subclass DummyOperator2."""
+    def test_init_defaults(self):
+        loc_op = DummyOperator2()
+        self.assertTrue(len(loc_op.terms) == 0)
+
+    def test_init_tuple(self):
+        coefficient = 0.5
+        loc_op = ((0, 'X'), (5, 'Y'), (6, 'Z'))
+        qubit_op = DummyOperator2(loc_op, coefficient)
+        self.assertTrue(len(qubit_op.terms) == 1)
+        self.assertTrue(qubit_op.terms[loc_op] == coefficient)
+
+    def test_init_list(self):
+        coefficient = 0.6j
+        loc_op = [(0, 'X'), (5, 'Y'), (6, 'Z')]
+        qubit_op = DummyOperator2(loc_op, coefficient)
+        self.assertTrue(len(qubit_op.terms) == 1)
+        self.assertTrue(qubit_op.terms[tuple(loc_op)] == coefficient)
+
+    def test_init_str(self):
+        qubit_op = DummyOperator2('X0 Y5 Z12', -1.)
+        correct = ((0, 'X'), (5, 'Y'), (12, 'Z'))
+        self.assertTrue(correct in qubit_op.terms)
+        self.assertTrue(qubit_op.terms[correct] == -1.0)
+
+    def test_init_str_identity(self):
+        qubit_op = DummyOperator2('', 2.)
+        self.assertTrue(len(qubit_op.terms) == 1)
+        self.assertTrue(() in qubit_op.terms)
+        self.assertAlmostEqual(qubit_op.terms[()], 2.)
+
+    def test_init_bad_term(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2(2)
+
+    def test_init_bad_coefficient(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2('X0', "0.5")
+
+    def test_init_bad_action(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2('Q0')
+
+    def test_init_bad_action_in_tuple(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2(((1, 'Q'),))
+
+    def test_init_bad_qubit_num_in_tuple(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2((("1", 'X'),))
+
+    def test_init_bad_tuple(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2(((0, 1, 'X'),))
+
+    def test_init_bad_str(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2('X')
+
+    def test_init_bad_qubit_num(self):
+        with self.assertRaises(ValueError):
+            qubit_op = DummyOperator2('X-1')
+
+    def test_isclose_abs_tol(self):
+        a = DummyOperator2('X0', -1.)
+        b = DummyOperator2('X0', -1.05)
+        c = DummyOperator2('X0', -1.11)
+        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
+        self.assertTrue(not a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+        a = DummyOperator2('X0', -1.0j)
+        b = DummyOperator2('X0', -1.05j)
+        c = DummyOperator2('X0', -1.11j)
+        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
+        self.assertTrue(not a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+
+    def test_compress(self):
+        a = DummyOperator2('X0', .9e-12)
+        self.assertTrue(len(a.terms) == 1)
+        a.compress()
+        self.assertTrue(len(a.terms) == 0)
+        a = DummyOperator2('X0', 1. + 1j)
+        a.compress(.5)
+        self.assertTrue(len(a.terms) == 1)
+        for term in a.terms:
+            self.assertTrue(a.terms[term] == 1. + 1j)
+        a = DummyOperator2('X0', 1.1 + 1j)
+        a.compress(1.)
+        self.assertTrue(len(a.terms) == 1)
+        for term in a.terms:
+            self.assertTrue(a.terms[term] == 1.1)
+        a = DummyOperator2('X0', 1.1 + 1j) + DummyOperator2('X1', 1.e-6j)
+        a.compress()
+        self.assertTrue(len(a.terms) == 2)
+        for term in a.terms:
+            self.assertTrue(isinstance(a.terms[term], complex))
+        a.compress(1.e-5)
+        self.assertTrue(len(a.terms) == 1)
+        for term in a.terms:
+            self.assertTrue(isinstance(a.terms[term], complex))
+        a.compress(1.)
+        self.assertTrue(len(a.terms) == 1)
+        for term in a.terms:
+            self.assertTrue(isinstance(a.terms[term], float))
+
+    def test_isclose_rel_tol(self):
+        a = DummyOperator2('X0', 1)
+        b = DummyOperator2('X0', 2)
+        self.assertTrue(a.isclose(b, rel_tol=2.5, abs_tol=0.1))
+        # Test symmetry
+        self.assertTrue(a.isclose(b, rel_tol=1, abs_tol=0.1))
+        self.assertTrue(b.isclose(a, rel_tol=1, abs_tol=0.1))
+
+    def test_isclose_zero_terms(self):
+        op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
+        self.assertTrue(op.isclose(DummyOperator2((), 0.0), rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(DummyOperator2((), 0.0).isclose(op, rel_tol=1e-12, abs_tol=1e-12))
+
+    def test_isclose_different_terms(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(a.isclose(b, rel_tol=1e-12, abs_tol=0.2))
+        self.assertTrue(not a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(b.isclose(a, rel_tol=1e-12, abs_tol=0.2))
+        self.assertTrue(not b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+
+    def test_isclose_different_num_terms(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        a += DummyOperator2(((2, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(not b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(not a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+
+    def test_rmul_scalar(self):
+        multiplier = 0.5
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        res1 = op * multiplier
+        res2 = multiplier * op
+        self.assertTrue(res1.isclose(res2))
+
+    def test_rmul_bad_multiplier(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        with self.assertRaises(TypeError):
+            op = "0.5" * op
+
+    def test_truediv_and_div(self):
+        divisor = 0.6j
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        op2 = copy.deepcopy(op)
+        original = copy.deepcopy(op)
+        res = op / divisor
+        res2 = op2.__div__(divisor)  # To test python 2 version as well
+        correct = op * (1. / divisor)
+        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res2.isclose(correct))
+        # Test if done out of place
+        self.assertTrue(op.isclose(original))
+        self.assertTrue(op2.isclose(original))
+
+    def test_truediv_bad_divisor(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        with self.assertRaises(TypeError):
+            op = op / "0.5"
+
+    def test_itruediv_and_idiv(self):
+        divisor = 2
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        op2 = copy.deepcopy(op)
+        original = copy.deepcopy(op)
+        correct = op * (1. / divisor)
+        op /= divisor
+        op2.__idiv__(divisor)  # To test python 2 version as well
+        self.assertTrue(op.isclose(correct))
+        self.assertTrue(op2.isclose(correct))
+        # Test if done in-place
+        self.assertTrue(not op.isclose(original))
+        self.assertTrue(not op2.isclose(original))
+
+    def test_itruediv_bad_divisor(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        with self.assertRaises(TypeError):
+            op /= "0.5"
+
+    def test_iadd_cancellation(self):
+        term_a = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        term_b = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        a = DummyOperator2(term_a, 1.0)
+        a += DummyOperator2(term_b, -1.0)
+        self.assertTrue(len(a.terms) == 0)
+
+    def test_iadd_different_term(self):
+        term_a = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        term_b = ((1, 'Z'), (3, 'Y'), (8, 'Z'))
+        a = DummyOperator2(term_a, 1.0)
+        a += DummyOperator2(term_b, 0.5)
+        self.assertTrue(len(a.terms) == 2)
+        self.assertAlmostEqual(a.terms[term_a], 1.0)
+        self.assertAlmostEqual(a.terms[term_b], 0.5)
+        a += DummyOperator2(term_b, 0.5)
+        self.assertTrue(len(a.terms) == 2)
+        self.assertAlmostEqual(a.terms[term_a], 1.0)
+        self.assertAlmostEqual(a.terms[term_b], 1.0)
+
+    def test_iadd_bad_addend(self):
+        op = DummyOperator2((), 1.0)
+        with self.assertRaises(TypeError):
+            op += "0.5"
+
+    def test_add(self):
+        term_a = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        term_b = ((1, 'Z'), (3, 'Y'), (8, 'Z'))
+        a = DummyOperator2(term_a, 1.0)
+        b = DummyOperator2(term_b, 0.5)
+        res = a + b + b
+        self.assertTrue(len(res.terms) == 2)
+        self.assertAlmostEqual(res.terms[term_a], 1.0)
+        self.assertAlmostEqual(res.terms[term_b], 1.0)
+        # Test out of place
+        self.assertTrue(a.isclose(DummyOperator2(term_a, 1.0)))
+        self.assertTrue(b.isclose(DummyOperator2(term_b, 0.5)))
+
+    def test_add_bad_addend(self):
+        op = DummyOperator2((), 1.0)
+        with self.assertRaises(TypeError):
+            op = op + "0.5"
+
+    def test_sub(self):
+        term_a = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        term_b = ((1, 'Z'), (3, 'Y'), (8, 'Z'))
+        a = DummyOperator2(term_a, 1.0)
+        b = DummyOperator2(term_b, 0.5)
+        res = a - b
+        self.assertTrue(len(res.terms) == 2)
+        self.assertAlmostEqual(res.terms[term_a], 1.0)
+        self.assertAlmostEqual(res.terms[term_b], -0.5)
+        res2 = b - a
+        self.assertTrue(len(res2.terms) == 2)
+        self.assertAlmostEqual(res2.terms[term_a], -1.0)
+        self.assertAlmostEqual(res2.terms[term_b], 0.5)
+
+    def test_sub_bad_subtrahend(self):
+        op = DummyOperator2((), 1.0)
+        with self.assertRaises(TypeError):
+            op = op - "0.5"
+
+    def test_isub_different_term(self):
+        term_a = ((1, 'X'), (3, 'Y'), (8, 'Z'))
+        term_b = ((1, 'Z'), (3, 'Y'), (8, 'Z'))
+        a = DummyOperator2(term_a, 1.0)
+        a -= DummyOperator2(term_b, 0.5)
+        self.assertTrue(len(a.terms) == 2)
+        self.assertAlmostEqual(a.terms[term_a], 1.0)
+        self.assertAlmostEqual(a.terms[term_b], -0.5)
+        a -= DummyOperator2(term_b, 0.5)
+        self.assertTrue(len(a.terms) == 2)
+        self.assertAlmostEqual(a.terms[term_a], 1.0)
+        self.assertAlmostEqual(a.terms[term_b], -1.0)
+
+    def test_isub_bad_addend(self):
+        op = DummyOperator2((), 1.0)
+        with self.assertRaises(TypeError):
+            op -= "0.5"
+
+    def test_neg(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        -op
+        # out of place
+        self.assertTrue(op.isclose(DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)))
+        correct = -1.0 * op
+        self.assertTrue(correct.isclose(-op))
+
+    def test_str(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        self.assertEqual(str(op), "0.5 [X1 Y3 Z8]")
+        op2 = DummyOperator2((), 2)
+        self.assertEqual(str(op2), "2 []")
+
+    def test_str_empty(self):
+        op = DummyOperator2()
+        self.assertEqual(str(op), '0')
+
+    def test_str_out_of_order(self):
+        op = DummyOperator2(((3, 'Y'), (1, 'X'), (8, 'Z')), 0.5)
+        self.assertEqual(str(op), '0.5 [X1 Y3 Z8]')
+
+    def test_str_multiple_terms(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+        op += DummyOperator2(((1, 'Y'), (3, 'Y'), (8, 'Z')), 0.6)
+        self.assertTrue((str(op) == "0.5 [X1 Y3 Z8] +\n0.6 [Y1 Y3 Z8]" or
+                str(op) == "0.6 [Y1 Y3 Z8] +\n0.5 [X1 Y3 Z8]"))
+        op2 = DummyOperator2((), 2)
+        self.assertEqual(str(op2), "2 []")
+
+    def test_rep(self):
+        op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         # Not necessary, repr could do something in addition
         self.assertEqual(repr(op), str(op))

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -16,7 +16,7 @@ import numpy
 import unittest
 
 from openfermion.ops._symbolic_operator import SymbolicOperator
- 
+
 
 class DummyOperator1(SymbolicOperator):
     """Subclass of SymbolicOperator created for testing purposes."""
@@ -331,15 +331,15 @@ class SymbolicOperatorTest1(unittest.TestCase):
         self.assertTrue(op1.isclose(DummyOperator1(
             ((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)))
         self.assertTrue(op2.isclose(DummyOperator1(((1, 1), (3, 1), (8, 0)),
-                                                    0.5)))
+                                                   0.5)))
         self.assertTrue(op3.isclose(DummyOperator1(correct_term,
-                                                    correct_coefficient)))
+                                                   correct_coefficient)))
 
     def test_mul_npfloat64(self):
         op = DummyOperator1(((1, 0), (3, 1)), 0.5)
         res = op * numpy.float64(0.5)
         self.assertTrue(res.isclose(DummyOperator1(((1, 0), (3, 1)),
-                                                    0.5 * 0.5)))
+                                                   0.5 * 0.5)))
 
     def test_mul_multiple_terms(self):
         op = DummyOperator1(((1, 0), (8, 1)), 0.5)
@@ -552,7 +552,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
         _ = -op
         # out of place
         self.assertTrue(op.isclose(DummyOperator1(((1, 1), (3, 1), (8, 1)),
-                                                   0.5)))
+                                                  0.5)))
         correct = -1.0 * op
         self.assertTrue(correct.isclose(-op))
 
@@ -733,8 +733,10 @@ class SymbolicOperatorTest2(unittest.TestCase):
 
     def test_isclose_zero_terms(self):
         op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
-        self.assertTrue(op.isclose(DummyOperator2((), 0.0), rel_tol=1e-12, abs_tol=1e-12))
-        self.assertTrue(DummyOperator2((), 0.0).isclose(op, rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(op.isclose(
+            DummyOperator2((), 0.0), rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(DummyOperator2((), 0.0).isclose(
+            op, rel_tol=1e-12, abs_tol=1e-12))
 
     def test_isclose_different_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
@@ -885,7 +887,8 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         -op
         # out of place
-        self.assertTrue(op.isclose(DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)))
+        self.assertTrue(op.isclose(
+            DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)))
         correct = -1.0 * op
         self.assertTrue(correct.isclose(-op))
 
@@ -907,7 +910,7 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         op += DummyOperator2(((1, 'Y'), (3, 'Y'), (8, 'Z')), 0.6)
         self.assertTrue((str(op) == "0.5 [X1 Y3 Z8] +\n0.6 [Y1 Y3 Z8]" or
-                str(op) == "0.6 [Y1 Y3 Z8] +\n0.5 [X1 Y3 Z8]"))
+                         str(op) == "0.6 [Y1 Y3 Z8] +\n0.5 [X1 Y3 Z8]"))
         op2 = DummyOperator2((), 2)
         self.assertEqual(str(op2), "2 []")
 

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -15,8 +15,7 @@ import copy
 import numpy
 import unittest
 
-from openfermion.ops._symbolic_operator import (SymbolicOperator,
-                                                SymbolicOperatorError)
+from openfermion.ops._symbolic_operator import SymbolicOperator
  
 
 class DummyOperator1(SymbolicOperator):

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -291,6 +291,17 @@ class SymbolicOperatorTest1(unittest.TestCase):
         self.assertEqual(op3.terms[((1, 1), (0, 0), (1, 0), (0, 1), (2, 1))],
                          1.5j)
 
+    def test_imul_fermion_op_duplicate_term(self):
+        op1 = DummyOperator1('1 2 3')
+        op1 += DummyOperator1('1 2')
+        op1 += DummyOperator1('1')
+
+        op2 = DummyOperator1('3')
+        op2 += DummyOperator1('2 3')
+
+        op1 *= op2
+        self.assertAlmostEqual(op1.terms[((1, 0), (2, 0), (3, 0))], 2.)
+
     def test_imul_bidir(self):
         op_a = DummyOperator1(((1, 1), (0, 0)), -1j)
         op_b = DummyOperator1(((1, 1), (0, 1), (2, 1)), -1.5)


### PR DESCRIPTION
I couldn't add commits to #191 because I don't have write access to the main repo, so I'm replacing it with this PR. Some notes on my implementation:
- I added four attributes that all subclasses need to define; see their descriptions in the docstring for SymbolicOperator. So far, the only thing I used the attribute `different_indices_commute` for is to see if we can reorder the factors in terms so that the indices are in ascending order. To get a functioning subclass it's enough to set these four attributes; I removed the uses of abstract base class methods (from the module `abc`) which were introduced in #191.
- The implementation of `__str__` preserves the current string representations for FermionOperators, but would slightly alter those of QubitOperators. Namely, operators would be surrounded in square brackets, and the identity term would be represented as `[]` instead of `I`. For instance, we would have
````
2.0 [] +
0.6 [Y1 Y3 Z8] +
0.5 [X1 Y3 Z8]
````
instead of
````
2.0 I +
0.6 Y1 Y3 Z8 +
0.5 X1 Y3 Z8
````
Of course, we can override this behavior but using the unified implementation will make it possible for #177 to be implemented only in SymbolicOperator.
- On that note, a unified implementation of #177 now amounts to writing the method `_long_string_init` which I left unimplemented.
- All the tests are pretty much straight from `_fermion_operator_test.py` and `_qubit_operator_test.py`. In the test file, the tests for `DummyOperator1` were from `_fermion_operator_test.py` and the tests for `DummyOperator2` were from `_qubit_operator_test.py` (modified to remove the dependence on `pytest`).
- I replaced all uses of `SymbolicOperatorError` with `ValueError` because I couldn't tell when one should be used over the other.
- It appears that most of the work that will go into defining a subclass is in overriding `__imul__`.
- I started calling the things that terms are made of "factors", but then realized later on that these were sometimes called "local operators" which is perhaps a better term. I still document them as "factors" but we can change this.