### PR TITLE
Fix Jordan Wigner for InteractionOperator

### DIFF
--- a/src/openfermion/transforms/_bksf.py
+++ b/src/openfermion/transforms/_bksf.py
@@ -110,8 +110,9 @@ def bravyi_kitaev_fast_interaction_op(iop):
                                 continue
                         # Handle case of 3 unique indices
                         elif len(set([p, q, r, s])) == 3:
-                            transformed_term = two_body(edge_matrix_indices,p, q, r, s)
-                            transformed_term *= coefficient/2.
+                            transformed_term = two_body(edge_matrix_indices,
+                                                        p, q, r, s)
+                            transformed_term *= .5 * coefficient
                             qubit_operator += transformed_term
                             continue
                         elif p != r and q < p:

--- a/src/openfermion/transforms/_bksf.py
+++ b/src/openfermion/transforms/_bksf.py
@@ -108,8 +108,15 @@ def bravyi_kitaev_fast_interaction_op(iop):
                         if len(set([p, q, r, s])) == 4:
                             if min(r, s) < min(p, q):
                                 continue
+                        # Handle case of 3 unique indices
+                        elif len(set([p, q, r, s])) == 3:
+                            transformed_term = two_body(edge_matrix_indices,p, q, r, s)
+                            transformed_term *= coefficient/2.
+                            qubit_operator += transformed_term
+                            continue
                         elif p != r and q < p:
                                 continue
