### PR TITLE
Define __eq__ for SymbolicOperator and eliminate isclose

### DIFF
--- a/examples/openfermion_demo.ipynb
+++ b/examples/openfermion_demo.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The print function prints each term in the operator on a different line. Note that the line my_operator = term_1 + term_2 creates a new object, which involves a copy of term_1 and term_2. The second block of code uses the inplace method +=, which is more efficient. This is especially important when trying to construct a very large FermionOperator. FermionOperators also support a wide range of builtins including, str(), repr(), *=, *, /, /=, +, +=, -, -=, - and **. Note that instead of supporting != and ==, we have the method .isclose(), since FermionOperators involve floats. We demonstrate some of these methods below."
+    "The print function prints each term in the operator on a different line. Note that the line my_operator = term_1 + term_2 creates a new object, which involves a copy of term_1 and term_2. The second block of code uses the inplace method +=, which is more efficient. This is especially important when trying to construct a very large FermionOperator. FermionOperators also support a wide range of builtins including, str(), repr(), *=, *, /, /=, +, +=, -, -=, - and **. Note that instead of supporting != and ==, we have the method  == , since FermionOperators involve floats. We demonstrate some of these methods below."
    ]
   },
   {
@@ -249,8 +249,8 @@
     "print(term_2 ** 3)\n",
     "\n",
     "print('')\n",
-    "print(term_1.isclose(2.*term_1 - term_1))\n",
-    "print(term_1.isclose(my_operator))"
+    "print(term_1 == 2.*term_1 - term_1)\n",
+    "print(term_1 == my_operator)"
    ]
   },
   {

--- a/examples/openfermion_demo.ipynb
+++ b/examples/openfermion_demo.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The print function prints each term in the operator on a different line. Note that the line my_operator = term_1 + term_2 creates a new object, which involves a copy of term_1 and term_2. The second block of code uses the inplace method +=, which is more efficient. This is especially important when trying to construct a very large FermionOperator. FermionOperators also support a wide range of builtins including, str(), repr(), *=, *, /, /=, +, +=, -, -=, - and **. Note that instead of supporting != and ==, we have the method  == , since FermionOperators involve floats. We demonstrate some of these methods below."
+    "The print function prints each term in the operator on a different line. Note that the line my_operator = term_1 + term_2 creates a new object, which involves a copy of term_1 and term_2. The second block of code uses the inplace method +=, which is more efficient. This is especially important when trying to construct a very large FermionOperator. FermionOperators also support a wide range of builtins including, str(), repr(), ==, !=, *=, *, /, /=, +, +=, -, -=, - and **. Note that since FermionOperators involve floats, == and != check for (in)equality up to numerical precision. We demonstrate some of these methods below."
    ]
   },
   {

--- a/src/openfermion/hamiltonians/_jellium_test.py
+++ b/src/openfermion/hamiltonians/_jellium_test.py
@@ -304,7 +304,7 @@ class JelliumTest(unittest.TestCase):
         test_hamiltonian = jordan_wigner_dual_basis_jellium(grid, spinless)
 
         # Make sure Hamiltonians are the same.
-        self.assertTrue(test_hamiltonian.isclose(qubit_hamiltonian))
+        self.assertTrue(test_hamiltonian == qubit_hamiltonian)
 
         # Check number of terms.
         n_qubits = count_qubits(qubit_hamiltonian)
@@ -328,7 +328,7 @@ class JelliumTest(unittest.TestCase):
         difference = hamiltonian_with_constant - hamiltonian_without_constant
         expected = QubitOperator('') * (2.8372 / length_scale)
 
-        self.assertTrue(expected.isclose(difference))
+        self.assertTrue(expected == difference)
 
     def test_plane_wave_energy_cutoff(self):
         grid = Grid(dimensions=1, length=5, scale=1.0)

--- a/src/openfermion/hamiltonians/_plane_wave_hamiltonian_test.py
+++ b/src/openfermion/hamiltonians/_plane_wave_hamiltonian_test.py
@@ -121,7 +121,7 @@ class PlaneWaveHamiltonianTest(unittest.TestCase):
 
         test_hamiltonian = jordan_wigner_dual_basis_hamiltonian(
             grid, geometry, spinless, include_constant=True)
-        self.assertTrue(test_hamiltonian.isclose(qubit_hamiltonian))
+        self.assertTrue(test_hamiltonian == qubit_hamiltonian)
 
     def test_jordan_wigner_dual_basis_hamiltonian_default_to_jellium(self):
         grid = Grid(dimensions=1, scale=1.0, length=4)

--- a/src/openfermion/hamiltonians/_plane_wave_hamiltonian_test.py
+++ b/src/openfermion/hamiltonians/_plane_wave_hamiltonian_test.py
@@ -96,8 +96,7 @@ class PlaneWaveHamiltonianTest(unittest.TestCase):
 
     def test_plane_wave_hamiltonian_default_to_jellium_with_no_geometry(self):
         grid = Grid(dimensions=1, scale=1.0, length=4)
-        self.assertTrue(plane_wave_hamiltonian(grid).isclose(
-            jellium_model(grid)))
+        self.assertTrue(plane_wave_hamiltonian(grid) == jellium_model(grid))
 
     def test_plane_wave_hamiltonian_bad_geometry(self):
         grid = Grid(dimensions=1, scale=1.0, length=4)
@@ -125,8 +124,8 @@ class PlaneWaveHamiltonianTest(unittest.TestCase):
 
     def test_jordan_wigner_dual_basis_hamiltonian_default_to_jellium(self):
         grid = Grid(dimensions=1, scale=1.0, length=4)
-        self.assertTrue(jordan_wigner_dual_basis_hamiltonian(grid).isclose(
-            jordan_wigner(jellium_model(grid, plane_wave=False))))
+        self.assertTrue(jordan_wigner_dual_basis_hamiltonian(grid) ==
+            jordan_wigner(jellium_model(grid, plane_wave=False)))
 
     def test_jordan_wigner_dual_basis_hamiltonian_bad_geometry(self):
         grid = Grid(dimensions=1, scale=1.0, length=4)

--- a/src/openfermion/ops/_fermion_operator_test.py
+++ b/src/openfermion/ops/_fermion_operator_test.py
@@ -26,7 +26,7 @@ class FermionOperatorTest(unittest.TestCase):
 
     def test_number_operator_site(self):
         op = number_operator(3, 2, 1j)
-        self.assertTrue(op.isclose(FermionOperator(((2, 1), (2, 0))) * 1j))
+        self.assertTrue(op == FermionOperator(((2, 1), (2, 0))) * 1j)
 
     def test_number_operator_nosite(self):
         op = number_operator(4)
@@ -34,7 +34,7 @@ class FermionOperatorTest(unittest.TestCase):
                     FermionOperator(((1, 1), (1, 0))) +
                     FermionOperator(((2, 1), (2, 0))) +
                     FermionOperator(((3, 1), (3, 0))))
-        self.assertTrue(op.isclose(expected))
+        self.assertTrue(op == expected)
 
     def test_is_normal_ordered_empty(self):
         op = FermionOperator() * 2
@@ -72,58 +72,58 @@ class FermionOperatorTest(unittest.TestCase):
 
     def test_normal_ordered_single_term(self):
         op = FermionOperator('4 3 2 1') + FermionOperator('3 2')
-        self.assertTrue(op.isclose(normal_ordered(op)))
+        self.assertTrue(op == normal_ordered(op))
 
     def test_normal_ordered_two_term(self):
         op_b = FermionOperator(((2, 0), (4, 0), (2, 1)), -88.)
         normal_ordered_b = normal_ordered(op_b)
         expected = (FermionOperator(((4, 0),), 88.) +
                     FermionOperator(((2, 1), (4, 0), (2, 0)), 88.))
-        self.assertTrue(normal_ordered_b.isclose(expected))
+        self.assertTrue(normal_ordered_b == expected)
 
     def test_normal_ordered_number(self):
         number_op2 = FermionOperator(((2, 1), (2, 0)))
-        self.assertTrue(number_op2.isclose(normal_ordered(number_op2)))
+        self.assertTrue(number_op2 == normal_ordered(number_op2))
 
     def test_normal_ordered_number_reversed(self):
         n_term_rev2 = FermionOperator(((2, 0), (2, 1)))
         number_op2 = number_operator(3, 2)
         expected = FermionOperator(()) - number_op2
-        self.assertTrue(normal_ordered(n_term_rev2).isclose(expected))
+        self.assertTrue(normal_ordered(n_term_rev2) == expected)
 
     def test_normal_ordered_offsite(self):
         op = FermionOperator(((3, 1), (2, 0)))
-        self.assertTrue(op.isclose(normal_ordered(op)))
+        self.assertTrue(op == normal_ordered(op))
 
     def test_normal_ordered_offsite_reversed(self):
         op = FermionOperator(((3, 0), (2, 1)))
         expected = -FermionOperator(((2, 1), (3, 0)))
-        self.assertTrue(expected.isclose(normal_ordered(op)))
+        self.assertTrue(expected == normal_ordered(op))
 
     def test_normal_ordered_double_create(self):
         op = FermionOperator(((2, 0), (3, 1), (3, 1)))
         expected = FermionOperator((), 0.0)
-        self.assertTrue(expected.isclose(normal_ordered(op)))
+        self.assertTrue(expected == normal_ordered(op))
 
     def test_normal_ordered_double_create_separated(self):
         op = FermionOperator(((3, 1), (2, 0), (3, 1)))
         expected = FermionOperator((), 0.0)
-        self.assertTrue(expected.isclose(normal_ordered(op)))
+        self.assertTrue(expected == normal_ordered(op))
 
     def test_normal_ordered_multi(self):
         op = FermionOperator(((2, 0), (1, 1), (2, 1)))
         expected = (-FermionOperator(((2, 1), (1, 1), (2, 0))) -
                     FermionOperator(((1, 1),)))
-        self.assertTrue(expected.isclose(normal_ordered(op)))
+        self.assertTrue(expected == normal_ordered(op))
 
     def test_normal_ordered_triple(self):
         op_132 = FermionOperator(((1, 1), (3, 0), (2, 0)))
         op_123 = FermionOperator(((1, 1), (2, 0), (3, 0)))
         op_321 = FermionOperator(((3, 0), (2, 0), (1, 1)))
 
-        self.assertTrue(op_132.isclose(normal_ordered(-op_123)))
-        self.assertTrue(op_132.isclose(normal_ordered(op_132)))
-        self.assertTrue(op_132.isclose(normal_ordered(op_321)))
+        self.assertTrue(op_132 == normal_ordered(-op_123))
+        self.assertTrue(op_132 == normal_ordered(op_132))
+        self.assertTrue(op_132 == normal_ordered(op_321))
 
     def test_is_molecular_term_FermionOperator(self):
         op = FermionOperator()
@@ -157,7 +157,7 @@ class FermionOperatorTest(unittest.TestCase):
         op = FermionOperator(((1, 1), (1, 0), (0, 1), (2, 0)))
         op_frozen = freeze_orbitals(op,[1])
         expected = FermionOperator(((0, 1), (1, 0)), -1)
-        self.assertTrue(op_frozen.isclose(expected))
+        self.assertTrue(op_frozen == expected)
 
     def test_freeze_orbitals_vanishing(self):
         op = FermionOperator(((1, 1), (2, 0)))

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -162,7 +162,7 @@ class QuadraticHamiltoniansTest(unittest.TestCase):
         fermion_operator = normal_ordered(
             get_fermion_operator(self.quad_ham_npc))
         self.assertTrue(
-            normal_ordered(majorana_op).isclose(fermion_operator))
+            normal_ordered(majorana_op) == fermion_operator)
 
     def test_diagonalizing_bogoliubov_transform(self):
         """Test getting the diagonalizing Bogoliubov transformation."""
@@ -208,7 +208,7 @@ class MajoranaOperatorTest(unittest.TestCase):
 
     def test_none_term(self):
         majorana_op = majorana_operator()
-        self.assertTrue(majorana_operator().isclose(FermionOperator()))
+        self.assertTrue(majorana_operator() == FermionOperator())
 
     def test_bad_coefficient(self):
         with self.assertRaises(ValueError):

--- a/src/openfermion/ops/_qubit_operator_test.py
+++ b/src/openfermion/ops/_qubit_operator_test.py
@@ -113,14 +113,14 @@ def test_mul_out_of_place():
     correct_term = ((0, 'Y'), (1, 'X'), (3, 'Z'), (11, 'X'))
     assert op1.isclose(QubitOperator(
         ((0, 'Y'), (3, 'X'), (8, 'Z'), (11, 'X')), 3.j))
-    assert op2.isclose(QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5))
-    assert op3.isclose(QubitOperator(correct_term, correct_coefficient))
+    assert op2 == QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+    assert op3 == QubitOperator(correct_term, correct_coefficient)
 
 
 def test_mul_npfloat64():
     op = QubitOperator(((1, 'X'), (3, 'Y')), 0.5)
     res = op * numpy.float64(0.5)
