### PR TITLE
Don't "raise" warning

### DIFF
--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -13,6 +13,7 @@
 """SymbolicOperator is the base class for FermionOperator and QubitOperator"""
 import copy
 import re
+import warnings
 
 from openfermion.config import EQ_TOLERANCE
 
@@ -610,8 +611,8 @@ class SymbolicOperator(object):
     # DEPRECATED FUNCTIONS
     # ====================
     def isclose(self, other):
-        raise DeprecationWarning('The method `isclose` is deprecated and will '
-                                 'be removed in a future version. Use == '
-                                 'instead. For instance, a == b instead of '
-                                 'a.isclose(b).')
+        warnings.warn('The method `isclose` is deprecated and will '
+                      'be removed in a future version. Use == '
+                      'instead. For instance, a == b instead of '
+                      'a.isclose(b).', DeprecationWarning)
         return self == other

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -933,12 +933,6 @@ class SymbolicOperatorTest2(unittest.TestCase):
 class DeprecatedFunctionsTest(unittest.TestCase):
     """Tests for deprecated functions."""
 
-    def test_warnings(self):
-        op1 = DummyOperator1()
-        op2 = DummyOperator1('0^', 0.)
-        with self.assertWarns(DeprecationWarning):
-            op1.isclose(op2)
-
     def test_isclose_zero_terms_1(self):
         op = DummyOperator1('1^ 0', -1j) * 0
         self.assertTrue(op == DummyOperator1())

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -936,7 +936,7 @@ class DeprecatedFunctionsTest(unittest.TestCase):
     def test_warnings(self):
         op1 = DummyOperator1()
         op2 = DummyOperator1('0^', 0.)
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             op1.isclose(op2)
 
     def test_isclose_zero_terms_1(self):

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -13,6 +13,7 @@
 """Tests  _symbolic_operator.py."""
 import copy
 import unittest
+import warnings
 
 import numpy
 from openfermion.utils._testing_utils import EqualsTester
@@ -932,6 +933,18 @@ class SymbolicOperatorTest2(unittest.TestCase):
 
 class DeprecatedFunctionsTest(unittest.TestCase):
     """Tests for deprecated functions."""
+
+    def test_warnings(self):
+        """Test that warnings are raised appropriately."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            op1 = DummyOperator1()
+            op1.isclose(op1)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertTrue("deprecated" in str(w[0].message))
 
     def test_isclose_zero_terms_1(self):
         op = DummyOperator1('1^ 0', -1j) * 0


### PR DESCRIPTION
I messed up; "raising" a warning causes the program to terminate and the correct way to do it is to use the `warnings` module.