### PR TITLE
Added possibility for QPE to have rotations controlled by an ancilla

### DIFF
--- a/examples/openfermion_demo.ipynb
+++ b/examples/openfermion_demo.ipynb
@@ -1349,7 +1349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/examples/openfermion_demo.ipynb
+++ b/examples/openfermion_demo.ipynb
@@ -1349,7 +1349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/src/openfermion/utils/_trotter_exp_to_qgates.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates.py
@@ -156,7 +156,8 @@ def trotter_operator_grouping(hamiltonian,
 
 
 def pauli_exp_to_qasm(qubit_operator_list,
-                      evolution_time=1.0):
+                      evolution_time=1.0,
+                      ancilla=None):
     """Exponentiate a list of QubitOperators to a QASM string generator.
 
     Exponentiates a list of QubitOperators, and yields string generators in
@@ -167,6 +168,8 @@ def pauli_exp_to_qasm(qubit_operator_list,
             QubitOperators to be exponentiated
         evolution_time (float): evolution time of the operators in
             the list
+        ancilla (string or None): if any, an ancilla qubit to perform
+            the rotation conditional on (for quantum phase estimation)
 
     Yields:
         string
@@ -220,8 +223,12 @@ def pauli_exp_to_qasm(qubit_operator_list,
             ret_list = ret_list + cnots1
 
             # 3. Rotation (Note kexp & Ntrot)
-            ret_list = ret_list + ["Rz {} {}".format(
-                term_coeff * evolution_time, qids[-1])]
+            if ancilla is not None:
+                ret_list = ret_list + ["C-Phase {} {} {}".format(
+                    term_coeff * evolution_time, qids[-1], ancilla)]
+            else:
+                ret_list = ret_list + ["Rz {} {}".format(
+                    term_coeff * evolution_time, qids[-1])]
 
             # 4. Second set of CNOTs
             ret_list = ret_list + cnots2
@@ -237,7 +244,8 @@ def trotterize_exp_qubop_to_qasm(hamiltonian,
                                  trotter_number=1,
                                  trotter_order=1,
                                  term_ordering=None,
-                                 k_exp=1.0):
+                                 k_exp=1.0,
+                                 ancilla=None):
     """Trotterize a Qubit hamiltonian and write it to QASM format.
 
     Assumes input hamiltonian is still hermitian and -1.0j has not yet been
@@ -266,5 +274,6 @@ def trotterize_exp_qubop_to_qasm(hamiltonian,
                                                     trotter_order,
                                                     term_ordering,
                                                     k_exp):
-        for exponentiated_qasm_string in pauli_exp_to_qasm([trotterized_op]):
+        for exponentiated_qasm_string in pauli_exp_to_qasm([trotterized_op],
+                                                           ancilla=ancilla):
             yield exponentiated_qasm_string

