### PR TITLE
Fix PolynomialTensor multiply, extend to floats, and allow dividing by numbers

### DIFF
--- a/src/openfermion/ops/_diagonal_coulomb_hamiltonian.py
+++ b/src/openfermion/ops/_diagonal_coulomb_hamiltonian.py
@@ -9,6 +9,9 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import division
+
+import copy
 
 """Class for electronic structure Hamiltonians with a diagonal Coulomb term"""
 
@@ -35,3 +38,34 @@ class DiagonalCoulombHamiltonian:
         self.one_body = one_body
         self.two_body = two_body
         self.constant = constant
+
+    def __imul__(self, multiplier):
+        self.one_body *= multiplier
+        self.two_body *= multiplier
+        self.constant *= multiplier
+        return self
+
+    def __mul__(self, multiplier):
+        product = copy.deepcopy(self)
+        product *= multiplier
+        return product
+
+    def __rmul__(self, multiplier):
+        product = copy.deepcopy(self)
+        product *= multiplier
+        return product
+
+    def __itruediv__(self, dividend):
+        self.one_body /= dividend
+        self.two_body /= dividend
+        self.constant /= dividend
+        return self
+
+    def __truediv__(self, dividend):
+        quotient = copy.deepcopy(self)
+        quotient /= dividend
+        return quotient
+
+    def __div__(self, divisor):
+        """ For compatibility with Python 2. """
+        return self.__truediv__(divisor)

--- a/src/openfermion/ops/_diagonal_coulomb_hamiltonian_test.py
+++ b/src/openfermion/ops/_diagonal_coulomb_hamiltonian_test.py
@@ -1,0 +1,35 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from __future__ import division
+
+import unittest
+
+from openfermion.transforms import get_fermion_operator
+from openfermion.utils._testing_utils import random_diagonal_coulomb_hamiltonian
+
+class DiagonalCoulombHamiltonianTest(unittest.TestCase):
+
+    def test_multiply(self):
+        n_qubits = 5
+        op1 = random_diagonal_coulomb_hamiltonian(n_qubits)
+        op2 = op1 * 1.5
+        op3 = 1.5 * op1
+        self.assertEqual(get_fermion_operator(op1) * 1.5,
+                         get_fermion_operator(op2),
+                         get_fermion_operator(op3))
+
+    def test_divide(self):
+        n_qubits = 5
+        op1 = random_diagonal_coulomb_hamiltonian(n_qubits)
+        op2 = op1 / 1.5
+        self.assertEqual(get_fermion_operator(op1) / 1.5,
+                         get_fermion_operator(op2))

--- a/src/openfermion/ops/_polynomial_tensor.py
+++ b/src/openfermion/ops/_polynomial_tensor.py
@@ -277,6 +277,11 @@ class PolynomialTensor(object):
         product *= multiplier
         return product
 
+    def __rmul__(self, multiplier):
+        product = copy.deepcopy(self)
+        product *= multiplier
+        return product
+
     def __itruediv__(self, dividend):
         if isinstance(dividend, (int, float, complex)):
             for key in self.n_body_tensors:
@@ -290,6 +295,10 @@ class PolynomialTensor(object):
         quotient = copy.deepcopy(self)
         quotient /= dividend
         return quotient
+
+    def __div__(self, divisor):
+        """ For compatibility with Python 2. """
+        return self.__truediv__(divisor)
 
     def __iter__(self):
         """Iterate over non-zero elements of PolynomialTensor."""

--- a/src/openfermion/ops/_polynomial_tensor.py
+++ b/src/openfermion/ops/_polynomial_tensor.py
@@ -9,10 +9,9 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 """Base class for representating operators that are polynomials in the
 fermionic ladder operators."""
-from __future__ import absolute_import
+from __future__ import division
 
 import copy
 import itertools

--- a/src/openfermion/ops/_polynomial_tensor_test.py
+++ b/src/openfermion/ops/_polynomial_tensor_test.py
@@ -19,6 +19,7 @@ import copy
 import numpy
 
 from openfermion.ops import PolynomialTensor
+from openfermion.transforms import get_fermion_operator
 from openfermion.utils._slater_determinants_test import (
     random_quadratic_hamiltonian)
 
@@ -260,6 +261,22 @@ class PolynomialTensorTest(unittest.TestCase):
         new_tensor = self.polynomial_tensor_a * self.polynomial_tensor_b
         self.assertEqual(new_tensor, self.polynomial_tensor_axb)
 
+        new_tensor_1 = self.polynomial_tensor_a * 2.
+        new_tensor_2 = 2. * self.polynomial_tensor_a
+
+        self.assertEqual(new_tensor_1, PolynomialTensor(
+            {(): self.constant * 2.,
+             (1, 0): self.one_body_a * 2.,
+             (1, 1, 0, 0): self.two_body_a * 2.}))
+        self.assertEqual(new_tensor_2, PolynomialTensor(
+            {(): self.constant * 2.,
+             (1, 0): self.one_body_a * 2.,
+             (1, 1, 0, 0): self.two_body_a * 2.}))
+        self.assertEqual(get_fermion_operator(new_tensor_1),
+                         get_fermion_operator(self.polynomial_tensor_a) * 2.)
+        self.assertEqual(get_fermion_operator(new_tensor_2),
+                         get_fermion_operator(self.polynomial_tensor_a) * 2.)
+
     def test_imul(self):
         new_tensor = copy.deepcopy(self.polynomial_tensor_a)
         new_tensor *= self.polynomial_tensor_b
