### PR TITLE
Clean up import statements and fix sphinx warnings

### DIFF
--- a/src/openfermion/__init__.py
+++ b/src/openfermion/__init__.py
@@ -20,7 +20,6 @@ www.openfermion.org
 
 from ._version import __version__
 
-from openfermion.config import EQ_TOLERANCE
 from openfermion.hamiltonians import *
 from openfermion.measurements import *
 from openfermion.ops import *

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -13,15 +13,15 @@
 from ._binary_operator import SymbolicBinary
 from ._code_operator import (BinaryCode,
                              linearize_decoder)
-from ._polynomial_tensor import general_basis_change, PolynomialTensor
+from ._polynomial_tensor import PolynomialTensor, general_basis_change
 from ._quadratic_hamiltonian import QuadraticHamiltonian
 from ._symbolic_operator import (SymbolicOperator,
                                  prune_unused_indices)
 
 # Imports out of alphabetical order to avoid circular dependency.
 from ._fermion_operator import (FermionOperator,
-                                normal_ordered,
-                                freeze_orbitals)
+                                freeze_orbitals,
+                                normal_ordered)
 from ._interaction_operator import InteractionOperator
 from ._qubit_operator import QubitOperator
 from ._interaction_rdm import InteractionRDM

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -13,13 +13,15 @@
 from ._binary_operator import SymbolicBinary
 from ._code_operator import (BinaryCode,
                              linearize_decoder)
+from ._polynomial_tensor import general_basis_change, PolynomialTensor
+from ._quadratic_hamiltonian import QuadraticHamiltonian
 from ._symbolic_operator import (SymbolicOperator,
                                  prune_unused_indices)
+
+# Imports out of alphabetical order to avoid circular dependency.
 from ._fermion_operator import (FermionOperator,
                                 normal_ordered,
                                 freeze_orbitals)
-from ._qubit_operator import QubitOperator
-from ._polynomial_tensor import general_basis_change, PolynomialTensor
 from ._interaction_operator import InteractionOperator
+from ._qubit_operator import QubitOperator
 from ._interaction_rdm import InteractionRDM
-from ._quadratic_hamiltonian import QuadraticHamiltonian

--- a/src/openfermion/ops/_fermion_operator.py
+++ b/src/openfermion/ops/_fermion_operator.py
@@ -115,10 +115,10 @@ def freeze_orbitals(fermion_operator, occupied, unoccupied=None, prune=True):
     order to preserve the expectation value of the operator.
 
     Args:
-    occupied: A list containing the indices of the orbitals that are to be
-        assumed to be occupied.
-    unoccupied: A list containing the indices of the orbitals that are to
-        be assumed to be unoccupied.
+        occupied: A list containing the indices of the orbitals that are to be
+            assumed to be occupied.
+        unoccupied: A list containing the indices of the orbitals that are to
+            be assumed to be unoccupied.
     """
     new_operator = fermion_operator
     frozen = [(index, 1) for index in occupied]

--- a/src/openfermion/ops/_interaction_rdm.py
+++ b/src/openfermion/ops/_interaction_rdm.py
@@ -17,10 +17,10 @@ import copy
 import numpy
 
 from openfermion.ops import (FermionOperator,
-                             PolynomialTensor,
                              InteractionOperator,
-                             normal_ordered,
-                             QubitOperator)
+                             PolynomialTensor,
+                             QubitOperator,
+                             normal_ordered)
 
 
 class InteractionRDMError(Exception):

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -18,7 +18,7 @@ from scipy.linalg import schur
 import numpy
 
 from openfermion.config import EQ_TOLERANCE
-from openfermion.ops import FermionOperator, PolynomialTensor
+from openfermion.ops import PolynomialTensor
 
 
 class QuadraticHamiltonianError(Exception):

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -44,7 +44,7 @@ from ._unitary_cc import (uccsd_convert_amplitude_format,
                           uccsd_singlet_operator,
                           uccsd_singlet_paramsize)
 
-# Imports out of alphabetical order to avoid circular dependancy.
+# Imports out of alphabetical order to avoid circular dependency.
 from ._jellium_hf_state import hartree_fock_state_jellium
 
 from ._low_depth_trotter_error import (

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -27,7 +27,8 @@ import warnings
 from openfermion.config import *
 from openfermion.ops import (FermionOperator, QuadraticHamiltonian,
                              QubitOperator, normal_ordered)
-from openfermion.utils import (Grid, commutator, fourier_transform,
+from openfermion.utils import (Grid, commutator, count_qubits,
+                               fourier_transform,
                                gaussian_state_preparation_circuit,
                                hermitian_conjugated, is_hermitian,
                                number_operator,
@@ -100,7 +101,6 @@ def jordan_wigner_sparse(fermion_operator, n_qubits=None):
         The corresponding Scipy sparse matrix.
     """
     if n_qubits is None:
-        from openfermion.utils import count_qubits
         n_qubits = count_qubits(fermion_operator)
 
     # Create a list of raising and lowering operators for each orbital.
@@ -154,7 +154,6 @@ def qubit_operator_sparse(qubit_operator, n_qubits=None):
     Returns:
         The corresponding Scipy sparse matrix.
     """
-    from openfermion.utils import count_qubits
     if n_qubits is None:
         n_qubits = count_qubits(qubit_operator)
     if n_qubits < count_qubits(qubit_operator):


### PR DESCRIPTION
- Removed some in-line `import` statements that are no longer necessary because of improved import ordering in some `__init__.py` files
- Alphabeticized some imports
- Made it so that `from openfermion import *` doesn't also import `EQ_TOLERANCE` from `config.py`. I think generally users generally expect `*` imports to import only functions and not constants. Anyway I originally only added it because I thought it was necessary to make some things work but I think I was mistaken.
- Fix sphinx warnings