### PR TITLE
Fix uccsd_singlet_paramsize?

### DIFF
--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -40,8 +40,8 @@ from ._trotter_exp_to_qgates import (pauli_exp_to_qasm,
                                      trotter_operator_grouping)
 
 from ._unitary_cc import (uccsd_convert_amplitude_format,
-                          uccsd_operator,
-                          uccsd_singlet_operator,
+                          uccsd_generator,
+                          uccsd_singlet_generator,
                           uccsd_singlet_paramsize)
 
 # Imports out of alphabetical order to avoid circular dependency.

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -118,13 +118,9 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
         Number of independent parameters for singlet UCCSD with a single
         reference.
     """
-    if n_electrons % 2 != 0:
-        raise ValueError('A singlet state must have an even number of '
-                         'electrons.')
-
     # Since the total spin S^2 is conserved, we work with spatial orbitals
     n_spatial_orbitals = n_qubits // 2
-    n_occupied = n_electrons // 2
+    n_occupied = int(numpy.ceil(n_electrons / 2))
     n_virtual = n_spatial_orbitals - n_occupied
 
     n_single_amplitudes = n_occupied * n_virtual
@@ -157,12 +153,8 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
         generator(FermionOperator): Generator of the UCCSD operator that
             builds the UCCSD wavefunction.
     """
-    if n_electrons % 2 != 0:
-        raise ValueError('A singlet state must have an even number of '
-                         'electrons.')
-
     n_spatial_orbitals = n_qubits // 2
-    n_occupied = n_electrons // 2
+    n_occupied = int(numpy.ceil(n_electrons / 2))
     n_virtual = n_spatial_orbitals - n_occupied
 
     # Unpack amplitudes

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -130,8 +130,8 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
     n_single_amplitudes = n_occupied * n_virtual
 
     # Below is equivalent to
-    #     n_single_amplitudes + (n_single_amplitudes choose 2)
-    n_double_amplitudes = n_single_amplitudes * (n_single_amplitudes + 1) // 2
+    #     2 * n_single_amplitudes + (n_single_amplitudes choose 2)
+    n_double_amplitudes = n_single_amplitudes * (n_single_amplitudes + 3) // 2
 
     return n_single_amplitudes + n_double_amplitudes
 
@@ -170,9 +170,9 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
     # Single amplitudes
     t1 = packed_amplitudes[:n_single_amplitudes]
     # Double amplitudes associated with one spatial occupied-virtual pair
-    t2_1 = packed_amplitudes[n_single_amplitudes:2 * n_single_amplitudes]
+    t2_1 = packed_amplitudes[n_single_amplitudes:3 * n_single_amplitudes]
     # Double amplitudes associated with two spatial occupied-virtual pairs
-    t2_2 = packed_amplitudes[2 * n_single_amplitudes:]
+    t2_2 = packed_amplitudes[3 * n_single_amplitudes:]
 
     # Initialize operator
     generator = FermionOperator()
@@ -212,8 +212,9 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
             (virtual_down, 0)),
             -coeff)
 
-        # Generate double excitation
-        coeff = t2_1[i]
+        # Generate double excitations
+        # up -> up and down -> down
+        coeff = t2_1[2 * i]
         generator += FermionOperator((
             (virtual_up, 1),
             (occupied_up, 0),
@@ -225,6 +226,20 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
             (virtual_down, 0),
             (occupied_up, 1),
             (virtual_up, 0)),
+            -coeff)
+        # up -> down and down -> up
+        coeff = t2_1[2 * i + 1]
+        generator += FermionOperator((
+            (virtual_down, 1),
+            (occupied_up, 0),
+            (virtual_up, 1),
+            (occupied_down, 0)),
+            coeff)
+        generator += FermionOperator((
+            (occupied_down, 1),
+            (virtual_up, 0),
+            (occupied_up, 1),
+            (virtual_down, 0)),
             -coeff)
 
     # Generate all spin-conserving double excitations derived

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -18,6 +18,7 @@ import itertools
 
 import numpy
 from openfermion.ops import FermionOperator, QubitOperator
+from openfermion.utils import up_index, down_index
 
 
 def uccsd_operator(single_amplitudes, double_amplitudes, anti_hermitian=True):
@@ -135,9 +136,7 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
     return n_single_amplitudes + n_double_amplitudes
 
 
