### PR TITLE
Fix docs errors and lint in ops

### DIFF
--- a/src/openfermion/ops/_binary_code.py
+++ b/src/openfermion/ops/_binary_code.py
@@ -118,8 +118,8 @@ class BinaryCode(object):
         BinaryCode their concatenation.
 
     Attributes:
-        decoder (list):  list of BinaryPolynomial: Outputs the decoding functions
-            as components.
+        decoder (list):  list of BinaryPolynomial: Outputs the decoding
+            functions as components.
         encoder (scipy.sparse.csc_matrix): Outputs A, the linear matrix that
             implements the encoding function.
         n_modes (int): Outputs the number of modes.

--- a/src/openfermion/ops/_binary_code_test.py
+++ b/src/openfermion/ops/_binary_code_test.py
@@ -23,7 +23,8 @@ class CodeOperatorTest(unittest.TestCase):
     def test_init_errors(self):
         with self.assertRaises(TypeError):
             BinaryCode(1,
-                       [BinaryPolynomial(' w1 + w0 '), BinaryPolynomial('w0 + 1')])
+                       [BinaryPolynomial(' w1 + w0 '),
+                           BinaryPolynomial('w0 + 1')])
         with self.assertRaises(TypeError):
             BinaryCode([[0, 1], [1, 0]], '1+w1')
         with self.assertRaises(BinaryCodeError):
@@ -41,8 +42,9 @@ class CodeOperatorTest(unittest.TestCase):
 
     def test_addition(self):
         a = BinaryCode([[0, 1, 0], [1, 0, 1]],
-                       [BinaryPolynomial(' w1 + w0 '), BinaryPolynomial('w0 + 1'),
-                        BinaryPolynomial('w1')])
+                       [BinaryPolynomial(' w1 + w0 '),
+                           BinaryPolynomial('w0 + 1'),
+                           BinaryPolynomial('w1')])
         d = BinaryCode([[0, 1], [1, 0]],
                        [BinaryPolynomial(' w0 '), BinaryPolynomial('w0 w1')])
         summation = a + d
@@ -57,8 +59,9 @@ class CodeOperatorTest(unittest.TestCase):
 
     def test_multiplication(self):
         a = BinaryCode([[0, 1, 0], [1, 0, 1]],
-                       [BinaryPolynomial(' w1 + w0 '), BinaryPolynomial('w0 + 1'),
-                        BinaryPolynomial('w1')])
+                       [BinaryPolynomial(' w1 + w0 '),
+                           BinaryPolynomial('w0 + 1'),
+                           BinaryPolynomial('w1')])
         d = BinaryCode([[0, 1], [1, 0]],
                        [BinaryPolynomial(' w0 '), BinaryPolynomial('w0 w1')])
 
@@ -71,9 +74,9 @@ class CodeOperatorTest(unittest.TestCase):
                                  "[0, 0, 0, 1], [0, 0, 1, 0]], "
                                  "'[[W0],[W0 W1],[W2],[W2 W3]]']")
         with self.assertRaises(BinaryCodeError):
-            d * a
+            _ = d * a
         with self.assertRaises(TypeError):
-            2.0 * a
+            _ = 2.0 * a
         with self.assertRaises(TypeError):
             a *= 2.0
         with self.assertRaises(ValueError):

--- a/src/openfermion/ops/_binary_polynomial.py
+++ b/src/openfermion/ops/_binary_polynomial.py
@@ -30,25 +30,25 @@ class BinaryPolynomial(object):
     a term of binary variables (variables of the values {0,1}, indexed
     by integers like w0, w1, w2 and so on) that is considered to be evaluated
     modulo 2. This implies the following set of rules:
-    
-    the binary addition  w1 + w1 = 0, 
-    binary multiplication w2 * w2 = w2 
+
+    the binary addition  w1 + w1 = 0,
+    binary multiplication w2 * w2 = w2
     and power rule w3 ^ 0  = 1, where raising to every other
     integer power than zero reproduces w3.
-    
+
     Of course, we can also add a non-trivial constant, which is 1.
-    Due to these binary rules, every function available will be a 
+    Due to these binary rules, every function available will be a
     multinomial like e.g.
-    
+
     1 + w1 w2 + w0 w1 .
-    
+
     These binary functions are used for non-linear binary codes in order
