### PR TITLE
Generalize hermitian_conjugated and move it to operator_utils

### DIFF
--- a/examples/openfermion_demo.ipynb
+++ b/examples/openfermion_demo.ipynb
@@ -285,8 +285,8 @@
     }
    ],
    "source": [
-    "from openfermion.ops import hermitian_conjugated, normal_ordered\n",
-    "from openfermion.utils import commutator, count_qubits\n",
+    "from openfermion.ops import normal_ordered\n",
+    "from openfermion.utils import commutator, count_qubits, hermitian_conjugated\n",
     "\n",
     "# Get the Hermitian conjugate of a FermionOperator, count its qubit, check if it is normal-ordered.\n",
     "term_1 = FermionOperator('4^ 3 3^', 1. + 2.j)\n",
@@ -374,9 +374,9 @@
     }
    ],
    "source": [
-    "from openfermion.ops import FermionOperator, hermitian_conjugated\n",
+    "from openfermion.ops import FermionOperator\n",
     "from openfermion.transforms import jordan_wigner, bravyi_kitaev\n",
-    "from openfermion.utils import eigenspectrum\n",
+    "from openfermion.utils import eigenspectrum, hermitian_conjugated\n",
     "\n",
     "# Initialize an operator.\n",
     "fermion_operator = FermionOperator('2^ 0', 3.17)\n",

--- a/src/openfermion/hamiltonians/__init__.py
+++ b/src/openfermion/hamiltonians/__init__.py
@@ -14,13 +14,6 @@ from ._chemical_series import (make_atomic_ring,
                                make_atomic_lattice,
                                make_atom)
 
-from ._special_operators import (up_index, down_index,
-                                 majorana_operator, number_operator,
-                                 s_squared_operator, s_plus_operator,
-                                 s_minus_operator, sz_operator)
-
-from ._hubbard import fermi_hubbard
-
 from ._jellium import (dual_basis_kinetic,
                        dual_basis_potential,
                        dual_basis_jellium_model,
@@ -29,8 +22,6 @@ from ._jellium import (dual_basis_kinetic,
                        plane_wave_kinetic,
                        plane_wave_potential)
 
-from ._mean_field_dwave import mean_field_dwave
-
 from ._molecular_data import MolecularData, periodic_table
 
 from ._plane_wave_hamiltonian import (dual_basis_external_potential,
@@ -38,3 +29,14 @@ from ._plane_wave_hamiltonian import (dual_basis_external_potential,
                                       plane_wave_hamiltonian,
                                       jordan_wigner_dual_basis_hamiltonian,
                                       wigner_seitz_length_scale)
+
+from ._special_operators import (up_index, down_index,
+                                 majorana_operator, number_operator,
+                                 s_squared_operator, s_plus_operator,
+                                 s_minus_operator, sz_operator)
+
+# Imports out of alphabetical order to avoid circular dependancy.
+
+from ._hubbard import fermi_hubbard
+
+from ._mean_field_dwave import mean_field_dwave

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -13,9 +13,9 @@
 """This module constructs Hamiltonians for the Fermi-Hubbard model."""
 from __future__ import absolute_import
 
-from openfermion.ops import (FermionOperator,
-                             hermitian_conjugated)
+from openfermion.ops import FermionOperator
 from openfermion.hamiltonians import up_index, down_index, number_operator
+from openfermion.utils import hermitian_conjugated
 
 
 def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,

--- a/src/openfermion/hamiltonians/_mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/_mean_field_dwave.py
@@ -14,8 +14,8 @@
 from __future__ import absolute_import
 
 from openfermion.hamiltonians import up_index, down_index, number_operator
-from openfermion.ops import (FermionOperator,
-                             hermitian_conjugated)
+from openfermion.ops import FermionOperator
+from openfermion.utils import hermitian_conjugated
 
 
 def mean_field_dwave(x_dimension, y_dimension, tunneling, sc_gap,

--- a/src/openfermion/measurements/_equality_constraint_projection.py
+++ b/src/openfermion/measurements/_equality_constraint_projection.py
@@ -14,8 +14,8 @@
 import numpy
 import scipy
 
-from openfermion.ops import FermionOperator, hermitian_conjugated
-from openfermion.utils import count_qubits
+from openfermion.ops import FermionOperator
+from openfermion.utils import count_qubits, hermitian_conjugated
 
 from ._rdm_equality_constraints import two_body_fermion_constraints
 

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -15,7 +15,6 @@ from ._code_operator import (BinaryCode,
                              linearize_decoder)
 from ._symbolic_operator import SymbolicOperator
 from ._fermion_operator import (FermionOperator,
-                                hermitian_conjugated,
                                 normal_ordered)
 from ._qubit_operator import QubitOperator
 from ._polynomial_tensor import general_basis_change, PolynomialTensor

--- a/src/openfermion/ops/_fermion_operator.py
+++ b/src/openfermion/ops/_fermion_operator.py
@@ -13,7 +13,6 @@
 """FermionOperator stores a sum of products of fermionic ladder operators."""
 import numpy
 
-from future.utils import iteritems
 from openfermion.ops import SymbolicOperator
 
 

--- a/src/openfermion/ops/_fermion_operator.py
+++ b/src/openfermion/ops/_fermion_operator.py
@@ -21,16 +21,6 @@ class FermionOperatorError(Exception):
     pass
 
 
-def hermitian_conjugated(fermion_operator):
-    """Return Hermitian conjugate of fermionic operator."""
-    conjugate_operator = FermionOperator()
-    for term, coefficient in iteritems(fermion_operator.terms):
-        conjugate_term = tuple([(tensor_factor, 1 - action) for
-                                (tensor_factor, action) in reversed(term)])
-        conjugate_operator.terms[conjugate_term] = numpy.conjugate(coefficient)
-    return conjugate_operator
-
-
 def normal_ordered_term(term, coefficient):
     """Return a normal ordered FermionOperator corresponding to single term.
 

--- a/src/openfermion/ops/_fermion_operator_test.py
+++ b/src/openfermion/ops/_fermion_operator_test.py
@@ -18,7 +18,6 @@ import unittest
 from openfermion.hamiltonians import number_operator
 from openfermion.ops._fermion_operator import (FermionOperator,
                                                FermionOperatorError,
-                                               hermitian_conjugated,
                                                normal_ordered)
 
 
@@ -35,65 +34,6 @@ class FermionOperatorTest(unittest.TestCase):
                     FermionOperator(((2, 1), (2, 0))) +
                     FermionOperator(((3, 1), (3, 0))))
         self.assertTrue(op.isclose(expected))
-
-    def test_hermitian_conjugate_empty(self):
-        op = FermionOperator()
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(FermionOperator()))
-
-    def test_hermitian_conjugate_simple(self):
-        op = FermionOperator('1^')
-        op_hc = FermionOperator('1')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_complex_const(self):
-        op = FermionOperator('1^ 3', 3j)
-        op_hc = -3j * FermionOperator('3^ 1')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_notordered(self):
-        op = FermionOperator('1 3^ 3 3^', 3j)
-        op_hc = -3j * FermionOperator('3 3^ 3 1^')
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugate_semihermitian(self):
-        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
-              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
-        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
-                 FermionOperator('3^ 1', -2j) +
-                 FermionOperator('2^ 2', -0.1j))
-        op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
-
-    def test_hermitian_conjugated_empty(self):
-        op = FermionOperator()
-        self.assertTrue(op.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_simple(self):
-        op = FermionOperator('0')
-        op_hc = FermionOperator('0^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_complex_const(self):
-        op = FermionOperator('2^ 2', 3j)
-        op_hc = FermionOperator('2^ 2', -3j)
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_multiterm(self):
-        op = FermionOperator('1^ 2') + FermionOperator('2 3 4')
-        op_hc = FermionOperator('2^ 1') + FermionOperator('4^ 3^ 2^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
-
-    def test_hermitian_conjugated_semihermitian(self):
-        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
-              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
-        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
-                 FermionOperator('3^ 1', -2j) +
-                 FermionOperator('2^ 2', -0.1j))
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
 
     def test_is_normal_ordered_empty(self):
         op = FermionOperator() * 2

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -18,7 +18,6 @@ import unittest
 
 from openfermion.hamiltonians import number_operator
 from openfermion.ops import (FermionOperator,
-                             hermitian_conjugated,
                              InteractionOperator,
                              normal_ordered,
                              QubitOperator)
@@ -27,6 +26,8 @@ from openfermion.transforms import (get_interaction_operator,
 from openfermion.transforms._jordan_wigner import (
     jordan_wigner, jordan_wigner_one_body, jordan_wigner_two_body,
     jordan_wigner_interaction_op)
+
+from openfermion.utils import hermitian_conjugated
 
 
 class JordanWignerTransformTest(unittest.TestCase):

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -20,8 +20,9 @@ from ._commutators import anticommutator, commutator, double_commutator
 from ._grid import Grid
 
 from ._operator_utils import (count_qubits, eigenspectrum, fourier_transform,
-                              get_file_path, inverse_fourier_transform,
-                              is_identity, load_operator, save_operator)
+                              get_file_path, hermitian_conjugated,
+                              inverse_fourier_transform, is_identity,
+                              load_operator, save_operator)
 
 from ._slater_determinants import (gaussian_state_preparation_circuit,
                                    slater_determinant_preparation_circuit)

--- a/src/openfermion/utils/_commutators_test.py
+++ b/src/openfermion/utils/_commutators_test.py
@@ -13,9 +13,9 @@
 """Tests for _commutators.py."""
 import unittest
 
-from openfermion.ops import (FermionOperator, hermitian_conjugated,
-                             QubitOperator)
+from openfermion.ops import FermionOperator, QubitOperator
 from openfermion.transforms import jordan_wigner
+from openfermion.utils import hermitian_conjugated
 from openfermion.utils._commutators import *
 from openfermion.utils._sparse_tools import pauli_matrix_map
 

--- a/src/openfermion/utils/_operator_utils.py
+++ b/src/openfermion/utils/_operator_utils.py
@@ -35,11 +35,10 @@ def hermitian_conjugated(operator):
     """Return Hermitian conjugate of operator."""
     if isinstance(operator, FermionOperator):
         conjugate_operator = FermionOperator()
-        for term, coefficient in iteritems(operator.terms):
+        for term, coefficient in operator.terms.items():
             conjugate_term = tuple([(tensor_factor, 1 - action) for
                                     (tensor_factor, action) in reversed(term)])
-            conjugate_operator.terms[conjugate_term] = numpy.conjugate(
-                    coefficient)
+            conjugate_operator.terms[conjugate_term] = coefficient.conjugate()
     elif isinstance(operator, QubitOperator):
         conjugate_operator = QubitOperator()
         for term, coefficient in operator.terms.items():

--- a/src/openfermion/utils/_operator_utils.py
+++ b/src/openfermion/utils/_operator_utils.py
@@ -31,6 +31,23 @@ class OperatorUtilsError(Exception):
     pass
 
 
+def hermitian_conjugated(operator):
+    """Return Hermitian conjugate of operator."""
+    if isinstance(operator, FermionOperator):
+        conjugate_operator = FermionOperator()
+        for term, coefficient in iteritems(operator.terms):
+            conjugate_term = tuple([(tensor_factor, 1 - action) for
+                                    (tensor_factor, action) in reversed(term)])
+            conjugate_operator.terms[conjugate_term] = numpy.conjugate(
+                    coefficient)
+    elif isinstance(operator, QubitOperator):
+        conjugate_operator = QubitOperator()
+        for term, coefficient in operator.terms.items():
+            conjugate_operator.terms[term] = coefficient.conjugate()
+
+    return conjugate_operator
+
+
 def count_qubits(operator):
     """Compute the minimum number of qubits on which operator acts.
 

--- a/src/openfermion/utils/_operator_utils_test.py
+++ b/src/openfermion/utils/_operator_utils_test.py
@@ -95,6 +95,68 @@ class OperatorUtilsTest(unittest.TestCase):
             is_identity('eleven')
 
 
+class HermitianConjugatedTest(unittest.TestCase):
+
+    def test_hermitian_conjugate_empty(self):
+        op = FermionOperator()
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(FermionOperator()))
+
+    def test_hermitian_conjugate_simple(self):
+        op = FermionOperator('1^')
+        op_hc = FermionOperator('1')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_complex_const(self):
+        op = FermionOperator('1^ 3', 3j)
+        op_hc = -3j * FermionOperator('3^ 1')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_notordered(self):
+        op = FermionOperator('1 3^ 3 3^', 3j)
+        op_hc = -3j * FermionOperator('3 3^ 3 1^')
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugate_semihermitian(self):
+        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
+              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
+        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
+                 FermionOperator('3^ 1', -2j) +
+                 FermionOperator('2^ 2', -0.1j))
+        op = hermitian_conjugated(op)
+        self.assertTrue(op.isclose(op_hc))
+
+    def test_hermitian_conjugated_empty(self):
+        op = FermionOperator()
+        self.assertTrue(op.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_simple(self):
+        op = FermionOperator('0')
+        op_hc = FermionOperator('0^')
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_complex_const(self):
+        op = FermionOperator('2^ 2', 3j)
+        op_hc = FermionOperator('2^ 2', -3j)
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_multiterm(self):
+        op = FermionOperator('1^ 2') + FermionOperator('2 3 4')
+        op_hc = FermionOperator('2^ 1') + FermionOperator('4^ 3^ 2^')
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+    def test_hermitian_conjugated_semihermitian(self):
+        op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
+              FermionOperator('3^ 1') * -2j + FermionOperator('2^ 2', 0.1j))
+        op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
+                 FermionOperator('3^ 1', -2j) +
+                 FermionOperator('2^ 2', -0.1j))
+        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+
+
 class SaveLoadOperatorTest(unittest.TestCase):
     def setUp(self):
         self.n_qubits = 5

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -27,10 +27,10 @@ import warnings
 from openfermion.config import *
 from openfermion.hamiltonians import number_operator, up_index, down_index
 from openfermion.ops import (FermionOperator, QuadraticHamiltonian,
-                             QubitOperator, hermitian_conjugated,
-                             normal_ordered)
+                             QubitOperator, normal_ordered)
 from openfermion.utils import (Grid, commutator, fourier_transform,
                                gaussian_state_preparation_circuit,
+                               hermitian_conjugated,
                                slater_determinant_preparation_circuit)
 from openfermion.hamiltonians._jellium import (grid_indices,
                                                momentum_vector,


### PR DESCRIPTION
- Allow `hermitian_conjugated` to be applied to QubitOperators
- Move it from `ops/_fermion_operator.py` to `utils/_operator_utils.py`