### PR TITLE
Change normalization and initialization of Majorana operators.

### DIFF
--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -146,17 +146,20 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         majorana_matrix, majorana_constant = self.quad_ham_npc.majorana_form()
         # Convert the Majorana form to a FermionOperator
         majorana_op = FermionOperator((), majorana_constant)
+        normalization = 1. / numpy.sqrt(2.)
         for i in range(2 * self.n_qubits):
             if i < self.n_qubits:
-                left_op = majorana_operator((i, 1))
+                left_op = majorana_operator((i, 'c'), normalization)
             else:
-                left_op = majorana_operator((i - self.n_qubits, 0))
+                left_op = majorana_operator((i - self.n_qubits, 'd'),
+                                            normalization)
             for j in range(2 * self.n_qubits):
                 if j < self.n_qubits:
-                    right_op = majorana_operator((j, 1), majorana_matrix[i, j])
+                    right_op = majorana_operator((j, 'c'),
+                            majorana_matrix[i, j] * normalization)
                 else:
-                    right_op = majorana_operator((j - self.n_qubits, 0),
-                                                 majorana_matrix[i, j])
+                    right_op = majorana_operator((j - self.n_qubits, 'd'),
+                            majorana_matrix[i, j] * normalization)
                 majorana_op += .5j * left_op * right_op
         # Get FermionOperator for original Hamiltonian
         fermion_operator = normal_ordered(
@@ -202,23 +205,6 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         for i in numpy.ndindex((self.n_qubits, self.n_qubits)):
             self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
             self.assertAlmostEqual(0., constraint_matrix_2[i])
-
-
-class MajoranaOperatorTest(unittest.TestCase):
-
-    def test_none_term(self):
-        majorana_op = majorana_operator()
-        self.assertTrue(majorana_operator().isclose(FermionOperator()))
-
-    def test_bad_coefficient(self):
-        with self.assertRaises(ValueError):
-            majorana_op = majorana_operator((1, 1), 'a')
-
-    def test_bad_term(self):
-        with self.assertRaises(ValueError):
-            majorana_op = majorana_operator((2, 2))
-        with self.assertRaises(ValueError):
-            majorana_op = majorana_operator('a')
 
 
 class AntisymmetricCanonicalFormTest(unittest.TestCase):

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -149,16 +149,16 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         normalization = 1. / numpy.sqrt(2.)
         for i in range(2 * self.n_qubits):
             if i < self.n_qubits:
-                left_op = majorana_operator((i, 'c'), normalization)
+                left_op = majorana_operator((i, 0), normalization)
             else:
-                left_op = majorana_operator((i - self.n_qubits, 'd'),
+                left_op = majorana_operator((i - self.n_qubits, 1),
                                             normalization)
             for j in range(2 * self.n_qubits):
                 if j < self.n_qubits:
-                    right_op = majorana_operator((j, 'c'),
+                    right_op = majorana_operator((j, 0),
                             majorana_matrix[i, j] * normalization)
                 else:
-                    right_op = majorana_operator((j - self.n_qubits, 'd'),
+                    right_op = majorana_operator((j - self.n_qubits, 1),
                             majorana_matrix[i, j] * normalization)
                 majorana_op += .5j * left_op * right_op
         # Get FermionOperator for original Hamiltonian

--- a/src/openfermion/transforms/_verstraete_cirac.py
+++ b/src/openfermion/transforms/_verstraete_cirac.py
@@ -139,8 +139,8 @@ def verstraete_cirac_2d_square(operator, x_dimension, y_dimension,
 def stabilizer(i, j):
     """Stabilizer operators which act on the auxiliary space.
     In the original paper, these are referred to as P_{ij}."""
-    c_i = majorana_operator((i, 1), numpy.sqrt(2.))
-    d_j = majorana_operator((j, 0), numpy.sqrt(2.))
+    c_i = majorana_operator((i, 0))
+    d_j = majorana_operator((j, 1))
     return 1.j * c_i * d_j
 
 

--- a/src/openfermion/utils/_special_operators.py
+++ b/src/openfermion/utils/_special_operators.py
@@ -162,17 +162,17 @@ def majorana_operator(term=None, coefficient=1.):
     Args:
         term(tuple or string): The first element of the tuple indicates the
             mode on which the Majorana operator acts, starting from zero.
-            The second element of the tuple is a string, either 'c' or 'd',
+            The second element of the tuple is a string, either 0 or 1,
             indicating which type of Majorana operator it is:
 
-                Type 'c': :math:`a^\dagger_p + a_p`
+                Type 0: :math:`a^\dagger_p + a_p`
 
-                Type 'd': :math:`i (a^\dagger_p - a_p)`
+                Type 1: :math:`i (a^\dagger_p - a_p)`
 
             where the :math:`a^\dagger_p` and :math:`a_p` are the usual
             fermionic ladder operators.
             Alternatively, one can provide a string such as 'c2', which
-            is a Type 'c' operator on mode 2, or 'd3', which is a Type 'd'
+            is a Type 0 operator on mode 2, or 'd3', which is a Type 1
             operator on mode 3.
             Default will result in the zero operator.
         coefficient(complex or float, optional): The coefficient of the term.
@@ -184,26 +184,37 @@ def majorana_operator(term=None, coefficient=1.):
     if not isinstance(coefficient, (int, float, complex)):
         raise ValueError('Coefficient must be scalar.')
 
+    # If term is a string, convert it to a tuple
+    if isinstance(term, str):
+        operator_type = term[0]
+        mode = int(term[1:])
+        if operator_type == 'c':
+            operator_type = 0
+        elif operator_type == 'd':
+            operator_type = 1
+        else:
+            raise ValueError('Invalid operator type: {}'.format(operator_type))
+        term = (mode, operator_type)
+
+    # Process term
+
     # Zero operator
     if term is None:
         return FermionOperator()
 
-    # Tuple or string input
-    elif isinstance(term, (tuple, str)):
-        if isinstance(term, tuple):
-            mode, operator_type = term
-        else:
-            operator_type = term[0]
-            mode = int(term[1:])
+    # Tuple
+    if isinstance(term, tuple):
+        mode, operator_type = term
 
-        if operator_type == 'c':
+        if operator_type == 0:
             majorana_op = FermionOperator(((mode, 1),), coefficient)
             majorana_op += FermionOperator(((mode, 0),), coefficient)
-        elif operator_type == 'd':
+        elif operator_type == 1:
             majorana_op = FermionOperator(((mode, 1),), 1.j * coefficient)
             majorana_op -= FermionOperator(((mode, 0),), 1.j * coefficient)
         else:
-            raise ValueError('Invalid operator type.')
+            raise ValueError('Invalid operator type: {}'.format(
+                str(operator_type)))
 
         return majorana_op
 

--- a/src/openfermion/utils/_special_operators.py
+++ b/src/openfermion/utils/_special_operators.py
@@ -162,7 +162,7 @@ def majorana_operator(term=None, coefficient=1.):
     Args:
         term(tuple or string): The first element of the tuple indicates the
             mode on which the Majorana operator acts, starting from zero.
-            The second element of the tuple is a string, either 0 or 1,
+            The second element of the tuple is an integer, either 0 or 1,
             indicating which type of Majorana operator it is:
 
                 Type 0: :math:`a^\dagger_p + a_p`

--- a/src/openfermion/utils/_special_operators.py
+++ b/src/openfermion/utils/_special_operators.py
@@ -160,17 +160,20 @@ def majorana_operator(term=None, coefficient=1.):
     """Initialize a Majorana operator.
 
     Args:
-        term(tuple): The first element of the tuple indicates the mode
-            on which the Majorana operator acts, starting from zero.
-            The second element of the tuple is an integer, either 1 or 0,
+        term(tuple or string): The first element of the tuple indicates the
+            mode on which the Majorana operator acts, starting from zero.
+            The second element of the tuple is a string, either 'c' or 'd',
             indicating which type of Majorana operator it is:
 
-                Type 1: :math:`\\frac{1}{\sqrt{2}} (a^\dagger_p + a_p)`
+                Type 'c': :math:`a^\dagger_p + a_p`
 
-                Type 0: :math:`\\frac{i}{\sqrt{2}} (a^\dagger_p - a_p)`
+                Type 'd': :math:`i (a^\dagger_p - a_p)`
 
             where the :math:`a^\dagger_p` and :math:`a_p` are the usual
             fermionic ladder operators.
+            Alternatively, one can provide a string such as 'c2', which
+            is a Type 'c' operator on mode 2, or 'd3', which is a Type 'd'
+            operator on mode 3.
             Default will result in the zero operator.
         coefficient(complex or float, optional): The coefficient of the term.
             Default value is 1.0.
@@ -181,26 +184,31 @@ def majorana_operator(term=None, coefficient=1.):
     if not isinstance(coefficient, (int, float, complex)):
         raise ValueError('Coefficient must be scalar.')
 
+    # Zero operator
     if term is None:
-        # Return zero operator
         return FermionOperator()
-    elif isinstance(term, tuple):
-        mode, operator_type = term
-        if operator_type == 1:
-            majorana_op = FermionOperator(
-                ((mode, 1),), coefficient / numpy.sqrt(2.))
-            majorana_op += FermionOperator(
-                ((mode, 0),), coefficient / numpy.sqrt(2.))
-        elif operator_type == 0:
-            majorana_op = FermionOperator(
-                ((mode, 1),), 1.j * coefficient / numpy.sqrt(2.))
-            majorana_op -= FermionOperator(
-                ((mode, 0),), 1.j * coefficient / numpy.sqrt(2.))
+
+    # Tuple or string input
+    elif isinstance(term, (tuple, str)):
+        if isinstance(term, tuple):
+            mode, operator_type = term
         else:
-            raise ValueError('Operator specified incorrectly.')
+            operator_type = term[0]
+            mode = int(term[1:])
+
+        if operator_type == 'c':
+            majorana_op = FermionOperator(((mode, 1),), coefficient)
+            majorana_op += FermionOperator(((mode, 0),), coefficient)
+        elif operator_type == 'd':
+            majorana_op = FermionOperator(((mode, 1),), 1.j * coefficient)
+            majorana_op -= FermionOperator(((mode, 0),), 1.j * coefficient)
+        else:
+            raise ValueError('Invalid operator type.')
+
         return majorana_op
+
+    # Invalid input.
     else:
-        # Invalid input.
         raise ValueError('Operator specified incorrectly.')
 
 

--- a/src/openfermion/utils/_special_operators_test.py
+++ b/src/openfermion/utils/_special_operators_test.py
@@ -84,14 +84,14 @@ class MajoranaOperatorTest(unittest.TestCase):
 
     def test_init(self):
         # Test 'c' operator
-        op1 = majorana_operator((2, 'c'))
+        op1 = majorana_operator((2, 0))
         op2 = majorana_operator('c2')
         correct = FermionOperator('2^') + FermionOperator('2')
         self.assertTrue(op1.isclose(op2))
         self.assertTrue(op1.isclose(correct))
 
         # Test 'd' operator
-        op1 = majorana_operator((3, 'd'))
+        op1 = majorana_operator((3, 1))
         op2 = majorana_operator('d3')
         correct = FermionOperator('3^', 1.j) - FermionOperator('3', 1.j)
         self.assertTrue(op1.isclose(op2))

--- a/src/openfermion/utils/_special_operators_test.py
+++ b/src/openfermion/utils/_special_operators_test.py
@@ -14,9 +14,9 @@
 import numpy
 import unittest
 from openfermion.ops import FermionOperator
-from openfermion.utils import (up_index, down_index, s_minus_operator,
-                               s_plus_operator, sz_operator,
-                               s_squared_operator)
+from openfermion.utils import (majorana_operator, s_minus_operator,
+                               s_plus_operator, s_squared_operator,
+                               sz_operator, up_index, down_index)
 
 
 class FermionSpinOperatorsTest(unittest.TestCase):
@@ -79,3 +79,34 @@ class FermionSpinOperatorsTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             s_squared_operator('a')
 
+
+class MajoranaOperatorTest(unittest.TestCase):
+
+    def test_init(self):
+        # Test 'c' operator
+        op1 = majorana_operator((2, 'c'))
+        op2 = majorana_operator('c2')
+        correct = FermionOperator('2^') + FermionOperator('2')
+        self.assertTrue(op1.isclose(op2))
+        self.assertTrue(op1.isclose(correct))
+
+        # Test 'd' operator
+        op1 = majorana_operator((3, 'd'))
+        op2 = majorana_operator('d3')
+        correct = FermionOperator('3^', 1.j) - FermionOperator('3', 1.j)
+        self.assertTrue(op1.isclose(op2))
+        self.assertTrue(op1.isclose(correct))
+
+    def test_none_term(self):
+        majorana_op = majorana_operator()
+        self.assertTrue(majorana_operator().isclose(FermionOperator()))
+
+    def test_bad_coefficient(self):
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator((1, 1), 'a')
+
+    def test_bad_term(self):
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator((2, 2))
+        with self.assertRaises(ValueError):
+            majorana_op = majorana_operator('a')


### PR DESCRIPTION
Resolves #258 .

Also switched the meaning of "Type 0" and "Type 1" operators, and allows initialization using strings, e.g. `majorana_operator('c3')` now means Type 0 operator on mode 3.