### PR TITLE
Updated _bksf.py

### DIFF
--- a/src/openfermion/transforms/_bksf.py
+++ b/src/openfermion/transforms/_bksf.py
@@ -68,7 +68,8 @@ def bravyi_kitaev_fast_interaction_op(iop):
     For the sake of brevity the reader is encouraged to look up the
     expressions of other terms from the code below. The variables for edge
     operators are chosen according to the nomenclature defined above
-    (B_i and A_ij).
+    (B_i and A_ij). A detailed description of these operators and the terms 
+    of the electronic Hamiltonian are provided in (arXiv 1712.00446).
 
     Args:
         iop (Interaction Operator):
@@ -188,18 +189,6 @@ def bravyi_kitaev_fast_edge_matrix(iop, n_qubits=None):
                                 iop[(p, 1), (q, 1), (r, 0), (s, 0)]))
                         elif q == s:
                             a, b = sorted([p, r])
-                            edge_matrix[b, a] = bool(complex(
-                                iop[(p, 1), (q, 1), (r, 0), (s, 0)]))
-
-                    # Handle case of two unique indices.
-                    elif len(set([p, q, r, s])) == 2:
-                        if p == s:
-                            a, b = sorted([p, q])
-                            edge_matrix[b, a] = bool(complex(
-                                iop[(p, 1), (q, 1), (r, 0), (s, 0)]))
-
-                        else:
-                            a, b = sorted([p, q])
                             edge_matrix[b, a] = bool(complex(
                                 iop[(p, 1), (q, 1), (r, 0), (s, 0)]))
 

--- a/src/openfermion/transforms/_bksf_test.py
+++ b/src/openfermion/transforms/_bksf_test.py
@@ -163,6 +163,7 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         self.assertEqual(evensector, 2 ** (n_qubits - 1))
 
     def test_bravyi_kitaev_fast_generate_fermions(self):
+        n_qubits = count_qubits(self.molecular_hamiltonian)
         # test for generating two fermions
         edge_matrix = _bksf.bravyi_kitaev_fast_edge_matrix(
             self.molecular_hamiltonian)
@@ -177,7 +178,7 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         bksf_vacuum_state_sp_matrix = get_sparse_operator(
             bksf_vacuum_state_operator)
         bksf_vacuum_state_matrix = bksf_vacuum_state_sp_matrix.toarray()
-        vacuum_state = numpy.zeros((64, 1))
+        vacuum_state = numpy.zeros((2**(n_qubits), 1))
         vacuum_state[0] = 1.
         bksf_vacuum_state = numpy.dot(bksf_vacuum_state_matrix, vacuum_state)
         two_fermion_state = numpy.dot(fermion_generation_matrix,


### PR DESCRIPTION
Removed lines pertaining to the two-unique-indices case. That case is incorrect -- terms with two unique indices should not contribute to the edge operator. Discussed and done with @kanavsetia. 