@@ -285,6 +302,8 @@ class PolynomialTensorTest(unittest.TestCase):
             {(): self.constant / 2.,
              (1, 0): self.one_body_a / 2.,
              (1, 1, 0, 0): self.two_body_a / 2.}))
+        self.assertEqual(get_fermion_operator(new_tensor),
+                         get_fermion_operator(self.polynomial_tensor_a) / 2.)
 
     def test_idiv(self):
         new_tensor = copy.deepcopy(self.polynomial_tensor_a)
@@ -293,6 +312,8 @@ class PolynomialTensorTest(unittest.TestCase):
             {(): self.constant / 3.,
              (1, 0): self.one_body_a / 3.,
              (1, 1, 0, 0): self.two_body_a / 3.}))
+        self.assertEqual(get_fermion_operator(new_tensor),
+                         get_fermion_operator(self.polynomial_tensor_a) / 3.)
 
     def test_invalid_dividend(self):
         with self.assertRaises(TypeError):

--- a/src/openfermion/ops/_polynomial_tensor_test.py
+++ b/src/openfermion/ops/_polynomial_tensor_test.py
@@ -267,7 +267,7 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_multiplier(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a * 2
+            self.polynomial_tensor_a * 'a'
 
     def test_invalid_tensor_shape_mult(self):
         with self.assertRaises(TypeError):
@@ -276,11 +276,27 @@ class PolynomialTensorTest(unittest.TestCase):
     def test_different_keys_mult(self):
         result = self.polynomial_tensor_a * self.polynomial_tensor_operand
         expected = PolynomialTensor(
-            {(): self.constant,
-             (1, 0): numpy.multiply(self.one_body_a, self.one_body_operand),
-             (1, 1, 0, 0): self.two_body_a,
-             (0, 0, 1, 1): self.two_body_operand})
+            {(1, 0): numpy.multiply(self.one_body_a, self.one_body_operand)})
         self.assertEqual(result, expected)
+
+    def test_div(self):
+        new_tensor = self.polynomial_tensor_a / 2.
+        self.assertEqual(new_tensor, PolynomialTensor(
+            {(): self.constant / 2.,
+             (1, 0): self.one_body_a / 2.,
+             (1, 1, 0, 0): self.two_body_a / 2.}))
+
+    def test_idiv(self):
+        new_tensor = copy.deepcopy(self.polynomial_tensor_a)
+        new_tensor /= 3.
+        self.assertEqual(new_tensor, PolynomialTensor(
+            {(): self.constant / 3.,
+             (1, 0): self.one_body_a / 3.,
+             (1, 1, 0, 0): self.two_body_a / 3.}))
+
+    def test_invalid_dividend(self):
+        with self.assertRaises(TypeError):
+            self.polynomial_tensor_a / 'a'
 
     def test_iter_and_str(self):
         one_body = numpy.zeros((self.n_qubits, self.n_qubits))

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -18,7 +18,9 @@ import itertools
 import numpy
 from scipy.linalg import qr
 
-from openfermion.ops import InteractionOperator, QuadraticHamiltonian
+from openfermion.ops import (DiagonalCoulombHamiltonian,
+                             InteractionOperator,
+                             QuadraticHamiltonian)
 
 
 def random_unitary_matrix(n, real=False):
@@ -49,6 +51,19 @@ def random_antisymmetric_matrix(n, real=False):
         rand_mat = numpy.random.randn(n, n) + 1.j * numpy.random.randn(n, n)
     antisymmetric_mat = rand_mat - rand_mat.T
     return antisymmetric_mat
+
+
+def random_diagonal_coulomb_hamiltonian(n_qubits, real=False):
+    """Generate a random instance of DiagonalCoulombHamiltonian.
+
+    Args:
+        n_qubits: The number of qubits
+        real: Whether to use only real numbers in the one-body term
+    """
+    one_body = random_hermitian_matrix(n_qubits, real=real)
+    two_body = random_hermitian_matrix(n_qubits, real=True)
+    constant = numpy.random.randn()
+    return DiagonalCoulombHamiltonian(one_body, two_body, constant)
 
 
 def random_quadratic_hamiltonian(n_qubits,


### PR DESCRIPTION
- Allows multiplying and dividing PolynomialTensors and DiagonalCoulombHamiltonians by numbers
- Fixed incorrect behavior in multiplication by a PolynomialTensor with different key (a missing key should count as the zero tensor; previous behavior was the same as adding zeros instead of multiplying zeros).