--- a/src/openfermion/utils/_trotter_exp_to_qgates.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates.py
@@ -168,6 +168,8 @@ def pauli_exp_to_qasm(qubit_operator_list,
             QubitOperators to be exponentiated
         evolution_time (float): evolution time of the operators in
             the list
+        qubit_list: a list of names for qubits (otherwise they will be labeled
+            with their index).
         ancilla (string or None): if any, an ancilla qubit to perform
             the rotation conditional on (for quantum phase estimation)
 
@@ -270,6 +272,8 @@ def trotterize_exp_qubop_to_qasm(hamiltonian,
         term_ordering (list of (tuples of tuples)): list of tuples
             (QubitOperator terms dictionary keys) that specifies
             order of terms when trotterizing
+        qubit_list: a list of names for qubits (otherwise they will be labeled
+            with their index).
         k_exp (float): optional exponential factor to all
             terms when trotterizing
 

--- a/src/openfermion/utils/_trotter_exp_to_qgates_test.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates_test.py
@@ -248,7 +248,7 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-C-Phase 0.5 3 ancilla
+C-Phase 0.5 ancilla 3
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -276,7 +276,7 @@ H q0
 Rx 1.5707963267948966 q3
 CNOT q0 q1
 CNOT q1 q3
-C-Phase 0.5 q3 ancilla
+C-Phase 0.5 ancilla q3
 CNOT q1 q3
 CNOT q0 q1
 H q0

--- a/src/openfermion/utils/_trotter_exp_to_qgates_test.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates_test.py
@@ -229,3 +229,28 @@ H 0
 Rx -1.5707963267948966 3'''
 
         self.assertEqual(qasmstr, strcorrect)
+
+    def test_qasm_string_Controlled_XYZ(self):
+        # Testing for correct QASM string output w/ Pauli-{X,Y,Z}
+        # QubitOperator('X0 Z1 Y3', 0.5) and a controlled ancilla
+
+        # Number of qubits
+        qasmstr = str(count_qubits(self.opA)) + "\n"
+
+        # Write each QASM operation
+        qasmstr += "\n".join(
+            trotterize_exp_qubop_to_qasm(self.opA, ancilla='ancilla'))
+
+        # Correct string
+        strcorrect = '''4
+H 0
+Rx 1.5707963267948966 3
+CNOT 0 1
+CNOT 1 3
+C-Phase 0.5 3 ancilla
+CNOT 1 3
+CNOT 0 1
+H 0
+Rx -1.5707963267948966 3'''
+
+        self.assertEqual(qasmstr, strcorrect)

--- a/src/openfermion/utils/_trotter_exp_to_qgates_test.py
+++ b/src/openfermion/utils/_trotter_exp_to_qgates_test.py
@@ -25,6 +25,7 @@ class TrottQasmTest(unittest.TestCase):
         # First qubit operator example
         self.opA = QubitOperator('X0 Z1 Y3', 0.5)
         self.opB = 0.6 * QubitOperator('Z3 Z4')
+        self.op_id = QubitOperator('', 1.0)
         self.qo1 = self.opA + self.opB
 
     def test_exceptions(self):
@@ -235,14 +236,14 @@ Rx -1.5707963267948966 3'''
         # QubitOperator('X0 Z1 Y3', 0.5) and a controlled ancilla
 
         # Number of qubits
-        qasmstr = str(count_qubits(self.opA)) + "\n"
+        qasmstr = str(count_qubits(self.opA)+1) + "\n"
 
         # Write each QASM operation
         qasmstr += "\n".join(
             trotterize_exp_qubop_to_qasm(self.opA, ancilla='ancilla'))
 
         # Correct string
-        strcorrect = '''4
+        strcorrect = '''5
 H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
@@ -254,3 +255,99 @@ H 0
 Rx -1.5707963267948966 3'''
 
         self.assertEqual(qasmstr, strcorrect)
+
+    def test_qasm_string_Controlled_XYZ_ancilla_list(self):
+                # Testing for correct QASM string output w/ Pauli-{X,Y,Z}
+        # QubitOperator('X0 Z1 Y3', 0.5) and a controlled ancilla
+
+        # Number of qubits
+        qasmstr = str(count_qubits(self.opA)+1) + "\n"
+
+        qubit_list = ['q0', 'q1', 'q2', 'q3']
+
+        # Write each QASM operation
+        qasmstr += "\n".join(
+            trotterize_exp_qubop_to_qasm(self.opA, ancilla='ancilla',
+                                         qubit_list=qubit_list))
+
+        # Correct string
+        strcorrect = '''5
+H q0
+Rx 1.5707963267948966 q3
+CNOT q0 q1
+CNOT q1 q3
+C-Phase 0.5 q3 ancilla
+CNOT q1 q3
+CNOT q0 q1
+H q0
+Rx -1.5707963267948966 q3'''
+
+        self.assertEqual(qasmstr, strcorrect)
+
+    def test_qasm_string_controlled_identity(self):
+        qasmstr = str(count_qubits(self.op_id)+1) + "\n"
+
+        # Write each QASM operation
+        qasmstr += "\n".join(
+            trotterize_exp_qubop_to_qasm(self.op_id, ancilla='ancilla'))
+
+        strcorrect = '''1
+Rz 1.0 ancilla'''
+
+        self.assertEqual(qasmstr, strcorrect)
+
+    def test_qasm_string_identity(self):
+        qasmstr = str(count_qubits(self.op_id)+1) + "\n"
+
+        # Write each QASM operation
+        qasmstr += "\n".join(
+            trotterize_exp_qubop_to_qasm(self.op_id))
+
+        strcorrect = '''1\n'''
+
+        self.assertEqual(qasmstr, strcorrect)
+
+    def test_qasm_string_multiple_operator(self):
+        # Testing for correct QASM string output 
+        # w/ sum of Pauli-{X,Y,Z} and Pauli-{Z}
+        # QubitOperator('X0 Z1 Y3', 0.5) + QubitOperator('Z3 Z4', 0.6)
+
+        # Number of qubits
+        qasmstr = str(count_qubits(self.qo1)) + "\n"
+
+        # Write each QASM operation
+        qasmstr += "\n".join(trotterize_exp_qubop_to_qasm(self.qo1))
+
+        # Two possibilities for the correct string depending on
+        # the order in which the operators loop.
+        strcorrect1 = '''5
+CNOT 3 4
+Rz 0.6 4
+CNOT 3 4
+H 0
+Rx 1.5707963267948966 3
+CNOT 0 1
+CNOT 1 3
+Rz 0.5 3
+CNOT 1 3
+CNOT 0 1
+H 0
+Rx -1.5707963267948966 3'''
+
+        strcorrect2 = '''5
+H 0
+Rx 1.5707963267948966 3
+CNOT 0 1
+CNOT 1 3
+Rz 0.5 3
+CNOT 1 3
+CNOT 0 1
+H 0
+Rx -1.5707963267948966 3
+CNOT 3 4
+Rz 0.6 4
+CNOT 3 4'''
+        try:
+            self.assertEqual(qasmstr, strcorrect1)
+        except:
+            self.assertEqual(qasmstr, strcorrect2)


### PR DESCRIPTION
Minor update to the trotter_exp_to_qgates file, allowing the Rz rotations to be controlled by an ancilla for QPE purposes. Also fixed a bug where passing the identity operator would cause an error.

Now passing the identity passes for time evolution (i.e. it doesn't return a phase gate). Not sure what is preferable here.