### PR TITLE
Remove redundant double excitation from UCCSD singlet generator

### DIFF
--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -188,8 +188,8 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
         virtual_down = down_index(virtual_spatial)
         occupied_up = up_index(occupied_spatial)
         occupied_down = down_index(occupied_spatial)
-        
-        # Generate single excitations 
+
+        # Generate single excitations
         coeff = t1[i]
         # Spin up excitation
         generator += FermionOperator((
@@ -237,69 +237,44 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
         occupied_spatial_1 = q
         virtual_spatial_2 = n_occupied + r
         occupied_spatial_2 = s
-        # Get indices of spin orbitals
-        virtual_up_1 = up_index(virtual_spatial_1)
-        virtual_down_1 = down_index(virtual_spatial_1)
-        occupied_up_1 = up_index(occupied_spatial_1)
-        occupied_down_1 = down_index(occupied_spatial_1)
-        virtual_up_2 = up_index(virtual_spatial_2)
-        virtual_down_2 = down_index(virtual_spatial_2)
-        occupied_up_2 = up_index(occupied_spatial_2)
-        occupied_down_2 = down_index(occupied_spatial_2)
 
         # Generate double excitations
         coeff = t2_2[i]
-        # p -> q is spin up and s -> r is spin down
-        generator += FermionOperator((
-            (virtual_up_1, 1),
-            (occupied_up_1, 0),
-            (virtual_down_2, 1),
-            (occupied_down_2, 0)),
-            coeff)
-        generator += FermionOperator((
-            (occupied_down_2, 1),
-            (virtual_down_2, 0),
-            (occupied_up_1, 1),
-            (virtual_up_1, 0)),
-            -coeff)
-        # p -> q is spin down and s -> r is spin up
-        generator += FermionOperator((
-            (virtual_up_2, 1),
-            (occupied_up_2, 0),
-            (virtual_down_1, 1),
-            (occupied_down_1, 0)),
-            coeff)
-        generator += FermionOperator((
-            (occupied_down_1, 1),
-            (virtual_down_1, 0),
-            (occupied_up_2, 1),
-            (virtual_up_2, 0)),
-            -coeff)
-        # Both are spin up excitations
-        generator += FermionOperator((
-            (virtual_up_1, 1),
-            (occupied_up_1, 0),
-            (virtual_up_2, 1),
-            (occupied_up_2, 0)),
-            coeff)
-        generator += FermionOperator((
-            (occupied_up_2, 1),
-            (virtual_up_2, 0),
-            (occupied_up_1, 1),
-            (virtual_up_1, 0)),
-            -coeff)
-        # Both are spin down excitations
-        generator += FermionOperator((
-            (virtual_down_1, 1),
-            (occupied_down_1, 0),
-            (virtual_down_2, 1),
-            (occupied_down_2, 0)),
-            coeff)
-        generator += FermionOperator((
-            (occupied_down_2, 1),
-            (virtual_down_2, 0),
-            (occupied_down_1, 1),
-            (virtual_down_1, 0)),
-            -coeff)
+        for spin, (this_index, other_index) in zip(
+                range(2), ((up_index, down_index), (down_index, up_index))):
+            # Get indices of spin orbitals
+            virtual_this_1 = this_index(virtual_spatial_1)
+            occupied_this_1 = this_index(occupied_spatial_1)
+            virtual_other_2 = other_index(virtual_spatial_2)
+            occupied_other_2 = other_index(occupied_spatial_2)
+            virtual_this_2 = this_index(virtual_spatial_2)
+            occupied_this_2 = this_index(occupied_spatial_2)
+
+            # p -> q is this spin and s -> r is the other spin
+            generator += FermionOperator((
+                (virtual_this_1, 1),
+                (occupied_this_1, 0),
+                (virtual_other_2, 1),
+                (occupied_other_2, 0)),
+                coeff)
+            generator += FermionOperator((
+                (occupied_other_2, 1),
+                (virtual_other_2, 0),
+                (occupied_this_1, 1),
+                (virtual_this_1, 0)),
+                -coeff)
+            # Both are this spin
+            generator += FermionOperator((
+                (virtual_this_1, 1),
+                (occupied_this_1, 0),
+                (virtual_this_2, 1),
+                (occupied_this_2, 0)),
+                coeff)
+            generator += FermionOperator((
+                (occupied_this_2, 1),
+                (virtual_this_2, 0),
+                (occupied_this_1, 1),
+                (virtual_this_1, 0)),
+                -coeff)
 
     return generator

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -248,38 +248,38 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
             other_index = spin_index_functions[1 - s]
 
             # Get indices of spin orbitals
-            virtual_this_1 = this_index(virtual_spatial_1)
-            occupied_this_1 = this_index(occupied_spatial_1)
-            virtual_other_2 = other_index(virtual_spatial_2)
-            occupied_other_2 = other_index(occupied_spatial_2)
-            virtual_this_2 = this_index(virtual_spatial_2)
-            occupied_this_2 = this_index(occupied_spatial_2)
+            virtual_1_this = this_index(virtual_spatial_1)
+            occupied_1_this = this_index(occupied_spatial_1)
+            virtual_2_other = other_index(virtual_spatial_2)
+            occupied_2_other = other_index(occupied_spatial_2)
+            virtual_2_this = this_index(virtual_spatial_2)
+            occupied_2_this = this_index(occupied_spatial_2)
 
             # p -> q is this spin and s -> r is the other spin
             generator += FermionOperator((
-                (virtual_this_1, 1),
-                (occupied_this_1, 0),
-                (virtual_other_2, 1),
-                (occupied_other_2, 0)),
+                (virtual_1_this, 1),
+                (occupied_1_this, 0),
+                (virtual_2_other, 1),
+                (occupied_2_other, 0)),
                 coeff)
             generator += FermionOperator((
-                (occupied_other_2, 1),
-                (virtual_other_2, 0),
-                (occupied_this_1, 1),
-                (virtual_this_1, 0)),
+                (occupied_2_other, 1),
+                (virtual_2_other, 0),
+                (occupied_1_this, 1),
+                (virtual_1_this, 0)),
                 -coeff)
             # Both are this spin
             generator += FermionOperator((
-                (virtual_this_1, 1),
-                (occupied_this_1, 0),
-                (virtual_this_2, 1),
-                (occupied_this_2, 0)),
+                (virtual_1_this, 1),
+                (occupied_1_this, 0),
+                (virtual_2_this, 1),
+                (occupied_2_this, 0)),
                 coeff)
             generator += FermionOperator((
-                (occupied_this_2, 1),
-                (virtual_this_2, 0),
-                (occupied_this_1, 1),
-                (virtual_this_1, 0)),
+                (occupied_2_this, 1),
+                (virtual_2_this, 0),
+                (occupied_1_this, 1),
+                (virtual_1_this, 0)),
                 -coeff)
 
     return generator

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -240,8 +240,8 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
 
         # Generate double excitations
         coeff = t2_2[i]