-    assert res.isclose(QubitOperator(((1, 'X'), (3, 'Y')), 0.5 * 0.5))
+    assert res == QubitOperator(((1, 'X'), (3, 'Y')), 0.5 * 0.5)
 
 
 def test_mul_multiple_terms():
@@ -131,7 +131,7 @@ def test_mul_multiple_terms():
     correct = QubitOperator((), 0.5**2 + 1.2**2 + 1.4j**2)
     correct += QubitOperator(((1, 'Y'), (3, 'Z')),
                              2j * 1j * 0.5 * 1.2)
-    assert res.isclose(correct)
+    assert res == correct
 
 
 def test_renormalize_error():

--- a/src/openfermion/ops/_qubit_operator_test.py
+++ b/src/openfermion/ops/_qubit_operator_test.py
@@ -111,8 +111,7 @@ def test_mul_out_of_place():
     op3 = op1 * op2
     correct_coefficient = 1.j * 3.0j * 0.5
     correct_term = ((0, 'Y'), (1, 'X'), (3, 'Z'), (11, 'X'))
-    assert op1.isclose(QubitOperator(
-        ((0, 'Y'), (3, 'X'), (8, 'Z'), (11, 'X')), 3.j))
+    assert op1 == QubitOperator(((0, 'Y'), (3, 'X'), (8, 'Z'), (11, 'X')), 3.j)
     assert op2 == QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
     assert op3 == QubitOperator(correct_term, correct_coefficient)
 

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -550,7 +550,9 @@ class SymbolicOperator(object):
         for term in set(self.terms).intersection(set(other.terms)):
             a = self.terms[term]
             b = other.terms[term]
-            if not abs(a - b) <= EQ_TOLERANCE:
+            # math.isclose does this in Python >=3.5
+            if not abs(a - b) <= max(EQ_TOLERANCE,
+                                     EQ_TOLERANCE * max(abs(a), abs(b))):
                 return False
         # terms only in one (compare to 0.0 so only abs_tol)
         for term in set(self.terms).symmetric_difference(set(other.terms)):

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -530,6 +530,11 @@ class SymbolicOperator(object):
             exponentiated *= self
         return exponentiated
 
