### PR TITLE
Return non-redundant Bogoliubov transformation matrix

### DIFF
--- a/src/openfermion/ops/_givens_rotations_test.py
+++ b/src/openfermion/ops/_givens_rotations_test.py
@@ -247,10 +247,14 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
             # Obtain a random quadratic Hamiltonian
             quadratic_hamiltonian = random_quadratic_hamiltonian(n)
 
-            # Get the diagonalizing fermionic unitary
-            ferm_unitary = (
+            # Get the diagonalizing transformation
+            transformation_matrix = (
                 quadratic_hamiltonian.diagonalizing_bogoliubov_transform())
-            lower_unitary = ferm_unitary[n:]
+            left_block = transformation_matrix[:, :n]
+            right_block = transformation_matrix[:, n:]
+            lower_unitary = numpy.empty((n, 2 * n), dtype=complex)
+            lower_unitary[:, :n] = numpy.conjugate(right_block)
+            lower_unitary[:, n:] = numpy.conjugate(left_block)
 
             # Get fermionic Gaussian decomposition of lower_unitary
             decomposition, left_decomposition, diagonal, left_diagonal = (

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -252,7 +252,7 @@ class QuadraticHamiltonian(PolynomialTensor):
                 a_N
            \\end{pmatrix},
 
-        where :math:`W` is an :math:`N \\times (2N)` unitary matrix.
+        where :math:`W` is an :math:`N \\times (2N)` matrix.
         However, if the Hamiltonian conserves particle number then
         creation operators don't need to be mixed with annihilation operators
         and :math:`W` only needs to be an :math:`N \\times N` matrix:
@@ -349,6 +349,7 @@ class QuadraticHamiltonian(PolynomialTensor):
             # creation operators
             left_block = transformation_matrix[:, :self.n_qubits]
             right_block = transformation_matrix[:, self.n_qubits:]
+            # Can't use numpy.block because that requires numpy>=1.13.0
             new_transformation_matrix = numpy.empty(
                     (self.n_qubits, 2 * self.n_qubits), dtype=complex)
             new_transformation_matrix[:, :self.n_qubits] = numpy.conjugate(

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -183,7 +183,18 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         block_matrix[self.n_qubits:, self.n_qubits:] = (
             -antisymmetric_part.conj())
 
-        ferm_unitary = self.quad_ham_npc.diagonalizing_bogoliubov_transform()
+        transformation_matrix = (
+                self.quad_ham_npc.diagonalizing_bogoliubov_transform())
+        left_block = transformation_matrix[:, :self.n_qubits]
+        right_block = transformation_matrix[:, self.n_qubits:]
+        ferm_unitary = numpy.zeros((2 * self.n_qubits, 2 * self.n_qubits),
+                                   dtype=complex)
+        ferm_unitary[:self.n_qubits, :self.n_qubits] = left_block
+        ferm_unitary[:self.n_qubits, self.n_qubits:] = right_block
+        ferm_unitary[self.n_qubits:, :self.n_qubits] = numpy.conjugate(
+                right_block)
+        ferm_unitary[self.n_qubits:, self.n_qubits:] = numpy.conjugate(
+                left_block)
 
         # Check that the transformation is diagonalizing
         majorana_matrix, majorana_constant = self.quad_ham_npc.majorana_form()

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -121,6 +121,7 @@ def gaussian_state_preparation_circuit(
         n_qubits = quadratic_hamiltonian.n_qubits
         left_block = transformation_matrix[:, :n_qubits]
         right_block = transformation_matrix[:, n_qubits:]
+        # Can't use numpy.block because that requires numpy>=1.13.0
         new_transformation_matrix = numpy.empty((n_qubits, 2 * n_qubits),
                                                 dtype=complex)
         new_transformation_matrix[:, :n_qubits] = numpy.conjugate(right_block)


### PR DESCRIPTION
Changes the `diagonalizing_bogoliubov_transform` method of QuadraticHamiltonian to return an Nx(2N) matrix describing the new creation operators instead of a (2N)x(2N) matrix describing both the creation and annihilation operators in the case that the Hamiltonian does not conserve particle number. This form is less redundant and also matches up more closely with the format of the matrix returned when the Hamiltonian does conserve particle number (NxN, describing the new creation operators).