-        for spin, (this_index, other_index) in zip(
-                range(2), ((up_index, down_index), (down_index, up_index))):
+        for this_index, other_index in ((up_index, down_index),
+                                        (down_index, up_index)):
             # Get indices of spin orbitals
             virtual_this_1 = this_index(virtual_spatial_1)
             occupied_this_1 = this_index(occupied_spatial_1)

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -240,8 +240,13 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
 
         # Generate double excitations
         coeff = t2_2[i]
-        for this_index, other_index in ((up_index, down_index),
-                                        (down_index, up_index)):
+        spin_index_functions = [up_index, down_index]
+        for s in range(2):
+            # Get the functions which map a spatial orbital index to a
+            # spin orbital index
+            this_index = spin_index_functions[s]
+            other_index = spin_index_functions[1 - s]
+
             # Get indices of spin orbitals
             virtual_this_1 = this_index(virtual_spatial_1)
             occupied_this_1 = this_index(occupied_spatial_1)

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -129,8 +129,8 @@ def uccsd_singlet_paramsize(n_qubits, n_electrons):
     n_single_amplitudes = n_occupied * n_virtual
 
     # Below is equivalent to
-    #     2 * n_single_amplitudes + (n_single_amplitudes choose 2)
-    n_double_amplitudes = n_single_amplitudes * (n_single_amplitudes + 3) // 2
+    #     n_single_amplitudes + (n_single_amplitudes choose 2)
+    n_double_amplitudes = n_single_amplitudes * (n_single_amplitudes + 1) // 2
 
     return n_single_amplitudes + n_double_amplitudes
 
@@ -168,9 +168,9 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
     # Single amplitudes
     t1 = packed_amplitudes[:n_single_amplitudes]
     # Double amplitudes associated with one spatial occupied-virtual pair
