### PR TITLE
Allow initialization of SymbolicOperator with single factor

### DIFF
--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -171,6 +171,23 @@ class SymbolicOperator(object):
             else:
                 self.terms[term] += coef
 
+    def _validate_factor(self, factor):
+        """Check that a factor of a term is valid."""
+        if len(factor) != 2:
+            raise ValueError('Invalid factor {}.'.format(factor))
+
+        index, action = factor
+
+        if action not in self.actions:
+            raise ValueError('Invalid action in factor {}. '
+                             'Valid actions are: {}'.format(
+                                 factor, self.actions))
+
+        if not isinstance(index, int) or index < 0:
+            raise ValueError('Invalid index in factor {}. '
+                             'The index should be a non-negative '
+                             'integer.'.format(factor))
+
     def _parse_sequence(self, term):
         """Parse a term given as a sequence type (i.e., list, tuple, etc.).
 
@@ -180,23 +197,14 @@ class SymbolicOperator(object):
         if not term:
             # Empty sequence
             return ()
+        elif isinstance(term[0], int):
+            # Single factor
+            self._validate_factor(term)
+            return (tuple(term),)
         else:
             # Check that all factors in the term are valid
             for factor in term:
-                if len(factor) != 2:
-                    raise ValueError('Invalid factor {}.'.format(factor))
-
-                index, action = factor
-
-                if action not in self.actions:
-                    raise ValueError('Invalid action in factor {}. '
-                                     'Valid actions are: {}'.format(
-                                         factor, self.actions))
-
-                if not isinstance(index, int) or index < 0:
-                    raise ValueError('Invalid index in factor {}. '
-                                     'The index should be a non-negative '
-                                     'integer.'.format(factor))
+                self._validate_factor(factor)
 
             # If factors with different indices commute, sort the factors
             # by index

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -69,6 +69,16 @@ class GeneralTest(unittest.TestCase):
         for op in different_ops_2:
             equals_tester.add_equality_group(op)
 
+    def test_init_single_factor(self):
+        """Test initialization of the form DummyOperator((index, action))."""
+        equals_tester = EqualsTester(self)
+
+        group_1 = [DummyOperator1((3, 0)), DummyOperator1(((3, 0),))]
+        group_2 = [DummyOperator2((5, 'X')), DummyOperator2(((5, 'X'),))]
+
+        equals_tester.add_equality_group(*group_1)
+        equals_tester.add_equality_group(*group_2)
+
 
 class SymbolicOperatorTest1(unittest.TestCase):
     """Test the subclass DummyOperator1."""

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -80,6 +80,7 @@ class GeneralTest(unittest.TestCase):
 
         equals_tester.add_equality_group(*group_1)
         equals_tester.add_equality_group(*group_2)
+        equals_tester.add_equality_group(*group_3)
 
 
 class SymbolicOperatorTest1(unittest.TestCase):

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -75,6 +75,8 @@ class GeneralTest(unittest.TestCase):
 
         group_1 = [DummyOperator1((3, 0)), DummyOperator1(((3, 0),))]
         group_2 = [DummyOperator2((5, 'X')), DummyOperator2(((5, 'X'),))]
+        group_3 = [DummyOperator2((5, 'X'), .5),
+                   DummyOperator2(((5, 'X'),), .5)]
 
         equals_tester.add_equality_group(*group_1)
         equals_tester.add_equality_group(*group_2)


### PR DESCRIPTION
Often I want to initialize something with a single factor like `QubitOperator('X0')` but programmatically so I need to use a tuple, like `QubitOperator(((0, 'X'),))` and I find it very annoying to have to type out the parentheses and second comma. So this PR lets you initialize it using `QubitOperator((0, 'X'))` instead.

Yes/No?