-def uccsd_singlet_operator(packed_amplitudes,
-                           n_qubits,
-                           n_electrons):
+def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
     """Create a singlet UCCSD generator for a system with n_electrons
 
     This function generates a FermionOperator for a UCCSD generator designed
@@ -158,15 +157,33 @@ def uccsd_singlet_operator(packed_amplitudes,
         uccsd_generator(FermionOperator): Generator of the UCCSD operator that
             builds the UCCSD wavefunction.
     """
-    n_occupied = int(numpy.ceil(n_electrons / 2.))
-    n_virtual = int(n_qubits / 2 - n_occupied)  # Virtual Spatial Orbitals
-    n_t1 = int(n_occupied * n_virtual)
+    if n_electrons % 2 != 0:
+        raise ValueError('A singlet state must have an even number of '
+                         'electrons.')
 
-    t1 = packed_amplitudes[:n_t1]
-    t2 = packed_amplitudes[n_t1:]
+    # Since the total spin S^2 is conserved, we work with spatial orbitals
+    n_spatial_orbitals = n_qubits // 2
+    n_occupied = n_electrons // 2
+    n_virtual = n_spatial_orbitals - n_occupied
+
+    n_single_amplitudes = n_occupied * n_virtual
+
+    t1 = packed_amplitudes[:n_single_amplitudes]
+    t2 = packed_amplitudes[n_single_amplitudes:]
 
     def t1_ind(i, j):
+        """i indexes a virtual spatial orbital and j indexes an
+        occupied spatial orbital."""
         return i * n_occupied + j