-    t2_1 = packed_amplitudes[n_single_amplitudes:3 * n_single_amplitudes]
+    t2_1 = packed_amplitudes[n_single_amplitudes:2 * n_single_amplitudes]
     # Double amplitudes associated with two spatial occupied-virtual pairs
-    t2_2 = packed_amplitudes[3 * n_single_amplitudes:]
+    t2_2 = packed_amplitudes[2 * n_single_amplitudes:]
 
     # Initialize operator
     generator = FermionOperator()
@@ -210,9 +210,8 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
             (virtual_down, 0)),
             -coeff)
 
-        # Generate double excitations
-        # up -> up and down -> down
-        coeff = t2_1[2 * i]
+        # Generate double excitation
+        coeff = t2_1[i]
         generator += FermionOperator((
             (virtual_up, 1),
             (occupied_up, 0),
@@ -224,20 +223,6 @@ def uccsd_singlet_generator(packed_amplitudes, n_qubits, n_electrons):
             (virtual_down, 0),
             (occupied_up, 1),
             (virtual_up, 0)),
-            -coeff)
-        # up -> down and down -> up
-        coeff = t2_1[2 * i + 1]
-        generator += FermionOperator((
-            (virtual_down, 1),
-            (occupied_up, 0),
-            (virtual_up, 1),
-            (occupied_down, 0)),
-            coeff)
-        generator += FermionOperator((
-            (occupied_down, 1),
-            (virtual_up, 0),
-            (occupied_up, 1),
-            (virtual_down, 0)),
             -coeff)
 
     # Generate all spin-conserving double excitations derived

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -62,8 +62,8 @@ class UnitaryCC(unittest.TestCase):
         packed_amplitudes = randn(int(packed_amplitude_size))
 
         generator = uccsd_singlet_generator(packed_amplitudes,
-                                           test_orbitals,
-                                           test_electrons)
+                                            test_orbitals,
+                                            test_electrons)
 
         conj_generator = hermitian_conjugated(generator)
 
@@ -78,8 +78,8 @@ class UnitaryCC(unittest.TestCase):
                                                         test_electrons)
         packed_amplitudes = randn(int(packed_amplitude_size))
         generator = uccsd_singlet_generator(packed_amplitudes,
-                                           test_orbitals,
-                                           test_electrons)
+                                            test_orbitals,
+                                            test_electrons)
 
         # Construct symmetry operators
         sz = sz_operator(test_orbitals)
@@ -104,8 +104,8 @@ class UnitaryCC(unittest.TestCase):
         initial_amplitudes = [1., 2.]
 
         generator = uccsd_singlet_generator(initial_amplitudes,
-                                           n_orbitals,
-                                           n_electrons)
+                                            n_orbitals,
+                                            n_electrons)
 
         test_generator = (FermionOperator("2^ 0", 1.) +
                           FermionOperator("0^ 2", -1.) +
@@ -114,7 +114,8 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("2^ 0 3^ 1", 2.) +
                           FermionOperator("1^ 3 0^ 2", -2.))
 
-        self.assertTrue(test_generator.isclose(generator))
+        self.assertTrue(normal_ordered(test_generator).isclose(
+                        normal_ordered(generator)))
 
         # Build 2
         n_orbitals = 6
@@ -125,8 +126,8 @@ class UnitaryCC(unittest.TestCase):
 
         initial_amplitudes = numpy.arange(1, n_params + 1, dtype=float)
         generator = uccsd_singlet_generator(initial_amplitudes,
-                                           n_orbitals,
-                                           n_electrons)
+                                            n_orbitals,
+                                            n_electrons)
 
         test_generator = (FermionOperator("2^ 0", 1.) +
                           FermionOperator("0^ 2", -1) +
@@ -149,7 +150,8 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("3^ 1 5^ 1", 5.) +
                           FermionOperator("1^ 5 1^ 3", -5.))
 
-        self.assertTrue(test_generator.isclose(generator))
+        self.assertTrue(normal_ordered(test_generator).isclose(
+                        normal_ordered(generator)))
 
     def test_sparse_uccsd_generator_numpy_inputs(self):
         """Test numpy ndarray inputs to uccsd_generator that are sparse"""