+
 
                     # Handle the two-body terms.
                     transformed_term = two_body(edge_matrix_indices,

--- a/src/openfermion/transforms/_jordan_wigner.py
+++ b/src/openfermion/transforms/_jordan_wigner.py
@@ -91,27 +91,25 @@ def jordan_wigner_interaction_op(iop, n_qubits=None):
     # Transform other one-body terms and "diagonal" two-body terms
     for p, q in itertools.combinations(range(n_qubits), 2):
         # One-body
-        coefficient = iop[(p, 1), (q, 0)]
+        coefficient = .5 * (iop[(p, 1), (q, 0)] + iop[(q, 1), (p, 0)])
         qubit_operator += jordan_wigner_one_body(p, q, coefficient)
 
         # Two-body
-        coefficient = iop[(p, 1), (q, 1), (p, 0), (q, 0)]
+        coefficient = (iop[(p, 1), (q, 1), (p, 0), (q, 0)] -
+                       iop[(p, 1), (q, 1), (q, 0), (p, 0)] -
+                       iop[(q, 1), (p, 1), (p, 0), (q, 0)] +
+                       iop[(q, 1), (p, 1), (q, 0), (p, 0)])
         qubit_operator += jordan_wigner_two_body(p, q, p, q, coefficient)
-        coefficient = iop[(p, 1), (q, 1), (q, 0), (p, 0)]
-        qubit_operator += jordan_wigner_two_body(p, q, q, p, coefficient)
 
     # Transform the rest of the two-body terms
     for (p, q), (r, s) in itertools.combinations(
             itertools.combinations(range(n_qubits), 2),
             2):
-        coefficient = iop[(p, 1), (q, 1), (r, 0), (s, 0)]
+        coefficient = (iop[(p, 1), (q, 1), (r, 0), (s, 0)] -
+                       iop[(p, 1), (q, 1), (s, 0), (r, 0)] -
+                       iop[(q, 1), (p, 1), (r, 0), (s, 0)] +
+                       iop[(q, 1), (p, 1), (s, 0), (r, 0)])
         qubit_operator += jordan_wigner_two_body(p, q, r, s, coefficient)
-        coefficient = iop[(p, 1), (q, 1), (s, 0), (r, 0)]
-        qubit_operator += jordan_wigner_two_body(p, q, s, r, coefficient)
-        coefficient = iop[(q, 1), (p, 1), (r, 0), (s, 0)]
-        qubit_operator += jordan_wigner_two_body(q, p, r, s, coefficient)
-        coefficient = iop[(q, 1), (p, 1), (s, 0), (r, 0)]
-        qubit_operator += jordan_wigner_two_body(q, p, s, r, coefficient)
 
     return qubit_operator
 

--- a/src/openfermion/transforms/_jordan_wigner.py
+++ b/src/openfermion/transforms/_jordan_wigner.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import itertools
 
+from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import (FermionOperator, InteractionOperator,
                              QubitOperator)
 
@@ -95,7 +96,7 @@ def jordan_wigner_interaction_op(iop, n_qubits=None):
                     coefficient = complex(iop[(p, 1), (q, 1), (r, 0), (s, 0)])
 
                     # Skip zero terms.
-                    if (not coefficient) or (p == q) or (r == s):
+                    if abs(coefficient) < EQ_TOLERANCE or (p == q) or (r == s):
                         continue
 
                     # Identify and skip one of the complex conjugates.

--- a/src/openfermion/transforms/_jordan_wigner.py
+++ b/src/openfermion/transforms/_jordan_wigner.py
@@ -179,17 +179,17 @@ def jordan_wigner_two_body(p, q, r, s, coefficient=1.):
             operators += ((d, operator_d),)
 
             # Get coefficients.
-            coefficient *= .125
+            coeff = .125 * coefficient
             parity_condition = bool(operator_p != operator_q or
                                     operator_p == operator_r)
             if (p > q) ^ (r > s):
                 if not parity_condition:
-                    coefficient *= -1.
+                    coeff *= -1.
             elif parity_condition:
-                coefficient *= -1.
+                coeff *= -1.
 
             # Add term.
-            qubit_operator += QubitOperator(operators, coefficient)
+            qubit_operator += QubitOperator(operators, coeff)
 
     # Handle case of three unique indices.
     elif len(set([p, q, r, s])) == 3:
@@ -216,12 +216,12 @@ def jordan_wigner_two_body(p, q, r, s, coefficient=1.):
 
             # Get coefficient.
             if (p == s) or (q == r):
-                coefficient *= .25
+                coeff = .25 * coefficient
             else:
-                coefficient *= -.25
+                coeff = -.25 * coefficient
 
             # Add term.
-            hopping_term = QubitOperator(operators, coefficient)
+            hopping_term = QubitOperator(operators, coeff)
             qubit_operator -= pauli_z * hopping_term
             qubit_operator += hopping_term
 
@@ -230,15 +230,16 @@ def jordan_wigner_two_body(p, q, r, s, coefficient=1.):
 
         # Get coefficient.
         if p == s:
-            coefficient *= -.25
+            coeff = -.25 * coefficient
         else:
-            coefficient *= .25
+            coeff = .25 * coefficient
 
         # Add terms.
-        qubit_operator -= QubitOperator((), coefficient)
-        qubit_operator += QubitOperator(((p, 'Z'),), coefficient)
-        qubit_operator += QubitOperator(((q, 'Z'),), coefficient)
+        qubit_operator -= QubitOperator((), coeff)
+        qubit_operator += QubitOperator(((p, 'Z'),), coeff)
+        qubit_operator += QubitOperator(((q, 'Z'),), coeff)
         qubit_operator -= QubitOperator(((min(q, p), 'Z'), (max(q, p), 'Z')),
-                                        coefficient)
+                                        coeff)
 
     return qubit_operator
+

--- a/src/openfermion/transforms/_jordan_wigner.py
+++ b/src/openfermion/transforms/_jordan_wigner.py
@@ -18,6 +18,7 @@ import itertools
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import (FermionOperator, InteractionOperator,
                              QubitOperator)
+from openfermion.utils import count_qubits
 
 
 def jordan_wigner(operator):