+
+    def t2_ind_1(i, j):
+        """i indexes a virtual spatial orbital and j indexes an
+        occupied spatial orbital."""
+        return n_single_amplitudes + t1_ind(i, j)
+
+    def t2_ind_2(p, q):
+        """p and q index spatial occupied-virtual pairs."""
+        pass
 
     def t2_ind(i, j, k, l):
         return (i * n_occupied * n_virtual * n_occupied +
@@ -180,17 +197,36 @@ def uccsd_singlet_operator(packed_amplitudes,
     # the spin component assumes alpha spins are even, beta spins are odd
     spaces = range(n_virtual), range(n_occupied), range(2)
 
-    # Generate all spin-conserving single excitations between occupied-virtual
-    for i, j, s in itertools.product(*spaces):
+    # Generate all spin-conserving single and double excitations derived
+    # from one spatial occupied-virtual pair
+    for i, j in itertools.product(range(n_virtual), range(n_occupied)):
+        # Get indices of spatial orbitals
+        virtual_spatial = i + n_occupied
+        occupied_spatial = j
+        
+        # Generate single excitations 
+        coeff = t1[t1_ind(i, j)]
+        # Spin up excitations
         uccsd_generator += FermionOperator((
-            (2 * (i + n_occupied) + s, 1),
-            (2 * j + s, 0)),
-            t1[t1_ind(i, j)])
+            (up_index(virtual_spatial), 1),
+            (up_index(occupied_spatial), 0)),
+            coeff)
+        uccsd_generator += FermionOperator((
+            (up_index(occupied_spatial), 1),
+            (up_index(virtual_spatial, 0)),
+            -coeff)
+        # Spin down excitations
+        uccsd_generator += FermionOperator((
+            (down_index(virtual_spatial), 1),
+            (down_index(occupied_spatial), 0)),
+            coeff)
+        uccsd_generator += FermionOperator((
+            (down_index(occupied_spatial), 1),
+            (down_index(virtual_spatial, 0)),
+            -coeff)
 
-        uccsd_generator += FermionOperator((
-            (2 * j + s, 1),
-            (2 * (i + n_occupied) + s, 0)),
-            -t1[t1_ind(i, j)])
+        # Generate double excitations
+        coeff = t2[t1_ind(i, j)]
 
     # Generate all spin-conserving double excitations between occupied-virtual
     for i, j, s, i2, j2, s2 in itertools.product(*spaces, repeat=2):

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -21,7 +21,7 @@ from openfermion.ops import FermionOperator, QubitOperator
 from openfermion.utils import up_index, down_index
 
 
-def uccsd_operator(single_amplitudes, double_amplitudes, anti_hermitian=True):
+def uccsd_generator(single_amplitudes, double_amplitudes, anti_hermitian=True):
     """Create a fermionic operator that is the generator of uccsd.
 
     This a the most straight-forward method to generate UCCSD operators,
@@ -51,7 +51,7 @@ def uccsd_operator(single_amplitudes, double_amplitudes, anti_hermitian=True):
         is the generator for the uccsd wavefunction.
     """
 
-    uccsd_generator = FermionOperator()
+    generator = FermionOperator()
 
     # Re-format inputs (ndarrays to lists) if necessary
     if (isinstance(single_amplitudes, numpy.ndarray) or
@@ -63,19 +63,19 @@ def uccsd_operator(single_amplitudes, double_amplitudes, anti_hermitian=True):
     # Add single excitations
     for (i, j), t_ij in single_amplitudes:
         i, j = int(i), int(j)
-        uccsd_generator += FermionOperator(((i, 1), (j, 0)), t_ij)
+        generator += FermionOperator(((i, 1), (j, 0)), t_ij)
         if anti_hermitian:
-            uccsd_generator += FermionOperator(((j, 1), (i, 0)), -t_ij)
+            generator += FermionOperator(((j, 1), (i, 0)), -t_ij)
 
     # Add double excitations
     for (i, j, k, l), t_ijkl in double_amplitudes:
         i, j, k, l = int(i), int(j), int(k), int(l)
-        uccsd_generator += FermionOperator(
+        generator += FermionOperator(
             ((i, 1), (j, 0), (k, 1), (l, 0)), t_ijkl)
         if anti_hermitian:
-            uccsd_generator += FermionOperator(
+            generator += FermionOperator(
                 ((l, 1), (k, 0), (j, 1), (i, 0)), -t_ijkl)
-    return uccsd_generator
+    return generator
 
 
 def uccsd_convert_amplitude_format(single_amplitudes, double_amplitudes):
@@ -136,7 +136,7 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
     return n_single_amplitudes + n_double_amplitudes
 
 
-def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
+def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
     """Create a singlet UCCSD generator for a system with n_electrons
 
     This function generates a FermionOperator for a UCCSD generator designed
@@ -154,7 +154,7 @@ def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
         n_electrons(int): Number of electrons in the physical system.
 
     Returns:
-        uccsd_generator(FermionOperator): Generator of the UCCSD operator that
+        generator(FermionOperator): Generator of the UCCSD operator that
             builds the UCCSD wavefunction.
     """
     if n_electrons % 2 != 0:
@@ -175,7 +175,7 @@ def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
     t2_2 = packed_amplitudes[2 * n_single_amplitudes:]
 
     # Initialize operator
-    uccsd_generator = FermionOperator()
+    generator = FermionOperator()
 
     # Generate all spin-conserving single and double excitations derived
     # from one spatial occupied-virtual pair
@@ -194,33 +194,33 @@ def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
         # Generate single excitations 
         coeff = t1[i]
         # Spin up excitation
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (virtual_up, 1),
             (occupied_up, 0)),
             coeff)
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (occupied_up, 1),
             (virtual_up, 0)),
             -coeff)
         # Spin down excitation
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (virtual_down, 1),
             (occupied_down, 0)),
             coeff)
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (occupied_down, 1),
             (virtual_down, 0)),
             -coeff)
 
         # Generate double excitation
         coeff = t2_1[i]
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (virtual_up, 1),
             (occupied_up, 0),
             (virtual_down, 1),
             (occupied_down, 0)),
             coeff)
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (occupied_down, 1),
             (virtual_down, 0),
             (occupied_up, 1),
@@ -243,30 +243,30 @@ def uccsd_singlet_operator(packed_amplitudes, n_qubits, n_electrons):
         # Generate double excitations
         coeff = t2_2[i]
         # p -> q is spin up and s -> r is spin down
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (up_index(virtual_spatial_1), 1),
             (up_index(occupied_spatial_1), 0),
             (down_index(virtual_spatial_2), 1),
             (down_index(occupied_spatial_2), 0)),
             coeff)
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (down_index(occupied_spatial_2), 1),
             (down_index(virtual_spatial_2), 0),
             (up_index(occupied_spatial_1), 1),
             (up_index(virtual_spatial_1), 0)),
             -coeff)
         # p -> q is spin down and s -> r is spin up
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (up_index(virtual_spatial_2), 1),
             (up_index(occupied_spatial_2), 0),
             (down_index(virtual_spatial_1), 1),
             (down_index(occupied_spatial_1), 0)),
             coeff)