+    def __eq__(self, other):
+        return self.isclose(other)
+
+    __hash__ = None
+
     def compress(self, abs_tol=EQ_TOLERANCE):
         """
         Eliminates all terms with coefficients close to zero and removes

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -103,48 +103,48 @@ class SymbolicOperatorTest1(unittest.TestCase):
         f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
         g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
         h = f + g
-        self.assertTrue(f.isclose(u * f))
-        self.assertTrue(f.isclose(f * u))
-        self.assertTrue(g.isclose(u * g))
-        self.assertTrue(g.isclose(g * u))
-        self.assertTrue(h.isclose(u * h))
-        self.assertTrue(h.isclose(h * u))
+        self.assertTrue(f == u * f)
+        self.assertTrue(f == f * u)
+        self.assertTrue(g == u * g)
+        self.assertTrue(g == g * u)
+        self.assertTrue(h == u * h)
+        self.assertTrue(h == h * u)
 
         u *= h
-        self.assertTrue(h.isclose(u))
-        self.assertFalse(f.isclose(u))
+        self.assertTrue(h == u)
+        self.assertFalse(f == u)
 
         # Method always returns new instances.
-        self.assertFalse(DummyOperator1.identity().isclose(u))
+        self.assertFalse(DummyOperator1.identity() == u)
 
     def test_zero_is_additive_identity(self):
         o = DummyOperator1.zero()
         f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
         g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
         h = f + g
-        self.assertTrue(f.isclose(o + f))
-        self.assertTrue(f.isclose(f + o))
-        self.assertTrue(g.isclose(o + g))
-        self.assertTrue(g.isclose(g + o))
-        self.assertTrue(h.isclose(o + h))
-        self.assertTrue(h.isclose(h + o))
+        self.assertTrue(f == o + f)
+        self.assertTrue(f == f + o)
+        self.assertTrue(g == o + g)
+        self.assertTrue(g == g + o)
+        self.assertTrue(h == o + h)
+        self.assertTrue(h == h + o)
 
         o += h
-        self.assertTrue(h.isclose(o))
-        self.assertFalse(f.isclose(o))
+        self.assertTrue(h == o)
+        self.assertFalse(f == o)
 
         # Method always returns new instances.
-        self.assertFalse(DummyOperator1.zero().isclose(o))
+        self.assertFalse(DummyOperator1.zero() == o)
 
     def test_zero_is_multiplicative_nil(self):
         o = DummyOperator1.zero()
         u = DummyOperator1.identity()
         f = DummyOperator1(((0, 1), (5, 0), (6, 1)), 0.6j)
         g = DummyOperator1(((0, 0), (5, 0), (6, 1)), 0.3j)
-        self.assertTrue(o.isclose(o * u))
-        self.assertTrue(o.isclose(o * f))
-        self.assertTrue(o.isclose(o * g))
-        self.assertTrue(o.isclose(o * (f + g)))
+        self.assertTrue(o == o * u)
+        self.assertTrue(o == o * f)
+        self.assertTrue(o == o * g)
+        self.assertTrue(o == o * (f + g))
 
     def test_init_str(self):
         fermion_op = DummyOperator1('0^ 5 12^', -1.)
@@ -213,27 +213,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
 
     def test_DummyOperator1(self):
         op = DummyOperator1((), 3.)
-        self.assertTrue(op.isclose(DummyOperator1(()) * 3.))
-
-    def test_isclose_abs_tol(self):
-        a = DummyOperator1('0^', -1.)
-        b = DummyOperator1('0^', -1.05)
-        c = DummyOperator1('0^', -1.11)
-        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
-        self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
-        a = DummyOperator1('0^', -1.0j)
-        b = DummyOperator1('0^', -1.05j)
-        c = DummyOperator1('0^', -1.11j)
-        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
-        self.assertFalse(a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
-
-    def test_isclose_rel_tol(self):
-        a = DummyOperator1('0', 1)
-        b = DummyOperator1('0', 2)
-        self.assertTrue(a.isclose(b, rel_tol=2.5, abs_tol=0.1))
-        # Test symmetry
-        self.assertTrue(a.isclose(b, rel_tol=1, abs_tol=0.1))
-        self.assertTrue(b.isclose(a, rel_tol=1, abs_tol=0.1))
+        self.assertTrue(op == DummyOperator1(()) * 3.)
 
     def test_isclose_zero_terms(self):
         op = DummyOperator1('1^ 0', -1j) * 0
@@ -245,17 +225,17 @@ class SymbolicOperatorTest1(unittest.TestCase):
     def test_isclose_different_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
         b = DummyOperator1(((1, 1),), -0.1j)
-        self.assertTrue(a.isclose(b, rel_tol=1e-12, abs_tol=0.2))
-        self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
-        self.assertTrue(b.isclose(a, rel_tol=1e-12, abs_tol=0.2))
-        self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(a == b, rel_tol=1e-12, abs_tol=0.2)
+        self.assertFalse(a == b, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(b == a, rel_tol=1e-12, abs_tol=0.2)
+        self.assertFalse(b == a, rel_tol=1e-12, abs_tol=0.05)
 
     def test_isclose_different_num_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
         a += DummyOperator1(((1, 1),), -0.1j)
         b = DummyOperator1(((1, 0),), -0.1j)
-        self.assertFalse(b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
-        self.assertFalse(a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+        self.assertFalse(b == a, rel_tol=1e-12, abs_tol=0.05)
+        self.assertFalse(a == b, rel_tol=1e-12, abs_tol=0.05)
 
     def test_imul_inplace(self):
         fermion_op = DummyOperator1("1^")
@@ -380,35 +360,35 @@ class SymbolicOperatorTest1(unittest.TestCase):
         correct += (DummyOperator1(((1, 0), (8, 1), (1, 1), (9, 1)), 0.7j) +
                     DummyOperator1(((1, 1), (9, 1), (1, 0), (8, 1)), 0.7j))
         correct += DummyOperator1(((1, 1), (9, 1), (1, 1), (9, 1)), 1.4j ** 2)
-        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res == correct)
 
     def test_rmul_scalar_real(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = 0.5
         res1 = op * multiplier
         res2 = multiplier * op
-        self.assertTrue(res1.isclose(res2))
+        self.assertTrue(res1 == res2)
 
     def test_rmul_scalar_complex(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = 0.6j
         res1 = op * multiplier
         res2 = multiplier * op
-        self.assertTrue(res1.isclose(res2))
+        self.assertTrue(res1 == res2)
 
     def test_rmul_scalar_npfloat64(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = numpy.float64(2.303)
         res1 = op * multiplier
         res2 = multiplier * op
-        self.assertTrue(res1.isclose(res2))
+        self.assertTrue(res1 == res2)
 
     def test_rmul_scalar_npcomplex128(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
         multiplier = numpy.complex128(-1.5j + 7.7)
         res1 = op * multiplier
         res2 = multiplier * op
-        self.assertTrue(res1.isclose(res2))
+        self.assertTrue(res1 == res2)
 
     def test_rmul_bad_multiplier(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -421,9 +401,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         res = op / divisor
         correct = op * (1. / divisor)
-        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res == correct)
         # Test if done out of place
-        self.assertTrue(op.isclose(original))
+        self.assertTrue(op == original)
 
     def test_truediv_and_div_complex(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -431,9 +411,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         res = op / divisor
         correct = op * (1. / divisor)
-        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res == correct)
         # Test if done out of place
-        self.assertTrue(op.isclose(original))
+        self.assertTrue(op == original)
 
     def test_truediv_and_div_npfloat64(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -441,9 +421,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         res = op / divisor
         correct = op * (1. / divisor)
-        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res == correct)
         # Test if done out of place
-        self.assertTrue(op.isclose(original))
+        self.assertTrue(op == original)
 
     def test_truediv_and_div_npcomplex128(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -451,9 +431,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         res = op / divisor
         correct = op * (1. / divisor)
-        self.assertTrue(res.isclose(correct))
+        self.assertTrue(res == correct)
         # Test if done out of place
-        self.assertTrue(op.isclose(original))
+        self.assertTrue(op == original)
 
     def test_truediv_bad_divisor(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -466,9 +446,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
         op /= divisor
-        self.assertTrue(op.isclose(correct))
+        self.assertTrue(op == correct)
         # Test if done in-place
-        self.assertFalse(op.isclose(original))
+        self.assertFalse(op == original)
 
     def test_itruediv_and_idiv_complex(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -476,9 +456,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
         op /= divisor
-        self.assertTrue(op.isclose(correct))
+        self.assertTrue(op == correct)
         # Test if done in-place
-        self.assertFalse(op.isclose(original))
+        self.assertFalse(op == original)
 
     def test_itruediv_and_idiv_npfloat64(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -486,9 +466,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
         op /= divisor
-        self.assertTrue(op.isclose(correct))
+        self.assertTrue(op == correct)
         # Test if done in-place
-        self.assertFalse(op.isclose(original))
+        self.assertFalse(op == original)
 
     def test_itruediv_and_idiv_npcomplex128(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -496,9 +476,9 @@ class SymbolicOperatorTest1(unittest.TestCase):
         original = copy.deepcopy(op)
         correct = op * (1. / divisor)
         op /= divisor
-        self.assertTrue(op.isclose(correct))
+        self.assertTrue(op == correct)
         # Test if done in-place
-        self.assertFalse(op.isclose(original))
+        self.assertFalse(op == original)
 
     def test_itruediv_bad_divisor(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -533,8 +513,8 @@ class SymbolicOperatorTest1(unittest.TestCase):
         self.assertEqual(res.terms[term_a], 1.0)
         self.assertEqual(res.terms[term_b], 1.0)
         # Test out of place
-        self.assertTrue(a.isclose(DummyOperator1(term_a, 1.0)))
-        self.assertTrue(b.isclose(DummyOperator1(term_b, 0.5)))
+        self.assertTrue(a == DummyOperator1(term_a, 1.0))
+        self.assertTrue(b == DummyOperator1(term_b, 0.5))
 
     def test_add_bad_addend(self):
         op = DummyOperator1((), 1.0)
@@ -585,7 +565,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
         self.assertTrue(op.isclose(DummyOperator1(((1, 1), (3, 1), (8, 1)),
                                                   0.5)))
         correct = -1.0 * op
-        self.assertTrue(correct.isclose(-op))
+        self.assertTrue(correct == -op)
 
     def test_pow_square_term(self):
         coeff = 6.7j
@@ -593,8 +573,8 @@ class SymbolicOperatorTest1(unittest.TestCase):
         term = DummyOperator1(ops, coeff)
         squared = term ** 2
         expected = DummyOperator1(ops + ops, coeff ** 2)
-        self.assertTrue(squared.isclose(term * term))
-        self.assertTrue(squared.isclose(expected))
+        self.assertTrue(squared == term * term)
+        self.assertTrue(squared == expected)
 
     def test_pow_zero_term(self):
         coeff = 6.7j
@@ -602,13 +582,13 @@ class SymbolicOperatorTest1(unittest.TestCase):
         term = DummyOperator1(ops, coeff)
         zerod = term ** 0
         expected = DummyOperator1(())
-        self.assertTrue(expected.isclose(zerod))
+        self.assertTrue(expected == zerod)
 
     def test_pow_one_term(self):
         coeff = 6.7j
         ops = ((3, 1), (1, 0), (4, 1))
         term = DummyOperator1(ops, coeff)
-        self.assertTrue(term.isclose(term ** 1))
+        self.assertTrue(term == term ** 1)
 
     def test_pow_high_term(self):
         coeff = 6.7j
@@ -616,7 +596,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
         term = DummyOperator1(ops, coeff)
         high = term ** 10
         expected = DummyOperator1(ops * 10, coeff ** 10)
-        self.assertTrue(expected.isclose(high))
+        self.assertTrue(expected == high)
 
     def test_pow_neg_error(self):
         with self.assertRaises(ValueError):
@@ -633,7 +613,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
         op_compressed = (DummyOperator1('3^ 1', 0.3) +
                          DummyOperator1('1^ 3', 1e-3))
         op.compress(1e-7)
-        self.assertTrue(op_compressed.isclose(op))
+        self.assertTrue(op_compressed == op)
 
     def test_str(self):
         op = DummyOperator1(((1, 1), (3, 0), (8, 1)), 0.5)
@@ -688,8 +668,8 @@ class SymbolicOperatorTest2(unittest.TestCase):
 
         qubit_op = DummyOperator2('[X0 X1] + [Y0 Y1]')
         correct = DummyOperator2('X0 X1') + DummyOperator2('Y0 Y1')
-        self.assertTrue(qubit_op.isclose(correct))
-        self.assertTrue(qubit_op.isclose(DummyOperator2(str(qubit_op))))
+        self.assertTrue(qubit_op == correct)
+        self.assertTrue(qubit_op == DummyOperator2(str(qubit_op)))
 
     def test_init_str_identity(self):
         qubit_op = DummyOperator2('', 2.)
@@ -733,13 +713,13 @@ class SymbolicOperatorTest2(unittest.TestCase):
         a = DummyOperator2('X0', -1.)
         b = DummyOperator2('X0', -1.05)
         c = DummyOperator2('X0', -1.11)
-        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
-        self.assertTrue(not a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+        self.assertTrue(a == b, rel_tol=1e-14, abs_tol=0.1)
+        self.assertTrue(not a == c, rel_tol=1e-14, abs_tol=0.1)
         a = DummyOperator2('X0', -1.0j)
         b = DummyOperator2('X0', -1.05j)
         c = DummyOperator2('X0', -1.11j)
-        self.assertTrue(a.isclose(b, rel_tol=1e-14, abs_tol=0.1))
-        self.assertTrue(not a.isclose(c, rel_tol=1e-14, abs_tol=0.1))
+        self.assertTrue(a == b, rel_tol=1e-14, abs_tol=0.1)
+        self.assertTrue(not a == c, rel_tol=1e-14, abs_tol=0.1)
 
     def test_compress(self):
         a = DummyOperator2('X0', .9e-12)
@@ -773,10 +753,10 @@ class SymbolicOperatorTest2(unittest.TestCase):
     def test_isclose_rel_tol(self):
         a = DummyOperator2('X0', 1)
         b = DummyOperator2('X0', 2)
-        self.assertTrue(a.isclose(b, rel_tol=2.5, abs_tol=0.1))
+        self.assertTrue(a == b, rel_tol=2.5, abs_tol=0.1)
         # Test symmetry
-        self.assertTrue(a.isclose(b, rel_tol=1, abs_tol=0.1))
-        self.assertTrue(b.isclose(a, rel_tol=1, abs_tol=0.1))
+        self.assertTrue(a == b, rel_tol=1, abs_tol=0.1)
+        self.assertTrue(b == a, rel_tol=1, abs_tol=0.1)
 
     def test_isclose_zero_terms(self):
         op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
@@ -788,30 +768,30 @@ class SymbolicOperatorTest2(unittest.TestCase):
     def test_isclose_different_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
         b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(a.isclose(b, rel_tol=1e-12, abs_tol=0.2))
-        self.assertTrue(not a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
-        self.assertTrue(b.isclose(a, rel_tol=1e-12, abs_tol=0.2))
-        self.assertTrue(not b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(a == b, rel_tol=1e-12, abs_tol=0.2)
+        self.assertTrue(not a == b, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(b == a, rel_tol=1e-12, abs_tol=0.2)
+        self.assertTrue(not b == a, rel_tol=1e-12, abs_tol=0.05)
 
     def test_isclose_different_num_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
         a += DummyOperator2(((2, 'Y'),), -0.1j)
         b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not b.isclose(a, rel_tol=1e-12, abs_tol=0.05))
-        self.assertTrue(not a.isclose(b, rel_tol=1e-12, abs_tol=0.05))
+        self.assertTrue(not b == a, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(not a == b, rel_tol=1e-12, abs_tol=0.05)
 
     def test_isclose_invalid_type(self):
         a = DummyOperator1()
         b = DummyOperator2()
         with self.assertRaises(TypeError):
-            a.isclose(b)
+            a == b
 
     def test_rmul_scalar(self):
         multiplier = 0.5
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         res1 = op * multiplier
         res2 = multiplier * op
-        self.assertTrue(res1.isclose(res2))
+        self.assertTrue(res1 == res2)
 
     def test_rmul_bad_multiplier(self):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
@@ -826,11 +806,11 @@ class SymbolicOperatorTest2(unittest.TestCase):
         res = op / divisor
         res2 = op2.__div__(divisor)  # To test python 2 version as well
         correct = op * (1. / divisor)
-        self.assertTrue(res.isclose(correct))
-        self.assertTrue(res2.isclose(correct))
+        self.assertTrue(res == correct)
+        self.assertTrue(res2 == correct)
         # Test if done out of place
-        self.assertTrue(op.isclose(original))
-        self.assertTrue(op2.isclose(original))
+        self.assertTrue(op == original)
+        self.assertTrue(op2 == original)
 
     def test_truediv_bad_divisor(self):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
@@ -845,11 +825,11 @@ class SymbolicOperatorTest2(unittest.TestCase):
         correct = op * (1. / divisor)
         op /= divisor
         op2.__idiv__(divisor)  # To test python 2 version as well
-        self.assertTrue(op.isclose(correct))
-        self.assertTrue(op2.isclose(correct))
+        self.assertTrue(op == correct)
+        self.assertTrue(op2 == correct)
         # Test if done in-place
-        self.assertTrue(not op.isclose(original))
-        self.assertTrue(not op2.isclose(original))
+        self.assertTrue(not op == original)
+        self.assertTrue(not op2 == original)
 
     def test_itruediv_bad_divisor(self):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
@@ -891,8 +871,8 @@ class SymbolicOperatorTest2(unittest.TestCase):
         self.assertAlmostEqual(res.terms[term_a], 1.0)
         self.assertAlmostEqual(res.terms[term_b], 1.0)
         # Test out of place
-        self.assertTrue(a.isclose(DummyOperator2(term_a, 1.0)))
-        self.assertTrue(b.isclose(DummyOperator2(term_b, 0.5)))
+        self.assertTrue(a == DummyOperator2(term_a, 1.0))
+        self.assertTrue(b == DummyOperator2(term_b, 0.5))
 
     def test_add_bad_addend(self):
         op = DummyOperator2((), 1.0)
@@ -943,7 +923,7 @@ class SymbolicOperatorTest2(unittest.TestCase):
         self.assertTrue(op.isclose(
             DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)))
         correct = -1.0 * op
-        self.assertTrue(correct.isclose(-op))
+        self.assertTrue(correct == -op)
 
     def test_str(self):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
@@ -985,4 +965,4 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = DummyOperator1(((1, 1), (8, 1), (3, 0)), 0.5)
         op = prune_unused_indices(op)
         expected = DummyOperator1(((0, 1), (2, 1), (1, 0)), 0.5)
-        self.assertTrue(expected.isclose(op))
+        self.assertTrue(expected == op)

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -217,25 +217,23 @@ class SymbolicOperatorTest1(unittest.TestCase):
 
     def test_isclose_zero_terms(self):
         op = DummyOperator1('1^ 0', -1j) * 0
-        self.assertTrue(op.isclose(DummyOperator1((), 0.0),
-                                   rel_tol=1e-12, abs_tol=1e-12))
-        self.assertTrue(DummyOperator1().isclose(
-            op, rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(op == DummyOperator1())
+        self.assertTrue(DummyOperator1() == op)
 
     def test_isclose_different_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
         b = DummyOperator1(((1, 1),), -0.1j)
-        self.assertTrue(a == b, rel_tol=1e-12, abs_tol=0.2)
-        self.assertFalse(a == b, rel_tol=1e-12, abs_tol=0.05)
-        self.assertTrue(b == a, rel_tol=1e-12, abs_tol=0.2)
-        self.assertFalse(b == a, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(a == b)
+        self.assertFalse(a == b)
+        self.assertTrue(b == a)
+        self.assertFalse(b == a)
 
     def test_isclose_different_num_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
         a += DummyOperator1(((1, 1),), -0.1j)
         b = DummyOperator1(((1, 0),), -0.1j)
-        self.assertFalse(b == a, rel_tol=1e-12, abs_tol=0.05)
-        self.assertFalse(a == b, rel_tol=1e-12, abs_tol=0.05)
+        self.assertFalse(b == a)
+        self.assertFalse(a == b)
 
     def test_imul_inplace(self):
         fermion_op = DummyOperator1("1^")
@@ -709,18 +707,6 @@ class SymbolicOperatorTest2(unittest.TestCase):
         with self.assertRaises(ValueError):
             qubit_op = DummyOperator2('X-1')
 
-    def test_isclose_abs_tol(self):
-        a = DummyOperator2('X0', -1.)
-        b = DummyOperator2('X0', -1.05)
-        c = DummyOperator2('X0', -1.11)
-        self.assertTrue(a == b, rel_tol=1e-14, abs_tol=0.1)
-        self.assertTrue(not a == c, rel_tol=1e-14, abs_tol=0.1)
-        a = DummyOperator2('X0', -1.0j)
-        b = DummyOperator2('X0', -1.05j)
-        c = DummyOperator2('X0', -1.11j)
-        self.assertTrue(a == b, rel_tol=1e-14, abs_tol=0.1)
-        self.assertTrue(not a == c, rel_tol=1e-14, abs_tol=0.1)
-
     def test_compress(self):
         a = DummyOperator2('X0', .9e-12)
         self.assertTrue(len(a.terms) == 1)
@@ -750,35 +736,25 @@ class SymbolicOperatorTest2(unittest.TestCase):
         for term in a.terms:
             self.assertTrue(isinstance(a.terms[term], float))
 
-    def test_isclose_rel_tol(self):
-        a = DummyOperator2('X0', 1)
-        b = DummyOperator2('X0', 2)
-        self.assertTrue(a == b, rel_tol=2.5, abs_tol=0.1)
-        # Test symmetry
-        self.assertTrue(a == b, rel_tol=1, abs_tol=0.1)
-        self.assertTrue(b == a, rel_tol=1, abs_tol=0.1)
-
     def test_isclose_zero_terms(self):
         op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
-        self.assertTrue(op.isclose(
-            DummyOperator2((), 0.0), rel_tol=1e-12, abs_tol=1e-12))
-        self.assertTrue(DummyOperator2((), 0.0).isclose(
-            op, rel_tol=1e-12, abs_tol=1e-12))
+        self.assertTrue(op == DummyOperator2())
+        self.assertTrue(DummyOperator2((), 0.0) == op)
 
     def test_isclose_different_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
         b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(a == b, rel_tol=1e-12, abs_tol=0.2)
-        self.assertTrue(not a == b, rel_tol=1e-12, abs_tol=0.05)
-        self.assertTrue(b == a, rel_tol=1e-12, abs_tol=0.2)
-        self.assertTrue(not b == a, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(a == b)
+        self.assertTrue(not a == b)
+        self.assertTrue(b == a)
+        self.assertTrue(not b == a)
 
     def test_isclose_different_num_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
         a += DummyOperator2(((2, 'Y'),), -0.1j)
         b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not b == a, rel_tol=1e-12, abs_tol=0.05)
-        self.assertTrue(not a == b, rel_tol=1e-12, abs_tol=0.05)
+        self.assertTrue(not b == a)
+        self.assertTrue(not a == b)
 
     def test_isclose_invalid_type(self):
         a = DummyOperator1()

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -223,10 +223,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
     def test_isclose_different_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
         b = DummyOperator1(((1, 1),), -0.1j)
-        self.assertTrue(a == b)
         self.assertFalse(a == b)
-        self.assertTrue(b == a)
-        self.assertFalse(b == a)
 
     def test_isclose_different_num_terms(self):
         a = DummyOperator1(((1, 0),), -0.1j)
@@ -337,18 +334,16 @@ class SymbolicOperatorTest1(unittest.TestCase):
         correct_coefficient = 3.0j * 0.5
         correct_term = ((0, 1), (3, 1), (3, 0), (11, 1),
                         (1, 1), (3, 1), (8, 0))
-        self.assertTrue(op1.isclose(DummyOperator1(
-            ((0, 1), (3, 1), (3, 0), (11, 1)), 3.j)))
-        self.assertTrue(op2.isclose(DummyOperator1(((1, 1), (3, 1), (8, 0)),
-                                                   0.5)))
-        self.assertTrue(op3.isclose(DummyOperator1(correct_term,
-                                                   correct_coefficient)))
+        self.assertTrue(op1 == DummyOperator1(
+            ((0, 1), (3, 1), (3, 0), (11, 1)), 3.j))
+        self.assertTrue(op2 == DummyOperator1(((1, 1), (3, 1), (8, 0)), 0.5))
+        self.assertTrue(op3 == DummyOperator1(correct_term,
+                                              correct_coefficient))
 
     def test_mul_npfloat64(self):
         op = DummyOperator1(((1, 0), (3, 1)), 0.5)
         res = op * numpy.float64(0.5)
-        self.assertTrue(res.isclose(DummyOperator1(((1, 0), (3, 1)),
-                                                   0.5 * 0.5)))
+        self.assertTrue(res == DummyOperator1(((1, 0), (3, 1)), 0.5 * 0.5))
 
     def test_mul_multiple_terms(self):
         op = DummyOperator1(((1, 0), (8, 1)), 0.5)
@@ -560,8 +555,8 @@ class SymbolicOperatorTest1(unittest.TestCase):
         op = DummyOperator1(((1, 1), (3, 1), (8, 1)), 0.5)
         _ = -op
         # out of place
-        self.assertTrue(op.isclose(DummyOperator1(((1, 1), (3, 1), (8, 1)),
-                                                  0.5)))
+        self.assertTrue(op == DummyOperator1(((1, 1), (3, 1), (8, 1)),
+                                                  0.5))
         correct = -1.0 * op
         self.assertTrue(correct == -op)
 
@@ -744,9 +739,7 @@ class SymbolicOperatorTest2(unittest.TestCase):
     def test_isclose_different_terms(self):
         a = DummyOperator2(((1, 'Y'),), -0.1j)
         b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(a == b)
         self.assertTrue(not a == b)
-        self.assertTrue(b == a)
         self.assertTrue(not b == a)
 
     def test_isclose_different_num_terms(self):
@@ -896,8 +889,8 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         -op
         # out of place
-        self.assertTrue(op.isclose(
-            DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)))
+        self.assertTrue(op ==
+                DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5))
         correct = -1.0 * op
         self.assertTrue(correct == -op)
 

--- a/src/openfermion/tests/_hydrogen_integration_test.py
+++ b/src/openfermion/tests/_hydrogen_integration_test.py
@@ -168,7 +168,7 @@ class HydrogenIntegrationTest(unittest.TestCase):
     def test_reverse_jordan_wigner(self):
         fermion_hamiltonian = reverse_jordan_wigner(self.qubit_hamiltonian)
         fermion_hamiltonian = normal_ordered(fermion_hamiltonian)
-        self.assertTrue(self.fermion_hamiltonian.isclose(fermion_hamiltonian))
+        self.assertTrue(self.fermion_hamiltonian == fermion_hamiltonian)
 
     def test_interaction_operator_mapping(self):
 
@@ -176,11 +176,11 @@ class HydrogenIntegrationTest(unittest.TestCase):
         molecular_hamiltonian = get_interaction_operator(
             self.fermion_hamiltonian)
         fermion_hamiltonian = get_fermion_operator(molecular_hamiltonian)
-        self.assertTrue(self.fermion_hamiltonian.isclose(fermion_hamiltonian))
+        self.assertTrue(self.fermion_hamiltonian == fermion_hamiltonian)
 
         # Make sure mapping of InteractionOperator to QubitOperator works.
         qubit_hamiltonian = jordan_wigner(self.molecular_hamiltonian)
-        self.assertTrue(self.qubit_hamiltonian.isclose(qubit_hamiltonian))
+        self.assertTrue(self.qubit_hamiltonian == qubit_hamiltonian)
 
     def test_rdm_numerically(self):
 

--- a/src/openfermion/tests/_lih_integration_test.py
+++ b/src/openfermion/tests/_lih_integration_test.py
@@ -78,12 +78,12 @@ class LiHIntegrationTest(unittest.TestCase):
         # Test reverse Jordan-Wigner.
         fermion_hamiltonian = reverse_jordan_wigner(self.qubit_hamiltonian)
         fermion_hamiltonian = normal_ordered(fermion_hamiltonian)
-        self.assertTrue(self.fermion_hamiltonian.isclose(fermion_hamiltonian))
+        self.assertTrue(self.fermion_hamiltonian == fermion_hamiltonian)
 
         # Test mapping to interaction operator.
         fermion_hamiltonian = get_fermion_operator(self.molecular_hamiltonian)
         fermion_hamiltonian = normal_ordered(fermion_hamiltonian)
-        self.assertTrue(self.fermion_hamiltonian.isclose(fermion_hamiltonian))
+        self.assertTrue(self.fermion_hamiltonian == fermion_hamiltonian)
 
         # Test RDM energy.
         fci_rdm_energy = self.nuclear_repulsion

--- a/src/openfermion/tests/_lih_integration_test.py
+++ b/src/openfermion/tests/_lih_integration_test.py
@@ -135,5 +135,5 @@ class LiHIntegrationTest(unittest.TestCase):
         # as the occupied_indices option of get_molecular_hamiltonian.
         frozen_hamiltonian = freeze_orbitals(
                 get_fermion_operator(self.molecular_hamiltonian), [0, 1])
-        self.assertTrue(frozen_hamiltonian.isclose(
-                get_fermion_operator(self.molecular_hamiltonian_no_core)))
+        self.assertTrue(frozen_hamiltonian ==
+                get_fermion_operator(self.molecular_hamiltonian_no_core))

--- a/src/openfermion/transforms/_binary_code_transform_test.py
+++ b/src/openfermion/transforms/_binary_code_transform_test.py
@@ -23,7 +23,7 @@ class CodeTransformTest(unittest.TestCase):
                                                                      0.5)
         transform = binary_code_transform(hamiltonian, code)
         correct_op = QubitOperator('X0 Z1',0.25) + QubitOperator('X0',0.25)
-        self.assertTrue(transform.isclose(correct_op))
+        self.assertTrue(transform == correct_op)
 
         with self.assertRaises(TypeError):
             binary_code_transform('0^ 2', code)
@@ -41,7 +41,7 @@ class CodeTransformTest(unittest.TestCase):
                      QubitOperator('X0', -0.125) + \
                      QubitOperator('Y0', -0.125j) + \
                      QubitOperator('Y0 Z1', -0.125j)
-        self.assertTrue(transform.isclose(correct_op))
+        self.assertTrue(transform == correct_op)
 
         with self.assertRaises(ValueError):
             dissolve(((1, '1'),))

--- a/src/openfermion/transforms/_binary_codes_test.py
+++ b/src/openfermion/transforms/_binary_codes_test.py
@@ -57,7 +57,7 @@ class CodeTransformTest(unittest.TestCase):
         op2 = QubitOperator('Z0 Z1 Z2 Z3 Z4 X5', 0.5) \
               - QubitOperator('Z0 Z1 Z2 Z3 Z4 Y5', 0.5j)
         op1 = binary_code_transform(ferm_op, jordan_wigner_code(6))
-        self.assertTrue(op1.isclose(op2))
+        self.assertTrue(op1 == op2)
 
     def test_checksum_code(self):
         hamiltonian, gs_energy = lih_hamiltonian()

--- a/src/openfermion/transforms/_binary_codes_test.py
+++ b/src/openfermion/transforms/_binary_codes_test.py
@@ -44,14 +44,14 @@ class CodeTransformTest(unittest.TestCase):
         correct_op = QubitOperator(((1, 'Z'), (2, 'X'), (3, 'X'), (4, 'X')),
                                    0.5) + \
                      QubitOperator(((2, 'Y'), (3, 'X'), (4, 'X')), 0.5j)
-        self.assertTrue(qubit_op.isclose(correct_op))
+        self.assertTrue(qubit_op == correct_op)
         ferm_op = FermionOperator('2^')
         n_modes = 5
         qubit_op = binary_code_transform(ferm_op, parity_code(n_modes))
         correct_op = QubitOperator(((1, 'Z'), (2, 'X'), (3, 'X'), (4, 'X')),
                                    0.5) \
                      + QubitOperator(((2, 'Y'), (3, 'X'), (4, 'X')), -0.5j)
-        self.assertTrue(qubit_op.isclose(correct_op))
+        self.assertTrue(qubit_op == correct_op)
 
         ferm_op = FermionOperator('5^')
         op2 = QubitOperator('Z0 Z1 Z2 Z3 Z4 X5', 0.5) \

--- a/src/openfermion/transforms/_bksf_test.py
+++ b/src/openfermion/transforms/_bksf_test.py
@@ -81,14 +81,14 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         qterm_b1 = QubitOperator(correct_operators_b1, 1)
         qterm_b2 = QubitOperator(correct_operators_b2, 1)
         qterm_b3 = QubitOperator(correct_operators_b3, 1)
-        self.assertTrue(qterm_b0.isclose(
-                        _bksf.edge_operator_b(edge_matrix_indices, 0)))
-        self.assertTrue(qterm_b1.isclose(
-                        _bksf.edge_operator_b(edge_matrix_indices, 1)))
-        self.assertTrue(qterm_b2.isclose(
-                        _bksf.edge_operator_b(edge_matrix_indices, 2)))
-        self.assertTrue(qterm_b3.isclose(
-                        _bksf.edge_operator_b(edge_matrix_indices, 3)))
+        self.assertTrue(qterm_b0 ==
+                        _bksf.edge_operator_b(edge_matrix_indices, 0))
+        self.assertTrue(qterm_b1 ==
+                        _bksf.edge_operator_b(edge_matrix_indices, 1))
+        self.assertTrue(qterm_b2 ==
+                        _bksf.edge_operator_b(edge_matrix_indices, 2))
+        self.assertTrue(qterm_b3 ==
+                        _bksf.edge_operator_b(edge_matrix_indices, 3))
 
     def test_bravyi_kitaev_fast_edgeoperator_Aij(self):
         # checking the edge operators
@@ -111,18 +111,18 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         qterm_a13 = QubitOperator(correct_operators_a13, 1)
         qterm_a23 = QubitOperator(correct_operators_a23, 1)
 
-        self.assertTrue(qterm_a01.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 0, 1)))
-        self.assertTrue(qterm_a02.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 0, 2)))
-        self.assertTrue(qterm_a03.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 0, 3)))
-        self.assertTrue(qterm_a12.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 1, 2)))
-        self.assertTrue(qterm_a13.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 1, 3)))
-        self.assertTrue(qterm_a23.isclose(_bksf.edge_operator_aij(
-                                          edge_matrix_indices, 2, 3)))
+        self.assertTrue(qterm_a01 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 0, 1))
+        self.assertTrue(qterm_a02 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 0, 2))
+        self.assertTrue(qterm_a03 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 0, 3))
+        self.assertTrue(qterm_a12 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 1, 2))
+        self.assertTrue(qterm_a13 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 1, 3))
+        self.assertTrue(qterm_a23 == _bksf.edge_operator_aij(
+                                          edge_matrix_indices, 2, 3))
 
     def test_bravyi_kitaev_fast_jw_number_operator(self):
         # bksf algorithm allows for even number of particles. So, compare the

--- a/src/openfermion/transforms/_bravyi_kitaev_test.py
+++ b/src/openfermion/transforms/_bravyi_kitaev_test.py
@@ -63,8 +63,8 @@ class BravyiKitaevTransformTest(unittest.TestCase):
         self.assertEqual(raising.terms[correct_operators_c], 0.5)
 
     def test_bk_identity(self):
-        self.assertTrue(bravyi_kitaev(FermionOperator(())).isclose(
-                        QubitOperator(())))
+        self.assertTrue(bravyi_kitaev(FermionOperator(())) ==
+                        QubitOperator(()))
 
     def test_bk_n_qubits_too_small(self):
         with self.assertRaises(ValueError):

--- a/src/openfermion/transforms/_conversion_test.py
+++ b/src/openfermion/transforms/_conversion_test.py
@@ -35,7 +35,7 @@ class GetInteractionOperatorTest(unittest.TestCase):
         molecular_operator = get_interaction_operator(op)
         fermion_operator = get_fermion_operator(molecular_operator)
         fermion_operator = normal_ordered(fermion_operator)
-        self.assertTrue(normal_ordered(op).isclose(fermion_operator))
+        self.assertTrue(normal_ordered(op) == fermion_operator)
 
     def test_get_interaction_operator_bad_input(self):
         with self.assertRaises(TypeError):
@@ -96,7 +96,7 @@ class GetQuadraticHamiltonianTest(unittest.TestCase):
         fermion_operator = get_fermion_operator(quadratic_op)
         fermion_operator = normal_ordered(fermion_operator)
         self.assertTrue(
-            normal_ordered(self.hermitian_op).isclose(fermion_operator))
+            normal_ordered(self.hermitian_op) == fermion_operator)
 
         # Non-particle-number-conserving chemical potential
         quadratic_op = get_quadratic_hamiltonian(self.hermitian_op,
@@ -104,14 +104,14 @@ class GetQuadraticHamiltonianTest(unittest.TestCase):
         fermion_operator = get_fermion_operator(quadratic_op)
         fermion_operator = normal_ordered(fermion_operator)
         self.assertTrue(
-            normal_ordered(self.hermitian_op).isclose(fermion_operator))
+            normal_ordered(self.hermitian_op) == fermion_operator)
 
         # Particle-number-conserving
         quadratic_op = get_quadratic_hamiltonian(self.hermitian_op_pc)
         fermion_operator = get_fermion_operator(quadratic_op)
         fermion_operator = normal_ordered(fermion_operator)
         self.assertTrue(
-            normal_ordered(self.hermitian_op_pc).isclose(fermion_operator))
+            normal_ordered(self.hermitian_op_pc) == fermion_operator)
 
     def test_get_quadratic_hamiltonian_hermitian_bad_term(self):
         """Test an operator with non-quadratic terms."""

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -133,63 +133,63 @@ class JordanWignerTransformTest(unittest.TestCase):
         c2 = FermionOperator(((2, 1),))
         a4 = FermionOperator(((4, 0),))
 
-        self.assertTrue(normal_ordered(c2 * a4).isclose(
-            normal_ordered(-a4 * c2)))
-        self.assertTrue(jordan_wigner(c2 * a4).isclose(
-            jordan_wigner(-a4 * c2)))
+        self.assertTrue(normal_ordered(c2 * a4) ==
+            normal_ordered(-a4 * c2))
+        self.assertTrue(jordan_wigner(c2 * a4) ==
+            jordan_wigner(-a4 * c2))
 
     def test_ccr_offsite_odd_ca(self):
         c1 = FermionOperator(((1, 1),))
         a4 = FermionOperator(((4, 0),))
-        self.assertTrue(normal_ordered(c1 * a4).isclose(
-            normal_ordered(-a4 * c1)))
+        self.assertTrue(normal_ordered(c1 * a4) ==
+            normal_ordered(-a4 * c1))
 
-        self.assertTrue(jordan_wigner(c1 * a4).isclose(
-            jordan_wigner(-a4 * c1)))
+        self.assertTrue(jordan_wigner(c1 * a4) ==
+            jordan_wigner(-a4 * c1))
 
     def test_ccr_offsite_even_cc(self):
         c2 = FermionOperator(((2, 1),))
         c4 = FermionOperator(((4, 1),))
-        self.assertTrue(normal_ordered(c2 * c4).isclose(
-            normal_ordered(-c4 * c2)))
+        self.assertTrue(normal_ordered(c2 * c4) ==
+            normal_ordered(-c4 * c2))
 
-        self.assertTrue(jordan_wigner(c2 * c4).isclose(
-            jordan_wigner(-c4 * c2)))
+        self.assertTrue(jordan_wigner(c2 * c4) ==
+            jordan_wigner(-c4 * c2))
 
     def test_ccr_offsite_odd_cc(self):
         c1 = FermionOperator(((1, 1),))
         c4 = FermionOperator(((4, 1),))
-        self.assertTrue(normal_ordered(c1 * c4).isclose(
-            normal_ordered(-c4 * c1)))
+        self.assertTrue(normal_ordered(c1 * c4) ==
+            normal_ordered(-c4 * c1))
 
-        self.assertTrue(jordan_wigner(c1 * c4).isclose(
-            jordan_wigner(-c4 * c1)))
+        self.assertTrue(jordan_wigner(c1 * c4) ==
+            jordan_wigner(-c4 * c1))
 
     def test_ccr_offsite_even_aa(self):
         a2 = FermionOperator(((2, 0),))
         a4 = FermionOperator(((4, 0),))
-        self.assertTrue(normal_ordered(a2 * a4).isclose(
-            normal_ordered(-a4 * a2)))
+        self.assertTrue(normal_ordered(a2 * a4) ==
+            normal_ordered(-a4 * a2))
 
-        self.assertTrue(jordan_wigner(a2 * a4).isclose(
-            jordan_wigner(-a4 * a2)))
+        self.assertTrue(jordan_wigner(a2 * a4) ==
+            jordan_wigner(-a4 * a2))
 
     def test_ccr_offsite_odd_aa(self):
         a1 = FermionOperator(((1, 0),))
         a4 = FermionOperator(((4, 0),))
-        self.assertTrue(normal_ordered(a1 * a4).isclose(
-            normal_ordered(-a4 * a1)))
+        self.assertTrue(normal_ordered(a1 * a4) ==
+            normal_ordered(-a4 * a1))
 
-        self.assertTrue(jordan_wigner(a1 * a4).isclose(
-            jordan_wigner(-a4 * a1)))
+        self.assertTrue(jordan_wigner(a1 * a4) ==
+            jordan_wigner(-a4 * a1))
 
     def test_ccr_onsite(self):
         c1 = FermionOperator(((1, 1),))
         a1 = hermitian_conjugated(c1)
-        self.assertTrue(normal_ordered(c1 * a1).isclose(
-            FermionOperator(()) - normal_ordered(a1 * c1)))
-        self.assertTrue(jordan_wigner(c1 * a1).isclose(
-            QubitOperator(()) - jordan_wigner(a1 * c1)))
+        self.assertTrue(normal_ordered(c1 * a1) ==
+            FermionOperator(()) - normal_ordered(a1 * c1))
+        self.assertTrue(jordan_wigner(c1 * a1) ==
+            QubitOperator(()) - jordan_wigner(a1 * c1))
 
     def test_jordan_wigner_transm_op(self):
         n = number_operator(self.n_qubits)
@@ -261,14 +261,14 @@ class InteractionOperatorsJWTest(unittest.TestCase):
         retransformed_test_op = reverse_jordan_wigner(jordan_wigner(
             get_interaction_operator(test_op)))
 
-        self.assertTrue(normal_ordered(retransformed_test_op).isclose(
-            normal_ordered(test_op)))
+        self.assertTrue(normal_ordered(retransformed_test_op) ==
+            normal_ordered(test_op))
 
     def test_jordan_wigner_twobody_interaction_op_reversal_symmetric(self):
         test_op = FermionOperator('1^ 2^ 2 1')
         test_op += hermitian_conjugated(test_op)
-        self.assertTrue(jordan_wigner(test_op).isclose(
-                        jordan_wigner(get_interaction_operator(test_op))))
+        self.assertTrue(jordan_wigner(test_op) ==
+                        jordan_wigner(get_interaction_operator(test_op)))
 
     def test_jordan_wigner_interaction_op_too_few_n_qubits(self):
         with self.assertRaises(ValueError):

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -48,7 +48,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(raising.terms[correct_operators_x], 0.5)
         self.assertEqual(raising.terms[correct_operators_y], -0.5j)
-        self.assertTrue(raising.isclose(qtermx + qtermy))
+        self.assertTrue(raising == qtermx + qtermy)
 
     def test_transm_raise1(self):
         raising = jordan_wigner(FermionOperator(((1, 1),)))
@@ -60,7 +60,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(raising.terms[correct_operators_x], 0.5)
         self.assertEqual(raising.terms[correct_operators_y], -0.5j)
-        self.assertTrue(raising.isclose(qtermx + qtermy))
+        self.assertTrue(raising == qtermx + qtermy)
 
     def test_transm_lower3(self):
         lowering = jordan_wigner(FermionOperator(((3, 0),)))
@@ -72,7 +72,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(lowering.terms[correct_operators_x], 0.5)
         self.assertEqual(lowering.terms[correct_operators_y], 0.5j)
-        self.assertTrue(lowering.isclose(qtermx + qtermy))
+        self.assertTrue(lowering == qtermx + qtermy)
 
     def test_transm_lower2(self):
         lowering = jordan_wigner(FermionOperator(((2, 0),)))
@@ -84,7 +84,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(lowering.terms[correct_operators_x], 0.5)
         self.assertEqual(lowering.terms[correct_operators_y], 0.5j)
-        self.assertTrue(lowering.isclose(qtermx + qtermy))
+        self.assertTrue(lowering == qtermx + qtermy)
 
     def test_transm_lower1(self):
         lowering = jordan_wigner(FermionOperator(((1, 0),)))
@@ -96,7 +96,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(lowering.terms[correct_operators_x], 0.5)
         self.assertEqual(lowering.terms[correct_operators_y], 0.5j)
-        self.assertTrue(lowering.isclose(qtermx + qtermy))
+        self.assertTrue(lowering == qtermx + qtermy)
 
     def test_transm_lower0(self):
         lowering = jordan_wigner(FermionOperator(((0, 0),)))
@@ -108,7 +108,7 @@ class JordanWignerTransformTest(unittest.TestCase):
 
         self.assertEqual(lowering.terms[correct_operators_x], 0.5)
         self.assertEqual(lowering.terms[correct_operators_y], 0.5j)
-        self.assertTrue(lowering.isclose(qtermx + qtermy))
+        self.assertTrue(lowering == qtermx + qtermy)
 
     def test_transm_raise3lower0(self):
         # recall that creation gets -1j on Y and annihilation gets +1j on Y.
@@ -224,10 +224,10 @@ class InteractionOperatorsJWTest(unittest.TestCase):
                 fermion_term = FermionOperator(((p, 1), (q, 0)))
                 correct_op = jordan_wigner(fermion_term)
                 hermitian_conjugate = hermitian_conjugated(fermion_term)
-                if not fermion_term.isclose(hermitian_conjugate):
+                if not fermion_term == hermitian_conjugate:
                     correct_op += jordan_wigner(hermitian_conjugate)
 
-                self.assertTrue(test_operator.isclose(correct_op))
+                self.assertTrue(test_operator == correct_op)
 
     def test_jordan_wigner_two_body(self):
         # Make sure it agrees with jordan_wigner(FermionTerm).
@@ -244,14 +244,14 @@ class InteractionOperatorsJWTest(unittest.TestCase):
                         correct_op = jordan_wigner(fermion_term)
                         hermitian_conjugate = hermitian_conjugated(
                             fermion_term)
-                        if not fermion_term.isclose(hermitian_conjugate):
+                        if not fermion_term == hermitian_conjugate:
                             if p == r and q == s:
                                 pass
                             else:
                                 correct_op += jordan_wigner(
                                     hermitian_conjugate)
 
-                        self.assertTrue(test_operator.isclose(correct_op),
+                        self.assertTrue(test_operator == correct_op,
                                         str(test_operator - correct_op))
 
     def test_jordan_wigner_twobody_interaction_op_allunique(self):
@@ -299,7 +299,7 @@ class GetInteractionOperatorTest(unittest.TestCase):
         interaction_operator = InteractionOperator(-2j, self.one_body,
                                                    self.two_body)
         qubit_operator = jordan_wigner(interaction_operator)
-        self.assertTrue(qubit_operator.isclose(-2j * QubitOperator(())))
+        self.assertTrue(qubit_operator == -2j * QubitOperator(()))
         self.assertEqual(interaction_operator,
                          get_interaction_operator(reverse_jordan_wigner(
                              qubit_operator), self.n_qubits))

--- a/src/openfermion/transforms/_reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_reverse_jordan_wigner_test.py
@@ -40,8 +40,8 @@ class ReverseJWTest(unittest.TestCase):
             ((1, 'Z'), (3, 'X'), (8, 'Z')), 1.2)
 
     def test_identity_jwterm(self):
-        self.assertTrue(FermionOperator(()).isclose(
-            reverse_jordan_wigner(QubitOperator(()))))
+        self.assertTrue(FermionOperator(()) ==
+            reverse_jordan_wigner(QubitOperator(())))
 
     def test_x(self):
         pauli_x = QubitOperator(((2, 'X'),))
@@ -111,8 +111,8 @@ class ReverseJWTest(unittest.TestCase):
         expected = expected1 * expected2
 
         self.assertTrue(xx == retransmed_xx)
-        self.assertTrue(normal_ordered(transmed_xx).isclose(
-            normal_ordered(expected)))
+        self.assertTrue(normal_ordered(transmed_xx) ==
+            normal_ordered(expected))
 
     def test_yy(self):
         yy = QubitOperator(((2, 'Y'), (3, 'Y')), 2.)
@@ -126,8 +126,8 @@ class ReverseJWTest(unittest.TestCase):
         expected = expected1 * expected2
 
         self.assertTrue(yy == retransmed_yy)
-        self.assertTrue(normal_ordered(transmed_yy).isclose(
-            normal_ordered(expected)))
+        self.assertTrue(normal_ordered(transmed_yy) ==
+            normal_ordered(expected))
 
     def test_xy(self):
         xy = QubitOperator(((4, 'X'), (5, 'Y')), -2.j)
@@ -141,8 +141,8 @@ class ReverseJWTest(unittest.TestCase):
         expected = expected1 * expected2
 
         self.assertTrue(xy == retransmed_xy)
-        self.assertTrue(normal_ordered(transmed_xy).isclose(
-            normal_ordered(expected)))
+        self.assertTrue(normal_ordered(transmed_xy) ==
+            normal_ordered(expected))
 
     def test_yx(self):
         yx = QubitOperator(((0, 'Y'), (1, 'X')), -0.5)
@@ -156,8 +156,8 @@ class ReverseJWTest(unittest.TestCase):
         expected = expected1 * expected2
 
         self.assertTrue(yx == retransmed_yx)
-        self.assertTrue(normal_ordered(transmed_yx).isclose(
-            normal_ordered(expected)))
+        self.assertTrue(normal_ordered(transmed_yx) ==
+            normal_ordered(expected))
 
     def test_jw_term_bad_type(self):
         with self.assertRaises(TypeError):

--- a/src/openfermion/transforms/_reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_reverse_jordan_wigner_test.py
@@ -47,13 +47,13 @@ class ReverseJWTest(unittest.TestCase):
         pauli_x = QubitOperator(((2, 'X'),))
         transmed_x = reverse_jordan_wigner(pauli_x)
         retransmed_x = jordan_wigner(transmed_x)
-        self.assertTrue(pauli_x.isclose(retransmed_x))
+        self.assertTrue(pauli_x == retransmed_x)
 
     def test_y(self):
         pauli_y = QubitOperator(((2, 'Y'),))
         transmed_y = reverse_jordan_wigner(pauli_y)
         retransmed_y = jordan_wigner(transmed_y)
-        self.assertTrue(pauli_y.isclose(retransmed_y))
+        self.assertTrue(pauli_y == retransmed_y)
 
     def test_z(self):
         pauli_z = QubitOperator(((2, 'Z'),))
@@ -61,10 +61,10 @@ class ReverseJWTest(unittest.TestCase):
 
         expected = (FermionOperator(()) +
                     FermionOperator(((2, 1), (2, 0)), -2.))
-        self.assertTrue(transmed_z.isclose(expected))
+        self.assertTrue(transmed_z == expected)
 
         retransmed_z = jordan_wigner(transmed_z)
-        self.assertTrue(pauli_z.isclose(retransmed_z))
+        self.assertTrue(pauli_z == retransmed_z)
 
     def test_reverse_jw_too_few_n_qubits(self):
         with self.assertRaises(ValueError):
@@ -74,30 +74,30 @@ class ReverseJWTest(unittest.TestCase):
         n_qubits = 5
         transmed_i = reverse_jordan_wigner(self.identity, n_qubits)
         expected_i = FermionOperator(())
-        self.assertTrue(transmed_i.isclose(expected_i))
+        self.assertTrue(transmed_i == expected_i)
         retransmed_i = jordan_wigner(transmed_i)
-        self.assertTrue(self.identity.isclose(retransmed_i))
+        self.assertTrue(self.identity == retransmed_i)
 
     def test_zero(self):
         n_qubits = 5
         transmed_i = reverse_jordan_wigner(QubitOperator(), n_qubits)
         expected_i = FermionOperator()
-        self.assertTrue(transmed_i.isclose(expected_i))
+        self.assertTrue(transmed_i == expected_i)
 
         retransmed_i = jordan_wigner(transmed_i)
         expected_i = QubitOperator()
-        self.assertTrue(expected_i.isclose(retransmed_i))
+        self.assertTrue(expected_i == retransmed_i)
 
     def test_yzxz(self):
         yzxz = QubitOperator(((0, 'Y'), (1, 'Z'), (2, 'X'), (3, 'Z')))
         transmed_yzxz = reverse_jordan_wigner(yzxz)
         retransmed_yzxz = jordan_wigner(transmed_yzxz)
-        self.assertTrue(yzxz.isclose(retransmed_yzxz))
+        self.assertTrue(yzxz == retransmed_yzxz)
 
     def test_term(self):
         transmed_term = reverse_jordan_wigner(self.term)
         retransmed_term = jordan_wigner(transmed_term)
-        self.assertTrue(self.term.isclose(retransmed_term))
+        self.assertTrue(self.term == retransmed_term)
 
     def test_xx(self):
         xx = QubitOperator(((3, 'X'), (4, 'X')), 2.)
@@ -110,7 +110,7 @@ class ReverseJWTest(unittest.TestCase):
                      FermionOperator(((4, 0),), 1.))
         expected = expected1 * expected2
 
-        self.assertTrue(xx.isclose(retransmed_xx))
+        self.assertTrue(xx == retransmed_xx)
         self.assertTrue(normal_ordered(transmed_xx).isclose(
             normal_ordered(expected)))
 
@@ -125,7 +125,7 @@ class ReverseJWTest(unittest.TestCase):
                      FermionOperator(((3, 0),)))
         expected = expected1 * expected2
 
-        self.assertTrue(yy.isclose(retransmed_yy))
+        self.assertTrue(yy == retransmed_yy)
         self.assertTrue(normal_ordered(transmed_yy).isclose(
             normal_ordered(expected)))
 
@@ -140,7 +140,7 @@ class ReverseJWTest(unittest.TestCase):
                      FermionOperator(((5, 0),)))
         expected = expected1 * expected2
 
-        self.assertTrue(xy.isclose(retransmed_xy))
+        self.assertTrue(xy == retransmed_xy)
         self.assertTrue(normal_ordered(transmed_xy).isclose(
             normal_ordered(expected)))
 
@@ -155,7 +155,7 @@ class ReverseJWTest(unittest.TestCase):
                             FermionOperator(((1, 0),)))
         expected = expected1 * expected2
 
-        self.assertTrue(yx.isclose(retransmed_yx))
+        self.assertTrue(yx == retransmed_yx)
         self.assertTrue(normal_ordered(transmed_yx).isclose(
             normal_ordered(expected)))
 
@@ -166,14 +166,14 @@ class ReverseJWTest(unittest.TestCase):
     def test_reverse_jordan_wigner(self):
         transmed_operator = reverse_jordan_wigner(self.qubit_operator)
         retransmed_operator = jordan_wigner(transmed_operator)
-        self.assertTrue(self.qubit_operator.isclose(retransmed_operator))
+        self.assertTrue(self.qubit_operator == retransmed_operator)
 
     def test_reverse_jw_linearity(self):
         term1 = QubitOperator(((0, 'X'), (1, 'Y')), -0.5)
         term2 = QubitOperator(((0, 'Y'), (1, 'X'), (2, 'Y'), (3, 'Y')), -1j)
 
         op12 = reverse_jordan_wigner(term1) - reverse_jordan_wigner(term2)
-        self.assertTrue(op12.isclose(reverse_jordan_wigner(term1 - term2)))
+        self.assertTrue(op12 == reverse_jordan_wigner(term1 - term2))
 
     def test_bad_type(self):
         with self.assertRaises(TypeError):
@@ -186,4 +186,4 @@ class ReverseJWTest(unittest.TestCase):
         transformed_op = reverse_jordan_wigner(qubit_op)
         expected_op = FermionOperator('1^')
         expected_op += FermionOperator('1')
-        self.assertTrue(transformed_op.isclose(expected_op))
+        self.assertTrue(transformed_op == expected_op)

--- a/src/openfermion/utils/_commutators_test.py
+++ b/src/openfermion/utils/_commutators_test.py
@@ -31,37 +31,37 @@ class CommutatorTest(unittest.TestCase):
     def test_commutes_identity(self):
         com = commutator(FermionOperator.identity(),
                          FermionOperator('2^ 3', 2.3))
-        self.assertTrue(com.isclose(FermionOperator.zero()))
+        self.assertTrue(com == FermionOperator.zero())
 
     def test_commutes_no_intersection(self):
         com = commutator(FermionOperator('2^ 3'), FermionOperator('4^ 5^ 3'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(FermionOperator.zero()))
+        self.assertTrue(com == FermionOperator.zero())
 
     def test_commutes_number_operators(self):
         com = commutator(FermionOperator('4^ 3^ 4 3'), FermionOperator('2^ 2'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(FermionOperator.zero()))
+        self.assertTrue(com == FermionOperator.zero())
 
     def test_commutator_hopping_operators(self):
         com = commutator(3 * FermionOperator('1^ 2'), FermionOperator('2^ 3'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(FermionOperator('1^ 3', 3)))
+        self.assertTrue(com == FermionOperator('1^ 3', 3))
 
     def test_commutator_hopping_with_single_number(self):
         com = commutator(FermionOperator('1^ 2', 1j), FermionOperator('1^ 1'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(-FermionOperator('1^ 2') * 1j))
+        self.assertTrue(com == -FermionOperator('1^ 2') * 1j)
 
     def test_commutator_hopping_with_double_number_one_intersection(self):
         com = commutator(FermionOperator('1^ 3'), FermionOperator('3^ 2^ 3 2'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(-FermionOperator('2^ 1^ 3 2')))
+        self.assertTrue(com == -FermionOperator('2^ 1^ 3 2'))
 
     def test_commutator_hopping_with_double_number_two_intersections(self):
         com = commutator(FermionOperator('2^ 3'), FermionOperator('3^ 2^ 3 2'))
         com = normal_ordered(com)
-        self.assertTrue(com.isclose(FermionOperator.zero()))
+        self.assertTrue(com == FermionOperator.zero())
 
     def test_commutator(self):
         operator_a = FermionOperator('')
@@ -133,7 +133,7 @@ class DoubleCommutatorTest(unittest.TestCase):
         com = double_commutator(FermionOperator('4^ 3^ 6 5'),
                                 FermionOperator('2^ 1 0'),
                                 FermionOperator('0^'))
-        self.assertTrue(com.isclose(FermionOperator.zero()))
+        self.assertTrue(com == FermionOperator.zero())
 
     def test_double_commutator_more_info_not_hopping(self):
         com = double_commutator(

--- a/src/openfermion/utils/_commutators_test.py
+++ b/src/openfermion/utils/_commutators_test.py
@@ -65,12 +65,12 @@ class CommutatorTest(unittest.TestCase):
 
     def test_commutator(self):
         operator_a = FermionOperator('')
-        self.assertTrue(FermionOperator().isclose(
-            commutator(operator_a, self.fermion_operator)))
+        self.assertTrue(FermionOperator() ==
+            commutator(operator_a, self.fermion_operator))
         operator_b = QubitOperator('X1 Y2')
-        self.assertTrue(commutator(self.qubit_operator, operator_b).isclose(
+        self.assertTrue(commutator(self.qubit_operator, operator_b) ==
             self.qubit_operator * operator_b -
-            operator_b * self.qubit_operator))
+            operator_b * self.qubit_operator)
 
     def test_ndarray_input(self):
         """Test when the inputs are numpy arrays."""
@@ -102,18 +102,18 @@ class AnticommutatorTest(unittest.TestCase):
         zero = FermionOperator()
         one = FermionOperator('')
 
-        self.assertTrue(one.isclose(
-            normal_ordered(anticommutator(op_1, op_1_dag))))
-        self.assertTrue(zero.isclose(
-            normal_ordered(anticommutator(op_1, op_2))))
-        self.assertTrue(zero.isclose(
-            normal_ordered(anticommutator(op_1, op_2_dag))))
-        self.assertTrue(zero.isclose(
-            normal_ordered(anticommutator(op_1_dag, op_2))))
-        self.assertTrue(zero.isclose(
-            normal_ordered(anticommutator(op_1_dag, op_2_dag))))
-        self.assertTrue(one.isclose(
-            normal_ordered(anticommutator(op_2, op_2_dag))))
+        self.assertTrue(one ==
+            normal_ordered(anticommutator(op_1, op_1_dag)))
+        self.assertTrue(zero ==
+            normal_ordered(anticommutator(op_1, op_2)))
+        self.assertTrue(zero ==
+            normal_ordered(anticommutator(op_1, op_2_dag)))
+        self.assertTrue(zero ==
+            normal_ordered(anticommutator(op_1_dag, op_2)))
+        self.assertTrue(zero ==
+            normal_ordered(anticommutator(op_1_dag, op_2_dag)))
+        self.assertTrue(one ==
+            normal_ordered(anticommutator(op_2, op_2_dag)))
 
     def test_ndarray_input(self):
         """Test when the inputs are numpy arrays."""
@@ -142,7 +142,7 @@ class DoubleCommutatorTest(unittest.TestCase):
             FermionOperator('4^ 2^ 4 2'), indices2=set([2, 3]),
             indices3=set([2, 4]), is_hopping_operator2=True,
             is_hopping_operator3=False)
-        self.assertTrue(com.isclose(FermionOperator('4^ 2^ 4 2') -
+        self.assertTrue(com == (FermionOperator('4^ 2^ 4 2') -
                                     FermionOperator('4^ 3^ 4 3')))
 
     def test_double_commtator_more_info_both_hopping(self):
@@ -152,7 +152,7 @@ class DoubleCommutatorTest(unittest.TestCase):
             FermionOperator('1^ 3', -1.3) + FermionOperator('3^ 1', -1.3),
             indices2=set([1, 2]), indices3=set([1, 3]),
             is_hopping_operator2=True, is_hopping_operator3=True)
-        self.assertTrue(com.isclose(FermionOperator('4^ 3^ 4 2', 2.73) +
+        self.assertTrue(com == (FermionOperator('4^ 3^ 4 2', 2.73) +
                                     FermionOperator('4^ 2^ 4 3', 2.73)))
 
 

--- a/src/openfermion/utils/_hubbard_trotter_error_test.py
+++ b/src/openfermion/utils/_hubbard_trotter_error_test.py
@@ -112,7 +112,7 @@ class OrderedHubbardTermsMoreInfoTest(unittest.TestCase):
 
         terms_total = sum(terms, FermionOperator.zero())
 
-        self.assertTrue(terms_total.isclose(hamiltonian))
+        self.assertTrue(terms_total == hamiltonian)
 
     def test_sum_of_ordered_terms_equals_full_hamiltonian_even_side_len(self):
         hamiltonian = normal_ordered(
@@ -123,7 +123,7 @@ class OrderedHubbardTermsMoreInfoTest(unittest.TestCase):
             hamiltonian)[0]
         terms_total = sum(terms, FermionOperator.zero())
 
-        self.assertTrue(terms_total.isclose(hamiltonian))
+        self.assertTrue(terms_total == hamiltonian)
 
     def test_sum_of_ordered_terms_equals_full_hamiltonian_odd_side_len(self):
         hamiltonian = normal_ordered(
@@ -134,7 +134,7 @@ class OrderedHubbardTermsMoreInfoTest(unittest.TestCase):
             hamiltonian)[0]
         terms_total = sum(terms, FermionOperator.zero())
 
-        self.assertTrue(terms_total.isclose(hamiltonian))
+        self.assertTrue(terms_total == hamiltonian)
 
     def test_correct_indices_terms_with_info(self):
         hamiltonian = normal_ordered(

--- a/src/openfermion/utils/_low_depth_trotter_error.py
+++ b/src/openfermion/utils/_low_depth_trotter_error.py
@@ -275,7 +275,7 @@ def stagger_with_info(hamiltonian, input_ordering, parity):
         # If the overall hopping operator isn't close to zero, append it.
         # Include the indices it acts on and that it's a hopping operator.
         if not (left_hopping_operator +
-                right_hopping_operator).isclose(zero):
+                right_hopping_operator) == zero:
             terms_in_step.append(left_hopping_operator +
                                  right_hopping_operator)
             indices_in_step.append(set((left, right)))
@@ -284,7 +284,7 @@ def stagger_with_info(hamiltonian, input_ordering, parity):
         # If the overall number operator isn't close to zero, append it.
         # Include the indices it acts on and that it's a number operator.
         if not (two_number_operator + left_number_operator +
-                right_number_operator).isclose(zero):
+                right_number_operator) == zero:
             terms_in_step.append(two_number_operator +
                                  left_number_operator +
                                  right_number_operator)

--- a/src/openfermion/utils/_low_depth_trotter_error_test.py
+++ b/src/openfermion/utils/_low_depth_trotter_error_test.py
@@ -246,14 +246,14 @@ class OrderedDualBasisTermsNoInfoTest(unittest.TestCase):
         for term in terms:
             found_in_other = False
             for term2 in expected_terms:
-                if term == term2, rel_tol=1e-8:
+                if term == term2:
                     self.assertFalse(found_in_other)
                     found_in_other = True
             self.assertTrue(found_in_other, msg=str(term))
         for term in expected_terms:
             found_in_other = False
             for term2 in terms:
-                if term == term2, rel_tol=1e-8:
+                if term == term2:
                     self.assertFalse(found_in_other)
                     found_in_other = True
             self.assertTrue(found_in_other, msg=str(term))

--- a/src/openfermion/utils/_low_depth_trotter_error_test.py
+++ b/src/openfermion/utils/_low_depth_trotter_error_test.py
@@ -136,7 +136,7 @@ class OrderedDualBasisTermsMoreInfoTest(unittest.TestCase):
         grid = Grid(dimension, grid_length, length_scale)
         hamiltonian = jellium_model(grid, spinless=True, plane_wave=False)
         hamiltonian = normal_ordered(hamiltonian)
-        self.assertTrue(terms_total.isclose(hamiltonian))
+        self.assertTrue(terms_total == hamiltonian)
 
     def test_correct_indices_terms_with_info(self):
         grid_length = 4
@@ -246,14 +246,14 @@ class OrderedDualBasisTermsNoInfoTest(unittest.TestCase):
         for term in terms:
             found_in_other = False
             for term2 in expected_terms:
-                if term.isclose(term2, rel_tol=1e-8):
+                if term == term2, rel_tol=1e-8:
                     self.assertFalse(found_in_other)
                     found_in_other = True
             self.assertTrue(found_in_other, msg=str(term))
         for term in expected_terms:
             found_in_other = False
             for term2 in terms:
-                if term.isclose(term2, rel_tol=1e-8):
+                if term == term2, rel_tol=1e-8:
                     self.assertFalse(found_in_other)
                     found_in_other = True
             self.assertTrue(found_in_other, msg=str(term))
@@ -277,4 +277,4 @@ class OrderedDualBasisTermsNoInfoTest(unittest.TestCase):
         grid = Grid(dimension, grid_length, length_scale)
         hamiltonian = jellium_model(grid, spinless=True, plane_wave=False)
         hamiltonian = normal_ordered(hamiltonian)
-        self.assertTrue(terms_total.isclose(hamiltonian))
+        self.assertTrue(terms_total == hamiltonian)

--- a/src/openfermion/utils/_operator_utils.py
+++ b/src/openfermion/utils/_operator_utils.py
@@ -68,7 +68,7 @@ def is_hermitian(operator):
     """Test if operator is Hermitian."""
     # Handle FermionOperator or QubitOperator
     if isinstance(operator, (FermionOperator, QubitOperator)):
-        return operator.isclose(hermitian_conjugated(operator))
+        return operator == hermitian_conjugated(operator)
 
     # Handle sparse matrix
     elif isinstance(operator, spmatrix):

--- a/src/openfermion/utils/_operator_utils_test.py
+++ b/src/openfermion/utils/_operator_utils_test.py
@@ -125,23 +125,23 @@ class HermitianConjugatedTest(unittest.TestCase):
         op = QubitOperator()
         op_hc = hermitian_conjugated(op)
         correct_op = op
-        self.assertTrue(op_hc.isclose(correct_op))
+        self.assertTrue(op_hc == correct_op)
 
         op = QubitOperator('X0 Y1', 2.)
         op_hc = hermitian_conjugated(op)
         correct_op = op
-        self.assertTrue(op_hc.isclose(correct_op))
+        self.assertTrue(op_hc == correct_op)
 
         op = QubitOperator('X0 Y1', 2.j)
         op_hc = hermitian_conjugated(op)
         correct_op = QubitOperator('X0 Y1', -2.j)
-        self.assertTrue(op_hc.isclose(correct_op))
+        self.assertTrue(op_hc == correct_op)
 
         op = QubitOperator('X0 Y1', 2.) + QubitOperator('Z4 X5 Y7', 3.j)
         op_hc = hermitian_conjugated(op)
         correct_op = (QubitOperator('X0 Y1', 2.) +
                       QubitOperator('Z4 X5 Y7', -3.j))
-        self.assertTrue(op_hc.isclose(correct_op))
+        self.assertTrue(op_hc == correct_op)
 
     def test_hermitian_conjugated_qubit_op_consistency(self):
         """Some consistency checks for conjugating QubitOperators."""
@@ -157,25 +157,25 @@ class HermitianConjugatedTest(unittest.TestCase):
     def test_hermitian_conjugate_empty(self):
         op = FermionOperator()
         op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(FermionOperator()))
+        self.assertTrue(op == FermionOperator())
 
     def test_hermitian_conjugate_simple(self):
         op = FermionOperator('1^')
         op_hc = FermionOperator('1')
         op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
+        self.assertTrue(op == op_hc)
 
     def test_hermitian_conjugate_complex_const(self):
         op = FermionOperator('1^ 3', 3j)
         op_hc = -3j * FermionOperator('3^ 1')
         op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
+        self.assertTrue(op == op_hc)
 
     def test_hermitian_conjugate_notordered(self):
         op = FermionOperator('1 3^ 3 3^', 3j)
         op_hc = -3j * FermionOperator('3 3^ 3 1^')
         op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
+        self.assertTrue(op == op_hc)
 
     def test_hermitian_conjugate_semihermitian(self):
         op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
@@ -184,26 +184,26 @@ class HermitianConjugatedTest(unittest.TestCase):
                  FermionOperator('3^ 1', -2j) +
                  FermionOperator('2^ 2', -0.1j))
         op = hermitian_conjugated(op)
-        self.assertTrue(op.isclose(op_hc))
+        self.assertTrue(op == op_hc)
 
     def test_hermitian_conjugated_empty(self):
         op = FermionOperator()
-        self.assertTrue(op.isclose(hermitian_conjugated(op)))
+        self.assertTrue(op == hermitian_conjugated(op))
 
     def test_hermitian_conjugated_simple(self):
         op = FermionOperator('0')
         op_hc = FermionOperator('0^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+        self.assertTrue(op_hc == hermitian_conjugated(op))
 
     def test_hermitian_conjugated_complex_const(self):
         op = FermionOperator('2^ 2', 3j)
         op_hc = FermionOperator('2^ 2', -3j)
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+        self.assertTrue(op_hc == hermitian_conjugated(op))
 
     def test_hermitian_conjugated_multiterm(self):
         op = FermionOperator('1^ 2') + FermionOperator('2 3 4')
         op_hc = FermionOperator('2^ 1') + FermionOperator('4^ 3^ 2^')
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+        self.assertTrue(op_hc == hermitian_conjugated(op))
 
     def test_hermitian_conjugated_semihermitian(self):
         op = (FermionOperator() + 2j * FermionOperator('1^ 3') +
@@ -211,7 +211,7 @@ class HermitianConjugatedTest(unittest.TestCase):
         op_hc = (FermionOperator() + FermionOperator('1^ 3', 2j) +
                  FermionOperator('3^ 1', -2j) +
                  FermionOperator('2^ 2', -0.1j))
-        self.assertTrue(op_hc.isclose(hermitian_conjugated(op)))
+        self.assertTrue(op_hc == hermitian_conjugated(op))
 
     def test_exceptions(self):
         with self.assertRaises(TypeError):
@@ -349,7 +349,7 @@ class SaveLoadOperatorTest(unittest.TestCase):
                       allow_overwrite=True)
         fermion_operator = load_operator(self.file_name)
 
-        self.assertTrue(fermion_operator.isclose(self.fermion_operator))
+        self.assertTrue(fermion_operator == self.fermion_operator)
 
     def test_load_bad_type(self):
         with self.assertRaises(TypeError):

--- a/src/openfermion/utils/_operator_utils_test.py
+++ b/src/openfermion/utils/_operator_utils_test.py
@@ -149,10 +149,10 @@ class HermitianConjugatedTest(unittest.TestCase):
                    FermionOperator('2^ 7 9 11^'))
 
         # Check that hermitian conjugation commutes with transforms
-        self.assertTrue(jordan_wigner(hermitian_conjugated(ferm_op)).isclose(
-            hermitian_conjugated(jordan_wigner(ferm_op))))
-        self.assertTrue(bravyi_kitaev(hermitian_conjugated(ferm_op)).isclose(
-            hermitian_conjugated(bravyi_kitaev(ferm_op))))
+        self.assertTrue(jordan_wigner(hermitian_conjugated(ferm_op)) ==
+            hermitian_conjugated(jordan_wigner(ferm_op)))
+        self.assertTrue(bravyi_kitaev(hermitian_conjugated(ferm_op)) ==
+            hermitian_conjugated(bravyi_kitaev(ferm_op)))
 
     def test_hermitian_conjugate_empty(self):
         op = FermionOperator()
@@ -372,8 +372,8 @@ class FourierTransformTest(unittest.TestCase):
             h_dual_basis = plane_wave_hamiltonian(
                 grid, geometry, spinless, False)
             h_plane_wave_t = fourier_transform(h_plane_wave, grid, spinless)
-            self.assertTrue(normal_ordered(h_plane_wave_t).isclose(
-                normal_ordered(h_dual_basis)))
+            self.assertTrue(normal_ordered(h_plane_wave_t) ==
+                normal_ordered(h_dual_basis))
 
     def test_inverse_fourier_transform_1d(self):
         grid = Grid(dimensions=1, scale=1.5, length=4)
@@ -386,8 +386,8 @@ class FourierTransformTest(unittest.TestCase):
                 grid, geometry, spinless, False)
             h_dual_basis_t = inverse_fourier_transform(
                 h_dual_basis, grid, spinless)
-            self.assertTrue(normal_ordered(h_dual_basis_t).isclose(
-                normal_ordered(h_plane_wave)))
+            self.assertTrue(normal_ordered(h_dual_basis_t) ==
+                normal_ordered(h_plane_wave))
 
     def test_inverse_fourier_transform_2d(self):
         grid = Grid(dimensions=2, scale=1.5, length=3)
@@ -397,5 +397,5 @@ class FourierTransformTest(unittest.TestCase):
         h_dual_basis = plane_wave_hamiltonian(grid, geometry, spinless, False)
         h_dual_basis_t = inverse_fourier_transform(
             h_dual_basis, grid, spinless)
-        self.assertTrue(normal_ordered(h_dual_basis_t).isclose(
-            normal_ordered(h_plane_wave)))
+        self.assertTrue(normal_ordered(h_dual_basis_t) ==
+                        normal_ordered(h_plane_wave))

--- a/src/openfermion/utils/_special_operators_test.py
+++ b/src/openfermion/utils/_special_operators_test.py
@@ -22,12 +22,12 @@ from openfermion.utils import (up_index, down_index, s_minus_operator,
 class FermionSpinOperatorsTest(unittest.TestCase):
 
     def test_up_index(self):
-        self.assertTrue(numpy == up_index(2), 4)
-        self.assertTrue(numpy == up_index(5), 10)
+        self.assertTrue(up_index(2) == 4)
+        self.assertTrue(up_index(5) == 10)
 
     def test_up_down(self):
-        self.assertTrue(numpy == down_index(2), 5)
-        self.assertTrue(numpy == down_index(5), 11)
+        self.assertTrue(down_index(2) == 5)
+        self.assertTrue(down_index(5) == 11)
 
     def test_sz_operator(self):
         op = sz_operator(2)

--- a/src/openfermion/utils/_special_operators_test.py
+++ b/src/openfermion/utils/_special_operators_test.py
@@ -22,12 +22,12 @@ from openfermion.utils import (up_index, down_index, s_minus_operator,
 class FermionSpinOperatorsTest(unittest.TestCase):
 
     def test_up_index(self):
-        self.assertTrue(numpy.isclose(up_index(2), 4))
-        self.assertTrue(numpy.isclose(up_index(5), 10))
+        self.assertTrue(numpy == up_index(2), 4)
+        self.assertTrue(numpy == up_index(5), 10)
 
     def test_up_down(self):
-        self.assertTrue(numpy.isclose(down_index(2), 5))
-        self.assertTrue(numpy.isclose(down_index(5), 11))
+        self.assertTrue(numpy == down_index(2), 5)
+        self.assertTrue(numpy == down_index(5), 11)
 
     def test_sz_operator(self):
         op = sz_operator(2)
@@ -35,7 +35,7 @@ class FermionSpinOperatorsTest(unittest.TestCase):
                     FermionOperator(((1, 1), (1, 0)), 0.5) +
                     FermionOperator(((2, 1), (2, 0)), 0.5) -
                     FermionOperator(((3, 1), (3, 0)), 0.5))
-        self.assertTrue(op.isclose(expected))
+        self.assertTrue(op == expected)
 
     def test_sz_operator_invalid_input(self):
         with self.assertRaises(TypeError):
@@ -45,7 +45,7 @@ class FermionSpinOperatorsTest(unittest.TestCase):
         op = s_plus_operator(2)
         expected = (FermionOperator(((0, 1), (1, 0))) +
                     FermionOperator(((2, 1), (3, 0))))
-        self.assertTrue(op.isclose(expected))
+        self.assertTrue(op == expected)
 
     def test_s_plus_operator_invalid_input(self):
         with self.assertRaises(TypeError):
@@ -56,7 +56,7 @@ class FermionSpinOperatorsTest(unittest.TestCase):
         expected = (FermionOperator(((1, 1), (0, 0))) +
                     FermionOperator(((3, 1), (2, 0))) +
                     FermionOperator(((5, 1), (4, 0))))
-        self.assertTrue(op.isclose(expected))
+        self.assertTrue(op == expected)
 
     def test_s_minus_operator_invalid_input(self):
         with self.assertRaises(TypeError):
@@ -73,7 +73,7 @@ class FermionSpinOperatorsTest(unittest.TestCase):
                FermionOperator(((2, 1), (2, 0)), 0.5) -
                FermionOperator(((3, 1), (3, 0)), 0.5))
         expected = s_minus * s_plus + s_z * s_z + s_z
-        self.assertTrue(op.isclose(expected))
+        self.assertTrue(op == expected)
 
     def test_s_squared_operator_invalid_input(self):
         with self.assertRaises(TypeError):

--- a/src/openfermion/utils/_special_operators_test.py
+++ b/src/openfermion/utils/_special_operators_test.py
@@ -87,19 +87,19 @@ class MajoranaOperatorTest(unittest.TestCase):
         op1 = majorana_operator((2, 0))
         op2 = majorana_operator('c2')
         correct = FermionOperator('2^') + FermionOperator('2')
-        self.assertTrue(op1.isclose(op2))
-        self.assertTrue(op1.isclose(correct))
+        self.assertTrue(op1 == op2)
+        self.assertTrue(op1 == correct)
 
         # Test 'd' operator
         op1 = majorana_operator((3, 1))
         op2 = majorana_operator('d3')
         correct = FermionOperator('3^', 1.j) - FermionOperator('3', 1.j)
-        self.assertTrue(op1.isclose(op2))
-        self.assertTrue(op1.isclose(correct))
+        self.assertTrue(op1 == op2)
+        self.assertTrue(op1 == correct)
 
     def test_none_term(self):
         majorana_op = majorana_operator()
-        self.assertTrue(majorana_operator().isclose(FermionOperator()))
+        self.assertTrue(majorana_operator() == FermionOperator())
 
     def test_bad_coefficient(self):
         with self.assertRaises(ValueError):

--- a/src/openfermion/utils/_trotter_error.py
+++ b/src/openfermion/utils/_trotter_error.py
@@ -156,7 +156,7 @@ def error_bound(terms, tight=False):
                     term_b = terms[beta]
                     coefficient_b, = term_b.terms.values()
                     if not (trivially_commutes(term_a, term_b) or
-                            commutator(term_a, term_b).isclose(zero)):
+                            commutator(term_a, term_b) == zero):
                         error_a += abs(coefficient_b)
 
                 error += 4.0 * abs(coefficient_a) * error_a ** 2

--- a/src/openfermion/utils/_trotter_error_test.py
+++ b/src/openfermion/utils/_trotter_error_test.py
@@ -30,19 +30,19 @@ class CommutatorTest(unittest.TestCase):
     def test_commutator_commutes(self):
         zero = QubitOperator()
         self.assertTrue(commutator(QubitOperator(()),
-                        QubitOperator('X3')).isclose(zero))
+                        QubitOperator('X3')) == zero)
 
     def test_commutator_single_pauli(self):
         com = commutator(QubitOperator('X3'),
                          QubitOperator('Y3'))
         expected = 2j * QubitOperator('Z3')
-        self.assertTrue(expected.isclose(com))
+        self.assertTrue(expected == com)
 
     def test_commutator_multi_pauli(self):
         com = commutator(QubitOperator('Z1 X2 Y4'),
                          QubitOperator('X1 Z2 X4'))
         expected = -2j * QubitOperator('Y1 Y2 Z4')
-        self.assertTrue(expected.isclose(com))
+        self.assertTrue(expected == com)
 
 
 class TriviallyCommutesTest(unittest.TestCase):
@@ -117,7 +117,7 @@ class ErrorOperatorTest(unittest.TestCase):
         terms = [QubitOperator(()), QubitOperator('Z0 Z1 Z2'),
                  QubitOperator('Z0 Z3'), QubitOperator('Z0 Z1 Z2 Z3')]
         zero = QubitOperator()
-        self.assertTrue(zero.isclose(error_operator(terms)))
+        self.assertTrue(zero == error_operator(terms))
 
 
 class ErrorBoundTest(unittest.TestCase):

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -90,8 +90,8 @@ class UnitaryCC(unittest.TestCase):
         comm_s_squared = normal_ordered(commutator(generator, s_squared))
         zero = FermionOperator()
 
-        self.assertTrue(comm_sz.isclose(zero))
-        self.assertTrue(comm_s_squared.isclose(zero))
+        self.assertTrue(comm_sz == zero)
+        self.assertTrue(comm_s_squared == zero)
 
     def test_uccsd_singlet_builds(self):
         """Test specific builds of the UCCSD singlet operator"""
@@ -114,8 +114,8 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("2^ 0 3^ 1", 2.) +
                           FermionOperator("1^ 3 0^ 2", -2.))
 
-        self.assertTrue(normal_ordered(test_generator).isclose(
-                        normal_ordered(generator)))
+        self.assertTrue(normal_ordered(test_generator) ==
+                        normal_ordered(generator))
 
         # Build 2
         n_orbitals = 6
@@ -150,8 +150,8 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("3^ 1 5^ 1", 5.) +
                           FermionOperator("1^ 5 1^ 3", -5.))
 
-        self.assertTrue(normal_ordered(test_generator).isclose(
-                        normal_ordered(generator)))
+        self.assertTrue(normal_ordered(test_generator) ==
+                        normal_ordered(generator))
 
     def test_sparse_uccsd_generator_numpy_inputs(self):
         """Test numpy ndarray inputs to uccsd_generator that are sparse"""

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -40,7 +40,7 @@ class UnitaryCC(unittest.TestCase):
         generator = uccsd_operator(single_amplitudes, double_amplitudes)
         conj_generator = hermitian_conjugated(generator)
 
-        self.assertTrue(generator.isclose(-1. * conj_generator))
+        self.assertTrue(generator == -1. * conj_generator)
 
     def test_uccsd_singlet_anti_hermitian(self):
         """Test that the singlet version is anti-Hermitian"""
@@ -58,7 +58,7 @@ class UnitaryCC(unittest.TestCase):
 
         conj_generator = hermitian_conjugated(generator)
 
-        self.assertTrue(generator.isclose(-1. * conj_generator))
+        self.assertTrue(generator == -1. * conj_generator)
 
     def test_uccsd_singlet_build(self):
         """Test a specific build of the UCCSD singlet operator"""
@@ -82,7 +82,7 @@ class UnitaryCC(unittest.TestCase):
                           (-1.1494145e-08) * FermionOperator("2^ 0") +
                           0.0565340614 * FermionOperator("3^ 1 3^ 1") +
                           (-0.0565340614) * FermionOperator("0^ 2 1^ 3"))
-        self.assertTrue(test_generator.isclose(generator))
+        self.assertTrue(test_generator == generator)
 
     def test_sparse_uccsd_operator_numpy_inputs(self):
         """Test numpy ndarray inputs to uccsd_operator that are sparse"""
@@ -108,7 +108,7 @@ class UnitaryCC(unittest.TestCase):
                           (-0.3434) * FermionOperator("2^ 6 12^ 0") +
                           (-0.23423) * FermionOperator("1^ 4 6^ 13") +
                           0.23423 * FermionOperator("13^ 6 4^ 1"))
-        self.assertTrue(test_generator.isclose(generator))
+        self.assertTrue(test_generator == generator)
 
     def test_sparse_uccsd_operator_list_inputs(self):
         """Test list inputs to uccsd_operator that are sparse"""
@@ -128,7 +128,7 @@ class UnitaryCC(unittest.TestCase):
                           (-0.3434) * FermionOperator("2^ 6 12^ 0") +
                           (-0.23423) * FermionOperator("1^ 4 6^ 13") +
                           0.23423 * FermionOperator("13^ 6 4^ 1"))
-        self.assertTrue(test_generator.isclose(generator))
+        self.assertTrue(test_generator == generator)
 
     def test_ucc(self):
         geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 0.7414))]


### PR DESCRIPTION
This change was discussed at #233 . After this is merged, `op1.isclose(op2)` is no longer valid syntax and `op1 == op2` should be used instead, where `op1` and `op2` are SymbolicOperators such as FermionOperator or QubitOperator.

I did not define `__neq__` yet. I will do that once this and #233 are merged, then use EqualsTester to reformulate some tests for `__eq__` (which will also test `__neq__`).