-    to decompress qubit bases back into fermion bases.  
-    In that instance, one BinaryPolynomial object characterizes the occupation 
-    of single orbital given a multi-qubit state in configuration 
-    \|w0> \|w1> \|w2> ... . 
-    
-    For initialization, the preferred data types is either a string of the 
+    to decompress qubit bases back into fermion bases.
+    In that instance, one BinaryPolynomial object characterizes the occupation
+    of single orbital given a multi-qubit state in configuration
+    \|w0> \|w1> \|w2> ... .
+
+    For initialization, the preferred data types is either a string of the
     multinomial, where each variable and constant is to be well separated by
     a whitespace, or in its native form of tuples,
     1 + w1 w2 + w0 w1 is represented as [(_SYMBOLIC_ONE,),(1,2),(0,1)]
@@ -267,8 +267,8 @@ class BinaryPolynomial(object):
 
         Args:
             binary_list (list, array, str): a list of binary values
-                corresponding  each binary variable 
-                (in order of their indices) in the expression 
+                corresponding  each binary variable
+                (in order of their indices) in the expression
 
         Returns (int, 0 or 1): result of the evaluation
 
@@ -276,7 +276,7 @@ class BinaryPolynomial(object):
           BinaryPolynomialError: Length of list provided must match the number
                 of qubits indexed in BinaryPolynomial
         """
-        if isinstance(binary_list,str):
+        if isinstance(binary_list, str):
             binary_list = list(map(int, list(binary_list)))
 
         all_qubits = self.enumerate_qubits()
@@ -487,7 +487,7 @@ class BinaryPolynomial(object):
         return self + addend
 
     def __add__(self, addend):
-        """ 
+        """
         Left addition of BinaryPolynomial.
         Args:
             addend (int or BinaryPolynomial): The operator or int to add.

--- a/src/openfermion/ops/_binary_polynomial_test.py
+++ b/src/openfermion/ops/_binary_polynomial_test.py
@@ -52,7 +52,7 @@ class BinaryPolynomialTest(unittest.TestCase):
         self.assertEqual(operator1.terms, [(3, 4)])
         operator1 = BinaryPolynomial([(4, 3, _SYMBOLIC_ONE)])
         self.assertEqual(operator1.terms, [(3, 4)])
-        operator1 = BinaryPolynomial(((1,2),(1,2)))
+        operator1 = BinaryPolynomial(((1, 2), (1, 2)))
         self.assertEqual(operator1.terms, [])
         with self.assertRaises(ValueError):
             operator1 = BinaryPolynomial(((1, -2),))
@@ -74,9 +74,9 @@ class BinaryPolynomialTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             operator1 *= 4.3
         with self.assertRaises(TypeError):
-            tmp = 4.3 * operator1
+            _ = 4.3 * operator1
         with self.assertRaises(TypeError):
-            tmp = operator1 * 4.3
+            _ = operator1 * 4.3
 
     def test_addition(self):
         operator1 = BinaryPolynomial('w1 w2')
@@ -88,7 +88,7 @@ class BinaryPolynomialTest(unittest.TestCase):
         addition = addition + 1
         self.assertEqual(addition.terms, [(_SYMBOLIC_ONE,)])
         with self.assertRaises(TypeError):
-            tmp = 4.3 + operator1
+            _ = 4.3 + operator1
         with self.assertRaises(TypeError):
             operator1 += 4.3
 
@@ -104,9 +104,9 @@ class BinaryPolynomialTest(unittest.TestCase):
         self.assertEqual(pow_loc.terms, [(_SYMBOLIC_ONE,), (1, 2),
                                          (3, 4)])
         with self.assertRaises(TypeError):
-            tmp = operator1 ** 4.3
+            _ = operator1 ** 4.3
         with self.assertRaises(TypeError):
-            tmp = operator1 ** (-1)
+            _ = operator1 ** (-1)
 
     def test_init_binary_rule(self):
         operator1 = BinaryPolynomial('1 + w2 w2 + w2')
@@ -158,9 +158,9 @@ class BinaryPolynomialTest(unittest.TestCase):
 
     def test_evaluate(self):
         operator1 = BinaryPolynomial()
-        self.assertEqual(operator1.evaluate('1111'),0)
+        self.assertEqual(operator1.evaluate('1111'), 0)
         operator1 = BinaryPolynomial(1)
-        self.assertEqual(operator1.evaluate('1111'),1)
+        self.assertEqual(operator1.evaluate('1111'), 1)
         operator1 = BinaryPolynomial('1 + w0 w2 w1 + w0 w1 + w0 w2')
         a = operator1.evaluate([0, 0, 1])
         self.assertEqual(a, 1.0)
@@ -195,4 +195,3 @@ class BinaryPolynomialTest(unittest.TestCase):
         operator2 += operator1
         self.assertEqual(operator1.terms, [(1,), (_SYMBOLIC_ONE,)])
         self.assertEqual(operator2.terms, [(_SYMBOLIC_ONE,)])
-

--- a/src/openfermion/ops/_fermion_operator.py
+++ b/src/openfermion/ops/_fermion_operator.py
@@ -11,9 +11,7 @@
 #   limitations under the License.
 
 """FermionOperator stores a sum of products of fermionic ladder operators."""
-import numpy
 
-from future.utils import iteritems
 from openfermion.ops import SymbolicOperator
 
 
@@ -25,15 +23,15 @@ def normal_ordered_term(term, coefficient):
     """Return a normal ordered FermionOperator corresponding to single term.
 
     Args:
-        term: A tuple of tuples. The first element of each tuple is
-            an integer indicating the mode on which a fermion ladder
+        term(list or tuple): A sequence of tuples. The first element of each
+            tuple is an integer indicating the mode on which a fermion ladder
             operator acts, starting from zero. The second element of each
             tuple is an integer, either 1 or 0, indicating whether creation
             or annihilation acts on that mode.
-        coefficient: The coefficient of the term.
+        coefficient(complex or float): The coefficient of the term.
 
     Returns:
-        ordered_term (FermionOperator): The normal ordered form of the input.
+        ordered_term(FermionOperator): The normal ordered form of the input.
             Note that this might have more terms.
 
     In our convention, normal ordering implies terms are ordered
@@ -64,11 +62,10 @@ def normal_ordered_term(term, coefficient):
                 # Replace a a^\dagger with 1 - a^\dagger a
                 # if indices are the same.
                 if right_operator[0] == left_operator[0]:
-                    new_term = term[:(j - 1)] + term[(j + 1)::]
+                    new_term = term[:(j - 1)] + term[(j + 1):]
 
                     # Recursively add the processed new term.
-                    ordered_term += normal_ordered_term(
-                        tuple(new_term), -coefficient)
+                    ordered_term += normal_ordered_term(new_term, -coefficient)
 
             # Handle case when operator type is the same.
             elif right_operator[1] == left_operator[1]:

--- a/src/openfermion/ops/_fermion_operator_test.py
+++ b/src/openfermion/ops/_fermion_operator_test.py
@@ -11,13 +11,9 @@
 #   limitations under the License.
 
 """Tests  _fermion_operator.py."""
-import copy
-import numpy
 import unittest
 
-from openfermion.ops._fermion_operator import (FermionOperator,
-                                               FermionOperatorError,
-                                               normal_ordered)
+from openfermion.ops._fermion_operator import FermionOperator, normal_ordered
 from openfermion.utils import number_operator
 
 

--- a/src/openfermion/ops/_givens_rotations_test.py
+++ b/src/openfermion/ops/_givens_rotations_test.py
@@ -54,7 +54,7 @@ class GivensMatrixElementsTest(unittest.TestCase):
         """Test bad input."""
         with self.assertRaises(ValueError):
             v = numpy.random.randn(2)
-            G = givens_matrix_elements(v[0], v[1], which='a')
+            _ = givens_matrix_elements(v[0], v[1], which='a')
 
 
 class GivensRotateTest(unittest.TestCase):
@@ -171,7 +171,7 @@ class GivensDecompositionTest(unittest.TestCase):
         Q = Q[:m, :n]
 
         with self.assertRaises(ValueError):
-            givens_rotations, V, diagonal = givens_decomposition(Q)
+            _, _, _ = givens_decomposition(Q)
 
     def test_identity(self):
         n = 3
@@ -322,12 +322,10 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         n, p = (3, 7)
         rand_mat = numpy.random.randn(n, p)
         with self.assertRaises(ValueError):
-            decomposition, left_unitary, antidiagonal = (
-                fermionic_gaussian_decomposition(rand_mat))
+            _, _, _ = fermionic_gaussian_decomposition(rand_mat)
 
     def test_bad_constraints(self):
         n = 3
         ones_mat = numpy.ones((n, 2 * n))
         with self.assertRaises(ValueError):
-            decomposition, left_unitary, antidiagonal = (
-                fermionic_gaussian_decomposition(ones_mat))
+            _, _, _ = fermionic_gaussian_decomposition(ones_mat)

--- a/src/openfermion/ops/_givens_rotations_test.py
+++ b/src/openfermion/ops/_givens_rotations_test.py
@@ -247,10 +247,14 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
             # Obtain a random quadratic Hamiltonian
             quadratic_hamiltonian = random_quadratic_hamiltonian(n)
 