@@ -165,7 +167,7 @@ class UnitaryCC(unittest.TestCase):
         sparse_double_amplitudes[1, 4, 6, 13] = -0.23423
 
         generator = uccsd_generator(sparse_single_amplitudes,
-                                   sparse_double_amplitudes)
+                                    sparse_double_amplitudes)
 
         test_generator = (0.12345 * FermionOperator("3^ 5") +
                           (-0.12345) * FermionOperator("5^ 3") +
@@ -185,7 +187,7 @@ class UnitaryCC(unittest.TestCase):
                                     [[1, 4, 6, 13], -0.23423]]
 
         generator = uccsd_generator(sparse_single_amplitudes,
-                                   sparse_double_amplitudes)
+                                    sparse_double_amplitudes)
 
         test_generator = (0.12345 * FermionOperator("3^ 5") +
                           (-0.12345) * FermionOperator("5^ 3") +

--- a/src/openfermion/utils/_unitary_cc_test.py
+++ b/src/openfermion/utils/_unitary_cc_test.py
@@ -99,9 +99,9 @@ class UnitaryCC(unittest.TestCase):
         n_orbitals = 4
         n_electrons = 2
         n_params = uccsd_singlet_paramsize(n_orbitals, n_electrons)
-        self.assertEqual(n_params, 3)
+        self.assertEqual(n_params, 2)
 
-        initial_amplitudes = [1., 2., 3.]
+        initial_amplitudes = [1., 2.]
 
         generator = uccsd_singlet_generator(initial_amplitudes,
                                            n_orbitals,
@@ -112,9 +112,7 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("3^ 1", 1.) +
                           FermionOperator("1^ 3", -1.) +
                           FermionOperator("2^ 0 3^ 1", 2.) +
-                          FermionOperator("1^ 3 0^ 2", -2.) +
-                          FermionOperator("3^ 0 2^ 1", 3.) +
-                          FermionOperator("1^ 2 0^ 3", -3.))
+                          FermionOperator("1^ 3 0^ 2", -2.))
 
         self.assertTrue(test_generator.isclose(generator))
 
@@ -123,9 +121,9 @@ class UnitaryCC(unittest.TestCase):
         n_electrons = 2
 
         n_params = uccsd_singlet_paramsize(n_orbitals, n_electrons)
-        self.assertEqual(n_params, 7)
+        self.assertEqual(n_params, 5)
 
-        initial_amplitudes = numpy.arange(1, 8, dtype=float)
+        initial_amplitudes = numpy.arange(1, n_params + 1, dtype=float)
         generator = uccsd_singlet_generator(initial_amplitudes,
                                            n_orbitals,
                                            n_electrons)
@@ -140,20 +138,16 @@ class UnitaryCC(unittest.TestCase):
                           FermionOperator("1^ 5", -2.) +
                           FermionOperator("2^ 0 3^ 1", 3.) +
                           FermionOperator("1^ 3 0^ 2", -3.) +
-                          FermionOperator("3^ 0 2^ 1", 4.) +
-                          FermionOperator("1^ 2 0^ 3", -4.) +
-                          FermionOperator("4^ 0 5^ 1", 5.) +
-                          FermionOperator("1^ 5 0^ 4", -5.) +
-                          FermionOperator("5^ 0 4^ 1", 6.) +
-                          FermionOperator("1^ 4 0^ 5", -6.) +
-                          FermionOperator("2^ 0 5^ 1", 7.) +
-                          FermionOperator("1^ 5 0^ 2", -7.) +
-                          FermionOperator("4^ 0 3^ 1", 7.) +
-                          FermionOperator("1^ 3 0^ 4", -7.) +
-                          FermionOperator("2^ 0 4^ 0", 7.) +
-                          FermionOperator("0^ 4 0^ 2", -7.) +
-                          FermionOperator("3^ 1 5^ 1", 7.) +
-                          FermionOperator("1^ 5 1^ 3", -7.))
+                          FermionOperator("4^ 0 5^ 1", 4.) +
+                          FermionOperator("1^ 5 0^ 4", -4.) +
+                          FermionOperator("2^ 0 5^ 1", 5.) +
+                          FermionOperator("1^ 5 0^ 2", -5.) +
+                          FermionOperator("4^ 0 3^ 1", 5.) +
+                          FermionOperator("1^ 3 0^ 4", -5.) +
+                          FermionOperator("2^ 0 4^ 0", 5.) +
+                          FermionOperator("0^ 4 0^ 2", -5.) +
+                          FermionOperator("3^ 1 5^ 1", 5.) +
+                          FermionOperator("1^ 5 1^ 3", -5.))
 
         self.assertTrue(test_generator.isclose(generator))
 


### PR DESCRIPTION
@jarrodmcc I messed up yesterday and added a redundant double excitation. I momentarily forgot that electrons are indistinguishable!