### PR TITLE
fixed bug in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
   - pip$PY install --only-binary=scipy scipy
   - pip$PY install --only-binary=jupyter jupyter
   - pip$PY install --only-binary=matplotlib matplotlib
-  - pip$PY install -r requirements.txt
   - pip$PY install pytest
   - pip$PY install pytest-cov
   - pip$PY install coveralls


### PR DESCRIPTION
This should cause travis to fail until we've fixed the future dependency in setup. This should prevent such problems from occurring in the future. Once we've fixed the setup script we should merge this and then bump the version again (unfortunately).