-            # Get the diagonalizing fermionic unitary
-            ferm_unitary = (
+            # Get the diagonalizing transformation
+            transformation_matrix = (
                 quadratic_hamiltonian.diagonalizing_bogoliubov_transform())
-            lower_unitary = ferm_unitary[n:]
+            left_block = transformation_matrix[:, :n]
+            right_block = transformation_matrix[:, n:]
+            lower_unitary = numpy.empty((n, 2 * n), dtype=complex)
+            lower_unitary[:, :n] = numpy.conjugate(right_block)
+            lower_unitary[:, n:] = numpy.conjugate(left_block)
 
             # Get fermionic Gaussian decomposition of lower_unitary
             decomposition, left_decomposition, diagonal, left_diagonal = (

--- a/src/openfermion/ops/_givens_rotations_test.py
+++ b/src/openfermion/ops/_givens_rotations_test.py
@@ -171,7 +171,7 @@ class GivensDecompositionTest(unittest.TestCase):
         Q = Q[:m, :n]
 
         with self.assertRaises(ValueError):
-            _, _, _ = givens_decomposition(Q)
+            _ = givens_decomposition(Q)
 
     def test_identity(self):
         n = 3
@@ -322,10 +322,10 @@ class FermionicGaussianDecompositionTest(unittest.TestCase):
         n, p = (3, 7)
         rand_mat = numpy.random.randn(n, p)
         with self.assertRaises(ValueError):
-            _, _, _ = fermionic_gaussian_decomposition(rand_mat)
+            _ = fermionic_gaussian_decomposition(rand_mat)
 
     def test_bad_constraints(self):
         n = 3
         ones_mat = numpy.ones((n, 2 * n))
         with self.assertRaises(ValueError):
-            _, _, _ = fermionic_gaussian_decomposition(ones_mat)
+            _ = fermionic_gaussian_decomposition(ones_mat)

--- a/src/openfermion/ops/_interaction_operator.py
+++ b/src/openfermion/ops/_interaction_operator.py
@@ -11,8 +11,6 @@
 #   limitations under the License.
 
 """Class and functions to store interaction operators."""
-from __future__ import absolute_import
-
 import itertools
 
 from openfermion.ops import PolynomialTensor

--- a/src/openfermion/ops/_interaction_operator_test.py
+++ b/src/openfermion/ops/_interaction_operator_test.py
@@ -11,8 +11,6 @@
 #   limitations under the License.
 
 """Tests for interaction_operator.py."""
-from __future__ import absolute_import
-
 import unittest
 
 import numpy

--- a/src/openfermion/ops/_interaction_operator_test.py
+++ b/src/openfermion/ops/_interaction_operator_test.py
@@ -13,8 +13,9 @@
 """Tests for interaction_operator.py."""
 from __future__ import absolute_import
 
-import numpy
 import unittest
+
+import numpy
 
 from openfermion.ops import InteractionOperator
 

--- a/src/openfermion/ops/_interaction_rdm.py
+++ b/src/openfermion/ops/_interaction_rdm.py
@@ -11,8 +11,6 @@
 #   limitations under the License.
 
 """Class and functions to store reduced density matrices."""
-from __future__ import absolute_import
-
 import copy
 import numpy
 

--- a/src/openfermion/ops/_interaction_rdm_test.py
+++ b/src/openfermion/ops/_interaction_rdm_test.py
@@ -11,8 +11,6 @@
 #   limitations under the License.
 
 """Tests for interaction_rdms.py."""
-from __future__ import absolute_import
-
 import os
 import unittest
 

--- a/src/openfermion/ops/_interaction_rdm_test.py
+++ b/src/openfermion/ops/_interaction_rdm_test.py
@@ -13,9 +13,10 @@
 """Tests for interaction_rdms.py."""
 from __future__ import absolute_import
 
+import os
 import unittest
 
-from openfermion.config import *
+from openfermion.config import THIS_DIRECTORY, EQ_TOLERANCE
 from openfermion.hamiltonians import MolecularData
 from openfermion.ops import QubitOperator
 from openfermion.ops._interaction_rdm import InteractionRDMError

--- a/src/openfermion/ops/_polynomial_tensor.py
+++ b/src/openfermion/ops/_polynomial_tensor.py
@@ -17,7 +17,7 @@ import copy
 import itertools
 import numpy
 
-from openfermion.config import *
+from openfermion.config import EQ_TOLERANCE
 
 
 class PolynomialTensorError(Exception):

--- a/src/openfermion/ops/_polynomial_tensor_test.py
+++ b/src/openfermion/ops/_polynomial_tensor_test.py
@@ -176,7 +176,7 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_getitem_indexing(self):
         with self.assertRaises(KeyError):
-            self.polynomial_tensor_a[(0, 1), (1, 1), (0, 0)]
+            _ = self.polynomial_tensor_a[(0, 1), (1, 1), (0, 0)]
 
     def test_invalid_setitem_indexing(self):
         test_tensor = copy.deepcopy(self.polynomial_tensor_a)
@@ -212,11 +212,11 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_addend(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a + 2
+            _ = self.polynomial_tensor_a + 2
 
     def test_invalid_tensor_shape_add(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a + self.polynomial_tensor_c
+            _ = self.polynomial_tensor_a + self.polynomial_tensor_c
 
     def test_different_keys_add(self):
         result = self.polynomial_tensor_a + self.polynomial_tensor_operand
@@ -242,11 +242,11 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_subtrahend(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a - 2
+            _ = self.polynomial_tensor_a - 2
 
     def test_invalid_tensor_shape_sub(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a - self.polynomial_tensor_c
+            _ = self.polynomial_tensor_a - self.polynomial_tensor_c
 
     def test_different_keys_sub(self):
         result = self.polynomial_tensor_a - self.polynomial_tensor_operand
@@ -284,11 +284,11 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_multiplier(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a * 'a'
+            _ = self.polynomial_tensor_a * 'a'
 
     def test_invalid_tensor_shape_mult(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a * self.polynomial_tensor_c
+            _ = self.polynomial_tensor_a * self.polynomial_tensor_c
 
     def test_different_keys_mult(self):
         result = self.polynomial_tensor_a * self.polynomial_tensor_operand
@@ -317,7 +317,7 @@ class PolynomialTensorTest(unittest.TestCase):
 
     def test_invalid_dividend(self):
         with self.assertRaises(TypeError):
-            self.polynomial_tensor_a / 'a'
+            _ = self.polynomial_tensor_a / 'a'
 
     def test_iter_and_str(self):
         one_body = numpy.zeros((self.n_qubits, self.n_qubits))

--- a/src/openfermion/ops/_polynomial_tensor_test.py
+++ b/src/openfermion/ops/_polynomial_tensor_test.py
@@ -11,7 +11,7 @@
 #   limitations under the License.
 
 """Tests for polynomial_tensor.py."""
-from __future__ import absolute_import, division
+from __future__ import division
 
 import unittest
 

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -153,12 +153,12 @@ class QuadraticHamiltonian(PolynomialTensor):
         """
         if self.conserves_particle_number and not non_negative:
             hermitian_matrix = self.combined_hermitian_part
-            orbital_energies, diagonalizing_unitary = numpy.linalg.eigh(
+            orbital_energies, _ = numpy.linalg.eigh(
                 hermitian_matrix)
             constant = self.constant
         else:
             majorana_matrix, majorana_constant = self.majorana_form()
-            canonical, orthogonal = antisymmetric_canonical_form(
+            canonical, _ = antisymmetric_canonical_form(
                 majorana_matrix)
             orbital_energies = canonical[
                 range(self.n_qubits), range(self.n_qubits, 2 * self.n_qubits)]
@@ -278,18 +278,18 @@ class QuadraticHamiltonian(PolynomialTensor):
                 A matrix representing the transformation :math:`W` of the
                 fermionic ladder operators. If the Hamiltonian conserves
                 particle number then this is :math:`N \\times N`; otherwise
-                it is :math:`2N \\times 2N`.
+                it is :math:`N \\times 2N`.
         """
         if self.conserves_particle_number:
-            energies, diagonalizing_unitary_T = numpy.linalg.eigh(
+            _, diagonalizing_unitary_T = numpy.linalg.eigh(
                     self.combined_hermitian_part)
             return diagonalizing_unitary_T.T
         else:
-            majorana_matrix, majorana_constant = self.majorana_form()
+            majorana_matrix, _ = self.majorana_form()
 
             # Get the orthogonal transformation that puts majorana_matrix
             # into canonical form
-            canonical, orthogonal = antisymmetric_canonical_form(
+            _, orthogonal = antisymmetric_canonical_form(
                     majorana_matrix)
 
             # Create the matrix that converts between fermionic ladder and
@@ -338,7 +338,7 @@ class QuadraticHamiltonian(PolynomialTensor):
         if self.conserves_particle_number:
             # The Hamiltonian conserves particle number, so we don't need
             # to use the most general procedure.
-            decomposition, diagonal = givens_decomposition_square(
+            decomposition, _ = givens_decomposition_square(
                     transformation_matrix)
             circuit_description = list(reversed(decomposition))
         else:
@@ -357,7 +357,7 @@ class QuadraticHamiltonian(PolynomialTensor):
             new_transformation_matrix[:, self.n_qubits:] = numpy.conjugate(
                     left_block)
             # Get the circuit description
-            decomposition, left_decomposition, diagonal, left_diagonal = (
+            decomposition, left_decomposition, _, _ = (
                 fermionic_gaussian_decomposition(new_transformation_matrix))
             # need to use left_diagonal too
             circuit_description = list(reversed(

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -229,11 +229,11 @@ class QuadraticHamiltonian(PolynomialTensor):
 
             \sum_{j} \\varepsilon_j b^\dagger_j b_j + \\text{constant},
 
-        where the :math:`b_j` are a new set fermionic operators
+        where the :math:`b^\dagger_j` are a new set fermionic creation operators
         that satisfy the canonical anticommutation relations.
-        The new fermionic operators are linear combinations of the
-        original ones. In the most general case, creation and annihilation
-        operators are mixed together:
+        The new creation operators are linear combinations of the
+        original ladder operators. In the most general case, creation and
+        annihilation operators are mixed together:
 
         .. math::
 
@@ -241,9 +241,6 @@ class QuadraticHamiltonian(PolynomialTensor):
                 b^\dagger_1 \\\\
                 \\vdots \\\\
                 b^\dagger_N \\\\
-                b_1 \\\\
-                \\vdots \\\\
-                b_N
            \\end{pmatrix}
            = W
            \\begin{pmatrix}
@@ -255,7 +252,7 @@ class QuadraticHamiltonian(PolynomialTensor):
                 a_N
            \\end{pmatrix},
 
-        where :math:`W` is a :math:`2N \\times 2N` unitary matrix.
+        where :math:`W` is an :math:`N \\times (2N)` matrix.
         However, if the Hamiltonian conserves particle number then
         creation operators don't need to be mixed with annihilation operators
         and :math:`W` only needs to be an :math:`N \\times N` matrix:
@@ -311,7 +308,7 @@ class QuadraticHamiltonian(PolynomialTensor):
             diagonalizing_unitary = majorana_basis_change.T.conj().dot(
                 orthogonal.dot(majorana_basis_change))
 
-            return diagonalizing_unitary
+            return diagonalizing_unitary[:self.n_qubits]
 
     def diagonalizing_circuit(self):
         """Get a circuit for a unitary that diagonalizes this Hamiltonian
@@ -336,23 +333,32 @@ class QuadraticHamiltonian(PolynomialTensor):
                 of modes :math:`i` and :math:`j` by angles :math:`\\theta`
                 and :math:`\\varphi`.
         """
-        diagonalizing_unitary = self.diagonalizing_bogoliubov_transform()
+        transformation_matrix = self.diagonalizing_bogoliubov_transform()
 
         if self.conserves_particle_number:
             # The Hamiltonian conserves particle number, so we don't need
             # to use the most general procedure.
             decomposition, diagonal = givens_decomposition_square(
-                    diagonalizing_unitary)
+                    transformation_matrix)
             circuit_description = list(reversed(decomposition))
         else:
             # The Hamiltonian does not conserve particle number, so we
             # need to use the most general procedure.
-            # Get the unitary rows which represent the Gaussian unitary
-            gaussian_unitary_matrix = diagonalizing_unitary[self.n_qubits:]
-
+            # Rearrange the transformation matrix because the circuit generation
+            # routine expects it to describe annihilation operators rather than
+            # creation operators
+            left_block = transformation_matrix[:, :self.n_qubits]
+            right_block = transformation_matrix[:, self.n_qubits:]
+            # Can't use numpy.block because that requires numpy>=1.13.0
+            new_transformation_matrix = numpy.empty(
+                    (self.n_qubits, 2 * self.n_qubits), dtype=complex)
+            new_transformation_matrix[:, :self.n_qubits] = numpy.conjugate(
+                    right_block)
+            new_transformation_matrix[:, self.n_qubits:] = numpy.conjugate(
+                    left_block)
             # Get the circuit description
             decomposition, left_decomposition, diagonal, left_diagonal = (
-                fermionic_gaussian_decomposition(gaussian_unitary_matrix))
+                fermionic_gaussian_decomposition(new_transformation_matrix))
             # need to use left_diagonal too
             circuit_description = list(reversed(
                 decomposition + left_decomposition))

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -10,9 +10,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Tests for quadratic_hamiltonian.py."""
+import unittest
+
 import numpy
 import scipy.sparse
-import unittest
 
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import (normal_ordered, FermionOperator)
@@ -159,10 +160,11 @@ class QuadraticHamiltonianTest(unittest.TestCase):
                                             normalization)
             for j in range(2 * self.n_qubits):
                 if j < self.n_qubits:
-                    right_op = majorana_operator((j, 0),
-                            majorana_matrix[i, j] * normalization)
+                    right_op = majorana_operator(
+                            (j, 0), majorana_matrix[i, j] * normalization)
                 else:
-                    right_op = majorana_operator((j - self.n_qubits, 1),
+                    right_op = majorana_operator(
+                            (j - self.n_qubits, 1),
                             majorana_matrix[i, j] * normalization)
                 majorana_op += .5j * left_op * right_op
         # Get FermionOperator for original Hamiltonian
@@ -197,8 +199,8 @@ class QuadraticHamiltonianTest(unittest.TestCase):
                 left_block)
 
         # Check that the transformation is diagonalizing
-        majorana_matrix, majorana_constant = self.quad_ham_npc.majorana_form()
-        canonical, orthogonal = antisymmetric_canonical_form(majorana_matrix)
+        majorana_matrix, _ = self.quad_ham_npc.majorana_form()
+        canonical, _ = antisymmetric_canonical_form(majorana_matrix)
         diagonalized = ferm_unitary.conj().dot(
             block_matrix.dot(ferm_unitary.T.conj()))
         for i in numpy.ndindex((2 * self.n_qubits, 2 * self.n_qubits)):
@@ -326,8 +328,7 @@ class AntisymmetricCanonicalFormTest(unittest.TestCase):
         # Obtain a random antisymmetric matrix
         rand_mat = numpy.random.randn(2 * n, 2 * n)
         antisymmetric_matrix = rand_mat - rand_mat.T
-        canonical, orthogonal = antisymmetric_canonical_form(
-            antisymmetric_matrix)
+        canonical, _ = antisymmetric_canonical_form(antisymmetric_matrix)
         for i in range(2 * n):
             for j in range(2 * n):
                 if i < n and j == n + i:

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -183,7 +183,18 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         block_matrix[self.n_qubits:, self.n_qubits:] = (
             -antisymmetric_part.conj())
 
-        ferm_unitary = self.quad_ham_npc.diagonalizing_bogoliubov_transform()
+        transformation_matrix = (
+                self.quad_ham_npc.diagonalizing_bogoliubov_transform())
+        left_block = transformation_matrix[:, :self.n_qubits]
+        right_block = transformation_matrix[:, self.n_qubits:]
+        ferm_unitary = numpy.zeros((2 * self.n_qubits, 2 * self.n_qubits),
+                                   dtype=complex)
+        ferm_unitary[:self.n_qubits, :self.n_qubits] = left_block
+        ferm_unitary[:self.n_qubits, self.n_qubits:] = right_block
+        ferm_unitary[self.n_qubits:, :self.n_qubits] = numpy.conjugate(
+                right_block)
+        ferm_unitary[self.n_qubits:, self.n_qubits:] = numpy.conjugate(
+                left_block)
 
         # Check that the transformation is diagonalizing
         majorana_matrix, majorana_constant = self.quad_ham_npc.majorana_form()

--- a/src/openfermion/ops/_qubit_operator.py
+++ b/src/openfermion/ops/_qubit_operator.py
@@ -166,7 +166,7 @@ class QubitOperator(SymbolicOperator):
         else:
             raise TypeError('Cannot in-place multiply term of invalid type ' +
                             'to QubitTerm.')
-    
+
     def renormalize(self):
         """Fix the trace norm of an operator to 1"""
         norm = self.induced_norm(2)

--- a/src/openfermion/ops/_qubit_operator_test.py
+++ b/src/openfermion/ops/_qubit_operator_test.py
@@ -11,14 +11,12 @@
 #   limitations under the License.
 
 """Tests for _qubit_operator.py."""
-import copy
 
 import numpy
 import pytest
 
 from openfermion.ops._qubit_operator import (_PAULI_OPERATOR_PRODUCTS,
-                                             QubitOperator,
-                                             QubitOperatorError)
+                                             QubitOperator)
 
 
 def test_pauli_operator_product_unchanged():
@@ -61,7 +59,6 @@ def test_imul_qubit_op():
     op1 = QubitOperator(((0, 'Y'), (3, 'X'), (8, 'Z'), (11, 'X')), 3.j)
     op2 = QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
     op1 *= op2
-    correct_coefficient = 1.j * 3.0j * 0.5
     correct_term = ((0, 'Y'), (1, 'X'), (3, 'Z'), (11, 'X'))
     assert len(op1.terms) == 1
     assert correct_term in op1.terms

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -87,7 +87,7 @@ class SymbolicOperator(object):
 
         # Parse the term
         # Sequence input
-        elif isinstance(term, tuple) or isinstance(term, list):
+        if isinstance(term, tuple) or isinstance(term, list):
             term = self._parse_sequence(term)
         # String input
         elif isinstance(term, str):
@@ -503,7 +503,7 @@ class SymbolicOperator(object):
         exponentiated = self.__class__(())
 
         # Handle non-zero exponents.
-        for i in range(exponent):
+        for _ in range(exponent):
             exponentiated *= self
         return exponentiated
 

--- a/src/openfermion/ops/_symbolic_operator_test.py
+++ b/src/openfermion/ops/_symbolic_operator_test.py
@@ -327,7 +327,6 @@ class SymbolicOperatorTest1(unittest.TestCase):
         op1 = DummyOperator1(((0, 1), (3, 0), (8, 1), (8, 0), (11, 1)), 3.j)
         op2 = DummyOperator1(((1, 1), (3, 1), (8, 0)), 0.5)
         op1 *= op2
-        correct_coefficient = 1.j * 3.0j * 0.5
         correct_term = ((0, 1), (3, 0), (8, 1), (8, 0), (11, 1),
                         (1, 1), (3, 1), (8, 0))
         self.assertEqual(len(op1.terms), 1)
@@ -727,35 +726,35 @@ class SymbolicOperatorTest2(unittest.TestCase):
 
     def test_init_bad_term(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2(2)
+            _ = DummyOperator2(2)
 
     def test_init_bad_coefficient(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2('X0', "0.5")
+            _ = DummyOperator2('X0', "0.5")
 
     def test_init_bad_action(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2('Q0')
+            _ = DummyOperator2('Q0')
 
     def test_init_bad_action_in_tuple(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2(((1, 'Q'),))
+            _ = DummyOperator2(((1, 'Q'),))
 
     def test_init_bad_qubit_num_in_tuple(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2((("1", 'X'),))
+            _ = DummyOperator2((("1", 'X'),))
 
     def test_init_bad_tuple(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2(((0, 1, 'X'),))
+            _ = DummyOperator2(((0, 1, 'X'),))
 
     def test_init_bad_str(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2('X')
+            _ = DummyOperator2('X')
 
     def test_init_bad_qubit_num(self):
         with self.assertRaises(ValueError):
-            qubit_op = DummyOperator2('X-1')
+            _ = DummyOperator2('X-1')
 
     def test_compress(self):
         a = DummyOperator2('X0', .9e-12)
@@ -918,7 +917,6 @@ class SymbolicOperatorTest2(unittest.TestCase):
 
     def test_neg(self):
         op = DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
-        -op
         # out of place
         self.assertTrue(op == DummyOperator2(((1, 'X'), (3, 'Y'), (8, 'Z')),
                                              0.5))

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -112,16 +112,24 @@ def gaussian_state_preparation_circuit(
     else:
         # The Hamiltonian does not conserve particle number, so we
         # need to use the most general procedure.
-        diagonalizing_unitary = (
+        transformation_matrix = (
             quadratic_hamiltonian.diagonalizing_bogoliubov_transform())
 
-        # Get the unitary rows which represent the Gaussian unitary
-        gaussian_unitary_matrix = diagonalizing_unitary[
-            quadratic_hamiltonian.n_qubits:]
+        # Rearrange the transformation matrix because the circuit generation
+        # routine expects it to describe annihilation operators rather than
+        # creation operators
+        n_qubits = quadratic_hamiltonian.n_qubits
+        left_block = transformation_matrix[:, :n_qubits]
+        right_block = transformation_matrix[:, n_qubits:]
+        # Can't use numpy.block because that requires numpy>=1.13.0
+        new_transformation_matrix = numpy.empty((n_qubits, 2 * n_qubits),
+                                                dtype=complex)
+        new_transformation_matrix[:, :n_qubits] = numpy.conjugate(right_block)
+        new_transformation_matrix[:, n_qubits:] = numpy.conjugate(left_block)
 
         # Get the circuit description
         decomposition, left_decomposition, diagonal, left_diagonal = (
-            fermionic_gaussian_decomposition(gaussian_unitary_matrix))
+            fermionic_gaussian_decomposition(new_transformation_matrix))
         if occupied_orbitals is None:
             # The ground state is desired, so the circuit should be applied
             # to the vaccuum state


### PR DESCRIPTION
- Fixed an error in the documentation of `QuadraticHamiltonian.bogoliubov_transform`.
- Removed lint caught by `pycodestyle` and my `pylint` in `ops`.