@@ -72,7 +73,6 @@ def jordan_wigner_interaction_op(iop, n_qubits=None):
     Returns:
         qubit_operator: An instance of the QubitOperator class.
     """
-    from openfermion.utils import count_qubits
     if n_qubits is None:
         n_qubits = count_qubits(iop)
     if n_qubits < count_qubits(iop):

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -278,6 +278,11 @@ class InteractionOperatorsJWTest(unittest.TestCase):
     def test_jordan_wigner_twobody_interaction_op_reversal_symmetric(self):
         test_op = FermionOperator('1^ 2^ 2 1')
         test_op += hermitian_conjugated(test_op)
+        print(jordan_wigner(test_op))
+        print()
+        print(jordan_wigner(get_interaction_operator(test_op)))
+        print()
+        print(get_interaction_operator(test_op)[(1, 1), (2, 1), (2, 0), (1, 0)])
         self.assertTrue(jordan_wigner(test_op) ==
                         jordan_wigner(get_interaction_operator(test_op)))
 

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -226,23 +226,23 @@ class InteractionOperatorsJWTest(unittest.TestCase):
         op1 = jordan_wigner(iop)
         op2 = jordan_wigner(get_fermion_operator(iop))
 
-        self.assertTrue(op1 == op2)
+        self.assertEqual(op1, op2)
 
         # Interaction operator from molecule
-
         geometry = [('Li', (0., 0., 0.)), ('H', (0., 0., 1.45))]
         basis = 'sto-3g'
         multiplicity = 1
 
         filename = os.path.join(DATA_DIRECTORY, 'H1-Li1_sto-3g_singlet_1.45')
-        molecule = MolecularData(geometry, basis, multiplicity, filename=filename)
+        molecule = MolecularData(geometry, basis, multiplicity,
+                                 filename=filename)
         molecule.load()
 
         iop = molecule.get_molecular_hamiltonian()
         op1 = jordan_wigner(iop)
         op2 = jordan_wigner(get_fermion_operator(iop))
 
-        assert op1 == op2
+        self.assertEqual(op1, op2)
 
     def test_jordan_wigner_one_body(self):
         # Make sure it agrees with jordan_wigner(FermionTerm).

--- a/src/openfermion/transforms/_jordan_wigner_test.py
+++ b/src/openfermion/transforms/_jordan_wigner_test.py
@@ -20,13 +20,15 @@ from openfermion.ops import (FermionOperator,
                              InteractionOperator,
                              normal_ordered,
                              QubitOperator)
-from openfermion.transforms import (get_interaction_operator,
+from openfermion.transforms import (get_fermion_operator,
+                                    get_interaction_operator,
                                     reverse_jordan_wigner)
 from openfermion.transforms._jordan_wigner import (
     jordan_wigner, jordan_wigner_one_body, jordan_wigner_two_body,
     jordan_wigner_interaction_op)
 
 from openfermion.utils import hermitian_conjugated, number_operator
+from openfermion.utils._testing_utils import random_interaction_operator
 
 
 class JordanWignerTransformTest(unittest.TestCase):
@@ -212,6 +214,15 @@ class InteractionOperatorsJWTest(unittest.TestCase):
         self.interaction_operator = InteractionOperator(self.constant,
                                                         self.one_body,
                                                         self.two_body)
+
+    def test_consistency(self):
+        """Test consistency with JW for FermionOperators."""
+        n_qubits = 5
+        iop = random_interaction_operator(n_qubits)
+        op1 = jordan_wigner(iop)
+        op2 = jordan_wigner(get_fermion_operator(iop))
+
+        self.assertTrue(op1 == op2)
 
     def test_jordan_wigner_one_body(self):
         # Make sure it agrees with jordan_wigner(FermionTerm).

--- a/src/openfermion/utils/_operator_utils_test.py
+++ b/src/openfermion/utils/_operator_utils_test.py
@@ -25,7 +25,6 @@ from openfermion.transforms import (bravyi_kitaev, jordan_wigner,
                                     get_fermion_operator,
                                     get_interaction_operator)
 from openfermion.utils import Grid
-from openfermion.utils._testing_utils import random_interaction_operator
 
 from openfermion.utils._operator_utils import *
 


### PR DESCRIPTION
Fixes #281 .

Instead of finding the bug I just rewrote the code. It's also now about 4x faster than the old (incorrect) code.

One thing I noticed and documented is that based on the way the helper functions `jordan_wigner_one_body` and `jordan_wigner_two_body` are written, this only supports InteractionOperators with real entries. Maybe a future PR can expand support to complex ones.