-        uccsd_generator += FermionOperator((
+        generator += FermionOperator((
             (down_index(occupied_spatial_1), 1),
             (down_index(virtual_spatial_1), 0),
             (up_index(occupied_spatial_2), 1),
             (up_index(virtual_spatial_2), 0)),
             -coeff)
 
-    return uccsd_generator
+    return generator

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -130,8 +130,8 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
     n_single_amplitudes = 2 * n_single_amplitudes_per_spin
 
     n_double_amplitudes_different_spin = n_single_amplitudes_per_spin ** 2
-    n_double_amplitudes_same_spin = 2 * int(comb(n_single_amplitudes_per_spin,
-                                                 2))
+    n_double_amplitudes_same_spin = 2 * (int(comb(n_occupied_spatial, 2)) *
+                                         int(comb(n_virtual_spatial, 2)))
     n_double_amplitudes = (n_double_amplitudes_different_spin +
                            n_double_amplitudes_same_spin)
 

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -17,6 +17,7 @@ from __future__ import division
 import itertools
 
 import numpy
+from scipy.special import comb
 from openfermion.ops import FermionOperator, QubitOperator
 
 
@@ -117,12 +118,24 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
         Number of independent parameters for singlet UCCSD with a single
         reference.
     """
-    n_occupied = int(numpy.ceil(n_electrons / 2.))
-    n_virtual = n_qubits // 2 - n_occupied
+    if n_electrons % 2 != 0:
+        raise ValueError('A singlet state must have an even number of '
+                         'electrons.')
 
-    n_single_amplitudes = n_occupied * n_virtual
-    n_double_amplitudes = n_single_amplitudes ** 2
-    return (n_single_amplitudes + n_double_amplitudes)
+    n_spatial_orbitals = n_qubits // 2
+    n_occupied_spatial = n_electrons // 2
+    n_virtual_spatial = n_spatial_orbitals - n_occupied_spatial
+
+    n_single_amplitudes_per_spin = n_occupied_spatial * n_virtual_spatial
+    n_single_amplitudes = 2 * n_single_amplitudes_per_spin
+
+    n_double_amplitudes_different_spin = n_single_amplitudes_per_spin ** 2
+    n_double_amplitudes_same_spin = 2 * int(comb(n_single_amplitudes_per_spin,
+                                                 2))
+    n_double_amplitudes = (n_double_amplitudes_different_spin +
+                           n_double_amplitudes_same_spin)
+
+    return n_single_amplitudes + n_double_amplitudes
 
 
 def uccsd_singlet_operator(packed_amplitudes,

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -17,7 +17,6 @@ from __future__ import division
 import itertools
 
 import numpy
-from scipy.special import comb
 from openfermion.ops import FermionOperator, QubitOperator
 
 
@@ -122,18 +121,16 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
         raise ValueError('A singlet state must have an even number of '
                          'electrons.')
 
+    # Since the total spin S^2 is conserved, we work with spatial orbitals
     n_spatial_orbitals = n_qubits // 2
-    n_occupied_spatial = n_electrons // 2
-    n_virtual_spatial = n_spatial_orbitals - n_occupied_spatial
+    n_occupied = n_electrons // 2
+    n_virtual = n_spatial_orbitals - n_occupied
 
-    n_single_amplitudes_per_spin = n_occupied_spatial * n_virtual_spatial
-    n_single_amplitudes = 2 * n_single_amplitudes_per_spin
+    n_single_amplitudes = n_occupied * n_virtual
 
-    n_double_amplitudes_different_spin = n_single_amplitudes_per_spin ** 2
-    n_double_amplitudes_same_spin = 2 * (int(comb(n_occupied_spatial, 2)) *
-                                         int(comb(n_virtual_spatial, 2)))
-    n_double_amplitudes = (n_double_amplitudes_different_spin +
-                           n_double_amplitudes_same_spin)
+    # Below is equivalent to
+    #     n_single_amplitudes + (n_single_amplitudes choose 2)
+    n_double_amplitudes = n_single_amplitudes * (n_single_amplitudes + 1) // 2
 
     return n_single_amplitudes + n_double_amplitudes
 

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -118,6 +118,9 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
         Number of independent parameters for singlet UCCSD with a single
         reference.
     """
+    if n_qubits % 2 != 0:
+        raise ValueError('The total number of spin-orbitals should be even.')
+
     # Since the total spin S^2 is conserved, we work with spatial orbitals
     n_spatial_orbitals = n_qubits // 2
     n_occupied = int(numpy.ceil(n_electrons / 2))
@@ -153,6 +156,9 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
         generator(FermionOperator): Generator of the UCCSD operator that
             builds the UCCSD wavefunction.
     """
+    if n_qubits % 2 != 0:
+        raise ValueError('The total number of spin-orbitals should be even.')
+
     n_spatial_orbitals = n_qubits // 2
     n_occupied = int(numpy.ceil(n_electrons / 2))
     n_virtual = n_spatial_orbitals - n_occupied

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -239,34 +239,69 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
         occupied_spatial_1 = q
         virtual_spatial_2 = n_occupied + r
         occupied_spatial_2 = s
+        # Get indices of spin orbitals
+        virtual_up_1 = up_index(virtual_spatial_1)
+        virtual_down_1 = down_index(virtual_spatial_1)
+        occupied_up_1 = up_index(occupied_spatial_1)
+        occupied_down_1 = down_index(occupied_spatial_1)
+        virtual_up_2 = up_index(virtual_spatial_2)
+        virtual_down_2 = down_index(virtual_spatial_2)
+        occupied_up_2 = up_index(occupied_spatial_2)
+        occupied_down_2 = down_index(occupied_spatial_2)
 
         # Generate double excitations
         coeff = t2_2[i]
         # p -> q is spin up and s -> r is spin down
         generator += FermionOperator((
-            (up_index(virtual_spatial_1), 1),
-            (up_index(occupied_spatial_1), 0),
-            (down_index(virtual_spatial_2), 1),
-            (down_index(occupied_spatial_2), 0)),
+            (virtual_up_1, 1),
+            (occupied_up_1, 0),
+            (virtual_down_2, 1),
+            (occupied_down_2, 0)),
             coeff)
         generator += FermionOperator((
-            (down_index(occupied_spatial_2), 1),
-            (down_index(virtual_spatial_2), 0),
-            (up_index(occupied_spatial_1), 1),
-            (up_index(virtual_spatial_1), 0)),
+            (occupied_down_2, 1),
+            (virtual_down_2, 0),
+            (occupied_up_1, 1),
+            (virtual_up_1, 0)),
             -coeff)
         # p -> q is spin down and s -> r is spin up
         generator += FermionOperator((
-            (up_index(virtual_spatial_2), 1),
-            (up_index(occupied_spatial_2), 0),
-            (down_index(virtual_spatial_1), 1),
-            (down_index(occupied_spatial_1), 0)),
+            (virtual_up_2, 1),
+            (occupied_up_2, 0),
+            (virtual_down_1, 1),
+            (occupied_down_1, 0)),
             coeff)
         generator += FermionOperator((
-            (down_index(occupied_spatial_1), 1),
-            (down_index(virtual_spatial_1), 0),
-            (up_index(occupied_spatial_2), 1),
-            (up_index(virtual_spatial_2), 0)),
+            (occupied_down_1, 1),
+            (virtual_down_1, 0),
+            (occupied_up_2, 1),
+            (virtual_up_2, 0)),
+            -coeff)
+        # Both are spin up excitations
+        generator += FermionOperator((
+            (virtual_up_1, 1),
+            (occupied_up_1, 0),
+            (virtual_up_2, 1),
+            (occupied_up_2, 0)),
+            coeff)
+        generator += FermionOperator((
+            (occupied_up_2, 1),
+            (virtual_up_2, 0),
+            (occupied_up_1, 1),
+            (virtual_up_1, 0)),
+            -coeff)
+        # Both are spin down excitations
+        generator += FermionOperator((
+            (virtual_down_1, 1),
+            (occupied_down_1, 0),
+            (virtual_down_2, 1),
+            (occupied_down_2, 0)),
+            coeff)
+        generator += FermionOperator((
+            (occupied_down_2, 1),
+            (virtual_down_2, 0),
+            (occupied_down_1, 1),
+            (virtual_down_1, 0)),
             -coeff)
 
     return generator

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -32,8 +32,7 @@ from openfermion.utils import (commutator, count_qubits, expectation,
                                hermitian_conjugated,
                                jordan_wigner_sparse, jw_hartree_fock_state,
                                s_squared_operator, sz_operator)
-from openfermion.utils._unitary_cc import (uccsd_convert_amplitude_format,
-                                           uccsd_generator,
+from openfermion.utils._unitary_cc import (uccsd_generator,
                                            uccsd_singlet_paramsize,
                                            uccsd_singlet_generator)
 

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -276,3 +276,10 @@ class UnitaryCC(unittest.TestCase):
         expected_ccsd_energy = ccsd_state_l.getH().dot(
             self.hamiltonian_matrix.dot(ccsd_state_r))[0, 0]
         self.assertAlmostEqual(expected_ccsd_energy, self.molecule.fci_energy)
+
+    def test_exceptions(self):
+        # Pass odd n_qubits to singlet generators
+        with self.assertRaises(ValueError):
+            _ = uccsd_singlet_paramsize(3, 4)
+        with self.assertRaises(ValueError):
+            _ = uccsd_singlet_generator([1.], 3, 4)

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -37,7 +37,7 @@ class UnitaryCC(unittest.TestCase):
         single_amplitudes = randn(*(test_orbitals,) * 2)
         double_amplitudes = randn(*(test_orbitals,) * 4)
 
-        generator = uccsd_operator(single_amplitudes, double_amplitudes)
+        generator = uccsd_generator(single_amplitudes, double_amplitudes)
         conj_generator = hermitian_conjugated(generator)
 
         self.assertTrue(generator.isclose(-1. * conj_generator))
@@ -52,7 +52,7 @@ class UnitaryCC(unittest.TestCase):
 
         packed_amplitudes = randn(int(packed_amplitude_size))
 
-        generator = uccsd_singlet_operator(packed_amplitudes,
+        generator = uccsd_singlet_generator(packed_amplitudes,
                                            test_orbitals,
                                            test_electrons)
 
@@ -66,7 +66,7 @@ class UnitaryCC(unittest.TestCase):
         n_orbitals = 4
         n_electrons = 2
 
-        generator = uccsd_singlet_operator(initial_amplitudes,
+        generator = uccsd_singlet_generator(initial_amplitudes,
                                            n_orbitals,
                                            n_electrons)
 
@@ -84,8 +84,8 @@ class UnitaryCC(unittest.TestCase):
                           (-0.0565340614) * FermionOperator("0^ 2 1^ 3"))
         self.assertTrue(test_generator.isclose(generator))
 
-    def test_sparse_uccsd_operator_numpy_inputs(self):
-        """Test numpy ndarray inputs to uccsd_operator that are sparse"""
+    def test_sparse_uccsd_generator_numpy_inputs(self):
+        """Test numpy ndarray inputs to uccsd_generator that are sparse"""
         test_orbitals = 30
         sparse_single_amplitudes = numpy.zeros((test_orbitals, test_orbitals))
         sparse_double_amplitudes = numpy.zeros((test_orbitals, test_orbitals,
@@ -97,7 +97,7 @@ class UnitaryCC(unittest.TestCase):
         sparse_double_amplitudes[0, 12, 6, 2] = 0.3434
         sparse_double_amplitudes[1, 4, 6, 13] = -0.23423
 
-        generator = uccsd_operator(sparse_single_amplitudes,
+        generator = uccsd_generator(sparse_single_amplitudes,
                                    sparse_double_amplitudes)
 
         test_generator = (0.12345 * FermionOperator("3^ 5") +
@@ -110,14 +110,14 @@ class UnitaryCC(unittest.TestCase):
                           0.23423 * FermionOperator("13^ 6 4^ 1"))
         self.assertTrue(test_generator.isclose(generator))
 
-    def test_sparse_uccsd_operator_list_inputs(self):
-        """Test list inputs to uccsd_operator that are sparse"""
+    def test_sparse_uccsd_generator_list_inputs(self):
+        """Test list inputs to uccsd_generator that are sparse"""
         sparse_single_amplitudes = [[[3, 5], 0.12345],
                                     [[12, 4], 0.44313]]
         sparse_double_amplitudes = [[[0, 12, 6, 2], 0.3434],
                                     [[1, 4, 6, 13], -0.23423]]
 
-        generator = uccsd_operator(sparse_single_amplitudes,
+        generator = uccsd_generator(sparse_single_amplitudes,
                                    sparse_double_amplitudes)
 
         test_generator = (0.12345 * FermionOperator("3^ 5") +
@@ -162,7 +162,7 @@ class UnitaryCC(unittest.TestCase):
         self.hamiltonian_matrix = get_sparse_operator(
             self.molecular_hamiltonian)
         # Test UCCSD for accuracy against FCI using loaded t amplitudes.
-        ucc_operator = uccsd_operator(
+        ucc_operator = uccsd_generator(
             self.molecule.ccsd_single_amps,
             self.molecule.ccsd_double_amps)
 
@@ -178,7 +178,7 @@ class UnitaryCC(unittest.TestCase):
         print("UCCSD ENERGY: {}".format(expected_uccsd_energy))
 
         # Test CCSD for precise match against FCI using loaded t amplitudes.
-        ccsd_operator = uccsd_operator(
+        ccsd_operator = uccsd_generator(
             self.molecule.ccsd_single_amps,
             self.molecule.ccsd_double_amps,
             anti_hermitian=False)
@@ -188,7 +188,7 @@ class UnitaryCC(unittest.TestCase):
             -hermitian_conjugated(ccsd_operator))
 
         # Test CCSD for precise match against FCI using loaded t amplitudes
-        ccsd_operator = uccsd_operator(
+        ccsd_operator = uccsd_generator(
             self.molecule.ccsd_single_amps,
             self.molecule.ccsd_double_amps,
             anti_hermitian=False)

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -96,20 +96,25 @@ class UnitaryCC(unittest.TestCase):
     def test_uccsd_singlet_builds(self):
         """Test specific builds of the UCCSD singlet operator"""
         # Build 1
-        initial_amplitudes = [-1.14941450e-08, 5.65340614e-02]
         n_orbitals = 4
         n_electrons = 2
+        n_params = uccsd_singlet_paramsize(n_orbitals, n_electrons)
+        self.assertEqual(n_params, 3)
+
+        initial_amplitudes = [1., 2., 3.]
 
         generator = uccsd_singlet_generator(initial_amplitudes,
                                            n_orbitals,
                                            n_electrons)
 
-        test_generator = (FermionOperator("0^ 2", 1.1494145e-08) +
-                          FermionOperator("2^ 0", -1.1494145e-08) +
-                          FermionOperator("1^ 3", 1.1494145e-08) +
-                          FermionOperator("3^ 1", -1.1494145e-08) +
-                          FermionOperator("2^ 0 3^ 1", 0.0565340614) +
-                          FermionOperator("1^ 3 0^ 2", -0.0565340614))
+        test_generator = (FermionOperator("2^ 0", 1.) +
+                          FermionOperator("0^ 2", -1.) +
+                          FermionOperator("3^ 1", 1.) +
+                          FermionOperator("1^ 3", -1.) +
+                          FermionOperator("2^ 0 3^ 1", 2.) +
+                          FermionOperator("1^ 3 0^ 2", -2.) +
+                          FermionOperator("3^ 0 2^ 1", 3.) +
+                          FermionOperator("1^ 2 0^ 3", -3.))
 
         self.assertTrue(test_generator.isclose(generator))
 
@@ -118,9 +123,9 @@ class UnitaryCC(unittest.TestCase):
         n_electrons = 2
 
         n_params = uccsd_singlet_paramsize(n_orbitals, n_electrons)
-        self.assertEqual(n_params, 5)
+        self.assertEqual(n_params, 7)
 
-        initial_amplitudes = numpy.arange(1, 6, dtype=float)
+        initial_amplitudes = numpy.arange(1, 8, dtype=float)
         generator = uccsd_singlet_generator(initial_amplitudes,
                                            n_orbitals,
                                            n_electrons)
@@ -135,16 +140,20 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("1^ 5", -2.) +
                           FermionOperator("2^ 0 3^ 1", 3.) +
                           FermionOperator("1^ 3 0^ 2", -3.) +
-                          FermionOperator("4^ 0 5^ 1", 4.) +
-                          FermionOperator("1^ 5 0^ 4", -4.) +
-                          FermionOperator("2^ 0 5^ 1", 5.) +
-                          FermionOperator("1^ 5 0^ 2", -5.) +
-                          FermionOperator("4^ 0 3^ 1", 5.) +
-                          FermionOperator("1^ 3 0^ 4", -5.) +
-                          FermionOperator("2^ 0 4^ 0", 5.) +
-                          FermionOperator("0^ 4 0^ 2", -5.) +
-                          FermionOperator("3^ 1 5^ 1", 5.) +
-                          FermionOperator("1^ 5 1^ 3", -5.))
+                          FermionOperator("3^ 0 2^ 1", 4.) +
+                          FermionOperator("1^ 2 0^ 3", -4.) +
+                          FermionOperator("4^ 0 5^ 1", 5.) +
+                          FermionOperator("1^ 5 0^ 4", -5.) +
+                          FermionOperator("5^ 0 4^ 1", 6.) +
+                          FermionOperator("1^ 4 0^ 5", -6.) +
+                          FermionOperator("2^ 0 5^ 1", 7.) +
+                          FermionOperator("1^ 5 0^ 2", -7.) +
+                          FermionOperator("4^ 0 3^ 1", 7.) +
+                          FermionOperator("1^ 3 0^ 4", -7.) +
+                          FermionOperator("2^ 0 4^ 0", 7.) +
+                          FermionOperator("0^ 4 0^ 2", -7.) +
+                          FermionOperator("3^ 1 5^ 1", 7.) +
+                          FermionOperator("1^ 5 1^ 3", -7.))
 
         self.assertTrue(test_generator.isclose(generator))
 

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -115,7 +115,39 @@ class UnitaryCC(unittest.TestCase):
         self.assertTrue(test_generator.isclose(generator))
 
         # Build 2
-        # TODO
+        n_orbitals = 6
+        n_electrons = 2
+
+        n_params = uccsd_singlet_paramsize(n_orbitals, n_electrons)
+        self.assertEqual(n_params, 5)
+
+        initial_amplitudes = numpy.arange(1, 6, dtype=float)
+        generator = uccsd_singlet_generator(initial_amplitudes,
+                                           n_orbitals,
+                                           n_electrons)
+
+        test_generator = (FermionOperator("2^ 0", 1.) +
+                          FermionOperator("0^ 2", -1) +
+                          FermionOperator("3^ 1", 1.) +
+                          FermionOperator("1^ 3", -1.) +
+                          FermionOperator("4^ 0", 2.) +
+                          FermionOperator("0^ 4", -2) +
+                          FermionOperator("5^ 1", 2.) +
+                          FermionOperator("1^ 5", -2.) +
+                          FermionOperator("2^ 0 3^ 1", 3.) +
+                          FermionOperator("1^ 3 0^ 2", -3.) +
+                          FermionOperator("4^ 0 5^ 1", 4.) +
+                          FermionOperator("1^ 5 0^ 4", -4.) +
+                          FermionOperator("2^ 0 5^ 1", 5.) +
+                          FermionOperator("1^ 5 0^ 2", -5.) +
+                          FermionOperator("4^ 0 3^ 1", 5.) +
+                          FermionOperator("1^ 3 0^ 4", -5.) +
+                          FermionOperator("2^ 0 4^ 0", 5.) +
+                          FermionOperator("0^ 4 0^ 2", -5.) +
+                          FermionOperator("3^ 1 5^ 1", 5.) +
+                          FermionOperator("1^ 5 1^ 3", -5.))
+
+        self.assertTrue(test_generator.isclose(generator))
 
     def test_sparse_uccsd_generator_numpy_inputs(self):
         """Test numpy ndarray inputs to uccsd_generator that are sparse"""


### PR DESCRIPTION
I'm a bit unsure about this one, but hopefully my variable names are clear enough that someone can follow my reasoning and correct me if I'm wrong.

Singlet implies Sz = 0, which means there are the same number of spin up as spin down electrons, which means the number of electrons is even, right?

Previously we had `n_single_amplitudes = n_occupied * n_virtual`, but since `n_occupied` and `n_virtual` refer to spatial orbitals, we need to double it because there are two spins, right?

Then, we had `n_double_amplitudes = n_single_amplitudes ** 2`. But we wouldn't want to count double excitations of the same electron, or for two electrons into the same orbital, etc., right?

If I'm right about this I think we may want to change `uccsd_singlet_operator` as well (I don't mind doing it).