### PR TITLE
Define __neq__ for SymbolicOperator, add tests, add back isclose with DeprecationWarning

### DIFF
--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -543,8 +543,7 @@ class SymbolicOperator(object):
             other(SymbolicOperator): SymbolicOperator to compare against.
         """
         if not isinstance(other, type(self)):
-            raise TypeError('Cannot compare a {} with a {}'.format(
-                type(self).__name__, type(other).__name__))
+            return False
 
         # terms which are in both:
         for term in set(self.terms).intersection(set(other.terms)):
@@ -564,7 +563,7 @@ class SymbolicOperator(object):
         return True
 
     def __neq__(self, other):
-        return not self == other
+        return not (self == other)
 
     def compress(self, abs_tol=EQ_TOLERANCE):
         """
@@ -615,5 +614,5 @@ class SymbolicOperator(object):
         raise DeprecationWarning('The method `isclose` is deprecated and will '
                                  'be removed in a future version. Use == '
                                  'instead. For instance, a == b instead of '
-                                 'a.isclose(b).'
+                                 'a.isclose(b).')
         return self == other

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -563,6 +563,9 @@ class SymbolicOperator(object):
                 return False
         return True
 
+    def __neq__(self, other):
+        return not self == other
+
     def compress(self, abs_tol=EQ_TOLERANCE):
         """
         Eliminates all terms with coefficients close to zero and removes
@@ -604,3 +607,13 @@ class SymbolicOperator(object):
         for coefficient in self.terms.values():
             norm += abs(coefficient) ** order
         return norm ** (1. / order)
+
+
+    # DEPRECATED FUNCTIONS
+    # ====================
+    def isclose(self, other):
+        raise DeprecationWarning('The method `isclose` is deprecated and will '
+                                 'be removed in a future version. Use == '
+                                 'instead. For instance, a == b instead of '
+                                 'a.isclose(b).'
+        return self == other

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -562,7 +562,7 @@ class SymbolicOperator(object):
                 return False
         return True
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not (self == other)
 
     def compress(self, abs_tol=EQ_TOLERANCE):

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -556,7 +556,7 @@ class SymbolicOperator(object):
         # terms only in one (compare to 0.0 so only abs_tol)
         for term in set(self.terms).symmetric_difference(set(other.terms)):
             if term in self.terms:
-                if not abs(self.terms[term]) <= EQ_TOLERANCE: 
+                if not abs(self.terms[term]) <= EQ_TOLERANCE:
                     return False
             elif not abs(other.terms[term]) <= EQ_TOLERANCE:
                 return False
@@ -606,7 +606,6 @@ class SymbolicOperator(object):
         for coefficient in self.terms.values():
             norm += abs(coefficient) ** order
         return norm ** (1. / order)
-
 
     # DEPRECATED FUNCTIONS
     # ====================

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -12,8 +12,10 @@
 
 """Tests  _symbolic_operator.py."""
 import copy
-import numpy
 import unittest
+
+import numpy
+from openfermion._testing_utils import EqualsTester
 
 from openfermion.ops._symbolic_operator import (SymbolicOperator,
                                                 prune_unused_indices)
@@ -33,6 +35,55 @@ class DummyOperator2(SymbolicOperator):
     action_strings = ('X', 'Y', 'Z')
     action_before_index = True
     different_indices_commute = True
+
+
+class GeneralTest(unittest.TestCase):
+    """General tests."""
+
+    def test_eq(self):
+        """Test == and !=."""
+        equals_tester = EqualsTester(self)
+
+        # Zeros
+        eq.add_equality_group(DummyOperator(),
+                              DummyOperator1('1^ 0', -1j, 0.),
+                              DummyOperator1('1^ 0', -1j) * 0)
+
+    def test_isclose_different_terms(self):
+        a = DummyOperator1(((1, 0),), -0.1j)
+        b = DummyOperator1(((1, 1),), -0.1j)
+        self.assertFalse(a == b)
+
+    def test_isclose_different_num_terms(self):
+        a = DummyOperator1(((1, 0),), -0.1j)
+        a += DummyOperator1(((1, 1),), -0.1j)
+        b = DummyOperator1(((1, 0),), -0.1j)
+        self.assertFalse(b == a)
+        self.assertFalse(a == b)
+
+    def test_isclose_zero_terms(self):
+        op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
+        self.assertTrue(op == DummyOperator2())
+        self.assertTrue(DummyOperator2((), 0.0) == op)
+
+    def test_isclose_different_terms(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(not a == b)
+        self.assertTrue(not b == a)
+
+    def test_isclose_different_num_terms(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        a += DummyOperator2(((2, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(not b == a)
+        self.assertTrue(not a == b)
+
+    def test_isclose_invalid_type(self):
+        a = DummyOperator1()
+        b = DummyOperator2()
+        with self.assertRaises(TypeError):
+            a == b
 
 
 class SymbolicOperatorTest1(unittest.TestCase):
@@ -214,23 +265,6 @@ class SymbolicOperatorTest1(unittest.TestCase):
     def test_DummyOperator1(self):
         op = DummyOperator1((), 3.)
         self.assertTrue(op == DummyOperator1(()) * 3.)
-
-    def test_isclose_zero_terms(self):
-        op = DummyOperator1('1^ 0', -1j) * 0
-        self.assertTrue(op == DummyOperator1())
-        self.assertTrue(DummyOperator1() == op)
-
-    def test_isclose_different_terms(self):
-        a = DummyOperator1(((1, 0),), -0.1j)
-        b = DummyOperator1(((1, 1),), -0.1j)
-        self.assertFalse(a == b)
-
-    def test_isclose_different_num_terms(self):
-        a = DummyOperator1(((1, 0),), -0.1j)
-        a += DummyOperator1(((1, 1),), -0.1j)
-        b = DummyOperator1(((1, 0),), -0.1j)
-        self.assertFalse(b == a)
-        self.assertFalse(a == b)
 
     def test_imul_inplace(self):
         fermion_op = DummyOperator1("1^")
@@ -730,30 +764,6 @@ class SymbolicOperatorTest2(unittest.TestCase):
         self.assertTrue(len(a.terms) == 1)
         for term in a.terms:
             self.assertTrue(isinstance(a.terms[term], float))
-
-    def test_isclose_zero_terms(self):
-        op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
-        self.assertTrue(op == DummyOperator2())
-        self.assertTrue(DummyOperator2((), 0.0) == op)
-
-    def test_isclose_different_terms(self):
-        a = DummyOperator2(((1, 'Y'),), -0.1j)
-        b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not a == b)
-        self.assertTrue(not b == a)
-
-    def test_isclose_different_num_terms(self):
-        a = DummyOperator2(((1, 'Y'),), -0.1j)
-        a += DummyOperator2(((2, 'Y'),), -0.1j)
-        b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not b == a)
-        self.assertTrue(not a == b)
-
-    def test_isclose_invalid_type(self):
-        a = DummyOperator1()
-        b = DummyOperator2()
-        with self.assertRaises(TypeError):
-            a == b
 
     def test_rmul_scalar(self):
         multiplier = 0.5

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -573,8 +573,7 @@ class SymbolicOperatorTest1(unittest.TestCase):
         op = DummyOperator1(((1, 1), (3, 1), (8, 1)), 0.5)
         _ = -op
         # out of place
-        self.assertTrue(op == DummyOperator1(((1, 1), (3, 1), (8, 1)),
-                                                  0.5))
+        self.assertTrue(op == DummyOperator1(((1, 1), (3, 1), (8, 1)), 0.5))
         correct = -1.0 * op
         self.assertTrue(correct == -op)
 
@@ -883,8 +882,8 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
         -op
         # out of place
-        self.assertTrue(op ==
-                DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5))
+        self.assertTrue(op == DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')),
+                                             0.5))
         correct = -1.0 * op
         self.assertTrue(correct == -op)
 

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -928,3 +928,13 @@ class SymbolicOperatorTest2(unittest.TestCase):
         op = prune_unused_indices(op)
         expected = DummyOperator1(((0, 1), (2, 1), (1, 0)), 0.5)
         self.assertTrue(expected == op)
+
+
+class DeprecatedFunctionsTest(unittest.TestCase):
+    """Tests for deprecated functions."""
+
+    def test_isclose(self):
+        op1 = DummyOperator1()
+        op2 = DummyOperator1('0^', 0.)
+        with self.assertRaises(DeprecationWarning):
+            op1.isclose(op2)

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -933,8 +933,43 @@ class SymbolicOperatorTest2(unittest.TestCase):
 class DeprecatedFunctionsTest(unittest.TestCase):
     """Tests for deprecated functions."""
 
-    def test_isclose(self):
+    def test_warnings(self):
         op1 = DummyOperator1()
         op2 = DummyOperator1('0^', 0.)
         with self.assertRaises(DeprecationWarning):
             op1.isclose(op2)
+
+    def test_isclose_zero_terms_1(self):
+        op = DummyOperator1('1^ 0', -1j) * 0
+        self.assertTrue(op == DummyOperator1())
+        self.assertTrue(DummyOperator1() == op)
+
+    def test_isclose_different_terms_1(self):
+        a = DummyOperator1(((1, 0),), -0.1j)
+        b = DummyOperator1(((1, 1),), -0.1j)
+        self.assertFalse(a == b)
+
+    def test_isclose_different_num_terms_1(self):
+        a = DummyOperator1(((1, 0),), -0.1j)
+        a += DummyOperator1(((1, 1),), -0.1j)
+        b = DummyOperator1(((1, 0),), -0.1j)
+        self.assertFalse(b == a)
+        self.assertFalse(a == b)
+
+    def test_isclose_zero_terms_2(self):
+        op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
+        self.assertTrue(op == DummyOperator2())
+        self.assertTrue(DummyOperator2((), 0.0) == op)
+
+    def test_isclose_different_terms_2(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(not a == b)
+        self.assertTrue(not b == a)
+
+    def test_isclose_different_num_terms_2(self):
+        a = DummyOperator2(((1, 'Y'),), -0.1j)
+        a += DummyOperator2(((2, 'Y'),), -0.1j)
+        b = DummyOperator2(((1, 'X'),), -0.1j)
+        self.assertTrue(not b == a)
+        self.assertTrue(not a == b)

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -15,7 +15,7 @@ import copy
 import unittest
 
 import numpy
-from openfermion._testing_utils import EqualsTester
+from openfermion.utils._testing_utils import EqualsTester
 
 from openfermion.ops._symbolic_operator import (SymbolicOperator,
                                                 prune_unused_indices)
@@ -40,50 +40,34 @@ class DummyOperator2(SymbolicOperator):
 class GeneralTest(unittest.TestCase):
     """General tests."""
 
-    def test_eq(self):
+    def test_eq_and_neq(self):
         """Test == and !=."""
         equals_tester = EqualsTester(self)
 
-        # Zeros
-        eq.add_equality_group(DummyOperator(),
-                              DummyOperator1('1^ 0', -1j, 0.),
-                              DummyOperator1('1^ 0', -1j) * 0)
+        zeros_1 = [DummyOperator1(),
+                   DummyOperator1('1^ 0', 0.),
+                   DummyOperator1('1^ 0', -1j) * 0]
 
-    def test_isclose_different_terms(self):
-        a = DummyOperator1(((1, 0),), -0.1j)
-        b = DummyOperator1(((1, 1),), -0.1j)
-        self.assertFalse(a == b)
+        zeros_2 = [DummyOperator2(),
+                   DummyOperator2(((1, 'Y'), (0, 'X')), 0.),
+                   DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0]
 
-    def test_isclose_different_num_terms(self):
-        a = DummyOperator1(((1, 0),), -0.1j)
-        a += DummyOperator1(((1, 1),), -0.1j)
-        b = DummyOperator1(((1, 0),), -0.1j)
-        self.assertFalse(b == a)
-        self.assertFalse(a == b)
+        different_ops_1 = [DummyOperator1(((1, 0),), -0.1j),
+                           DummyOperator1(((1, 1),), -0.1j),
+                           (DummyOperator1(((1, 0),), -0.1j) +
+                            DummyOperator1(((1, 1),), -0.1j))]
 
-    def test_isclose_zero_terms(self):
-        op = DummyOperator2(((1, 'Y'), (0, 'X')), -1j) * 0
-        self.assertTrue(op == DummyOperator2())
-        self.assertTrue(DummyOperator2((), 0.0) == op)
+        different_ops_2 = [DummyOperator2(((1, 'Y'),), -0.1j),
+                           DummyOperator2(((1, 'X'),), -0.1j),
+                           (DummyOperator2(((1, 'Y'),), -0.1j) +
+                            DummyOperator2(((2, 'Y'),), -0.1j))]
 
-    def test_isclose_different_terms(self):
-        a = DummyOperator2(((1, 'Y'),), -0.1j)
-        b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not a == b)
-        self.assertTrue(not b == a)
-
-    def test_isclose_different_num_terms(self):
-        a = DummyOperator2(((1, 'Y'),), -0.1j)
-        a += DummyOperator2(((2, 'Y'),), -0.1j)
-        b = DummyOperator2(((1, 'X'),), -0.1j)
-        self.assertTrue(not b == a)
-        self.assertTrue(not a == b)
-
-    def test_isclose_invalid_type(self):
-        a = DummyOperator1()
-        b = DummyOperator2()
-        with self.assertRaises(TypeError):
-            a == b
+        equals_tester.add_equality_group(*zeros_1)
+        equals_tester.add_equality_group(*zeros_2)
+        for op in different_ops_1:
+            equals_tester.add_equality_group(op)
+        for op in different_ops_2:
+            equals_tester.add_equality_group(op)
 
 
 class SymbolicOperatorTest1(unittest.TestCase):


### PR DESCRIPTION
- Define `__neq__` for SymbolicOperator and add tests
- Allow `__eq__` for SymbolicOperator to be applied to an operator of a different type (returns `False`).
- Add back `isclose` with a DeprecationWarning