### PR TITLE
Use raw strings for math

### DIFF
--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -22,7 +22,7 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
                   chemical_potential=0., magnetic_field=0.,
                   periodic=True, spinless=False,
                   particle_hole_symmetry=False):
-    """Return symbolic representation of a Fermi-Hubbard Hamiltonian.
+    r"""Return symbolic representation of a Fermi-Hubbard Hamiltonian.
 
     The idea of this model is that some fermions move around on a grid and the
     energy of the model depends on where the fermions are.
@@ -40,24 +40,24 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
 
     .. math::
 
-        \\begin{align}
-        H = &- t \sum_{\langle i,j \\rangle} \sum_{\sigma}
+        \begin{align}
+        H = &- t \sum_{\langle i,j \rangle} \sum_{\sigma}
                      (a^\dagger_{i, \sigma} a_{j, \sigma} +
                       a^\dagger_{j, \sigma} a_{i, \sigma})
-             + U \sum_{i} a^\dagger_{i, \\uparrow} a_{i, \\uparrow}
+             + U \sum_{i} a^\dagger_{i, \uparrow} a_{i, \uparrow}
                          a^\dagger_{j, \downarrow} a_{j, \downarrow}
-            \\\\
+            \\
             &- \mu \sum_i \sum_{\sigma} a^\dagger_{i, \sigma} a_{i, \sigma}
-             - h \sum_i (a^\dagger_{i, \\uparrow} a_{i, \\uparrow} -
+             - h \sum_i (a^\dagger_{i, \uparrow} a_{i, \uparrow} -
                        a^\dagger_{i, \downarrow} a_{i, \downarrow})
-        \\end{align}
+        \end{align}
 
     where
 
-        - The indices :math:`\langle i, j \\rangle` run over pairs
+        - The indices :math:`\langle i, j \rangle` run over pairs
           :math:`i` and :math:`j` of sites that are connected to each other
           in the grid
-        - :math:`\sigma \in \\{\\uparrow, \downarrow\\}` is the spin
+        - :math:`\sigma \in \{\uparrow, \downarrow\}` is the spin
         - :math:`t` is the tunneling amplitude
         - :math:`U` is the Coulomb potential
         - :math:`\mu` is the chemical potential
@@ -96,8 +96,8 @@ def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,
 
             .. math::
 
-                U \sum_{k=1}^{N-1} (a_k^\dagger a_k - \\frac12)
-                                   (a_{k+1}^\dagger a_{k+1} - \\frac12)
+                U \sum_{k=1}^{N-1} (a_k^\dagger a_k - \frac12)
+                                   (a_{k+1}^\dagger a_{k+1} - \frac12)
 
             which is unchanged under a particle-hole transformation.
             Default is False

--- a/src/openfermion/hamiltonians/_mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/_mean_field_dwave.py
@@ -20,7 +20,7 @@ from openfermion.utils import (hermitian_conjugated, number_operator,
 
 def mean_field_dwave(x_dimension, y_dimension, tunneling, sc_gap,
                      chemical_potential=0., periodic=True):
-    """Return symbolic representation of a BCS mean-field d-wave Hamiltonian.
+    r"""Return symbolic representation of a BCS mean-field d-wave Hamiltonian.
 
     The Hamiltonians of this model live on a grid of dimensions
     `x_dimension` x `y_dimension`.
@@ -33,25 +33,25 @@ def mean_field_dwave(x_dimension, y_dimension, tunneling, sc_gap,
 
     .. math::
 
-        \\begin{align}
-        H = &- t \sum_{\langle i,j \\rangle} \sum_\sigma
+        \begin{align}
+        H = &- t \sum_{\langle i,j \rangle} \sum_\sigma
                 (a^\dagger_{i, \sigma} a_{j, \sigma} +
                  a^\dagger_{j, \sigma} a_{i, \sigma})
             - \mu \sum_i \sum_{\sigma} a^\dagger_{i, \sigma} a_{i, \sigma}
-            \\\\
-            &- \sum_{\langle i,j \\rangle} \Delta_{ij}
-              (a^\dagger_{i, \\uparrow} a^\dagger_{j, \downarrow} -
-               a^\dagger_{i, \downarrow} a^\dagger_{j, \\uparrow} +
-               a_{j, \downarrow} a_{i, \\uparrow} -
-               a_{j, \\uparrow} a_{i, \downarrow})
-        \\end{align}
+            \\
+            &- \sum_{\langle i,j \rangle} \Delta_{ij}
+              (a^\dagger_{i, \uparrow} a^\dagger_{j, \downarrow} -
+               a^\dagger_{i, \downarrow} a^\dagger_{j, \uparrow} +
+               a_{j, \downarrow} a_{i, \uparrow} -
+               a_{j, \uparrow} a_{i, \downarrow})
+        \end{align}
 
     where
 
-        - The indices :math:`\langle i, j \\rangle` run over pairs
+        - The indices :math:`\langle i, j \rangle` run over pairs
           :math:`i` and :math:`j` of sites that are connected to each other
           in the grid
-        - :math:`\sigma \in \\{\\uparrow, \downarrow\\}` is the spin
+        - :math:`\sigma \in \{\uparrow, \downarrow\}` is the spin
         - :math:`t` is the tunneling amplitude
         - :math:`\Delta_{ij}` is equal to :math:`+\Delta/2` for
           horizontal edges and :math:`-\Delta/2` for vertical edges,

--- a/src/openfermion/ops/_diagonal_coulomb_hamiltonian.py
+++ b/src/openfermion/ops/_diagonal_coulomb_hamiltonian.py
@@ -18,13 +18,13 @@ import numpy
 
 
 class DiagonalCoulombHamiltonian:
-    """Class for storing Hamiltonians of the form
+    r"""Class for storing Hamiltonians of the form
 
     .. math::
 
         \sum_{p, q} T_{pq} a^\dagger_p a_q +
         \sum_{p, q} V_{pq} a^\dagger_p a_p a^\dagger_q a_q +
-        \\text{constant}
+        \text{constant}
 
     where
 

--- a/src/openfermion/ops/_givens_rotations.py
+++ b/src/openfermion/ops/_givens_rotations.py
@@ -138,9 +138,9 @@ def double_givens_rotate(operator, givens_rotation, i, j, which='row'):
 
 
 def givens_decomposition_square(unitary_matrix):
-    """Decompose a square matrix into a sequence of Givens rotations.
+    r"""Decompose a square matrix into a sequence of Givens rotations.
 
-    The input is a square :math:`n \\times n` matrix :math:`Q`.
+    The input is a square :math:`n \times n` matrix :math:`Q`.
     :math:`Q` can be decomposed as follows:
 
     .. math::
@@ -154,17 +154,17 @@ def givens_decomposition_square(unitary_matrix):
 
         U = G_k ... G_1
 
-    where :math:`G_1, \\ldots, G_k` are complex Givens rotations.
+    where :math:`G_1, \ldots, G_k` are complex Givens rotations.
     A Givens rotation is a rotation within the two-dimensional subspace
     spanned by two coordinate axes. Within the two relevant coordinate
     axes, a Givens rotation has the form
 
     .. math::
 
-        \\begin{pmatrix}
-            \\cos(\\theta) & -e^{i \\varphi} \\sin(\\theta) \\\\
-            \\sin(\\theta) &     e^{i \\varphi} \\cos(\\theta)
-        \\end{pmatrix}.
+        \begin{pmatrix}
+            \cos(\theta) & -e^{i \varphi} \sin(\theta) \\
+            \sin(\theta) &     e^{i \varphi} \cos(\theta)
+        \end{pmatrix}.
 
     Args:
         unitary_matrix: A numpy array with orthonormal rows,
@@ -177,10 +177,10 @@ def givens_decomposition_square(unitary_matrix):
             rotations. The list looks like [(G_1, ), (G_2, G_3), ... ].
             The Givens rotations within a tuple can be implemented in parallel.
             The description of a Givens rotation is itself a tuple of the
-            form :math:`(i, j, \\theta, \\varphi)`, which represents a
+            form :math:`(i, j, \theta, \varphi)`, which represents a
             Givens rotation of coordinates
-            :math:`i` and :math:`j` by angles :math:`\\theta` and
-            :math:`\\varphi`.
+            :math:`i` and :math:`j` by angles :math:`\theta` and
+            :math:`\varphi`.
         diagonal (ndarray):
             A list of the nonzero entries of :math:`D`.
     """
@@ -237,9 +237,9 @@ def givens_decomposition_square(unitary_matrix):
 
 
 def givens_decomposition(unitary_rows):
-    """Decompose a matrix into a sequence of Givens rotations.
+    r"""Decompose a matrix into a sequence of Givens rotations.
 
-    The input is an :math:`m \\times n` matrix :math:`Q` with :math:`m \leq n`.
+    The input is an :math:`m \times n` matrix :math:`Q` with :math:`m \leq n`.
     The rows of :math:`Q` are orthonormal.
     :math:`Q` can be decomposed as follows:
 
@@ -248,7 +248,7 @@ def givens_decomposition(unitary_rows):
         V Q U^\dagger = D
 
     where :math:`V` and :math:`U` are unitary matrices, and :math:`D`
-    is an :math:`m \\times n` matrix with the
+    is an :math:`m \times n` matrix with the
     first :math:`m` columns forming a diagonal matrix and the rest of the
     columns being zero. Furthermore, we can decompose :math:`U` as
 
@@ -256,17 +256,17 @@ def givens_decomposition(unitary_rows):
 
         U = G_k ... G_1
 
-    where :math:`G_1, \\ldots, G_k` are complex Givens rotations.
+    where :math:`G_1, \ldots, G_k` are complex Givens rotations.
     A Givens rotation is a rotation within the two-dimensional subspace
     spanned by two coordinate axes. Within the two relevant coordinate
     axes, a Givens rotation has the form
 
     .. math::
 
-        \\begin{pmatrix}
-            \\cos(\\theta) & -e^{i \\varphi} \\sin(\\theta) \\\\
-            \\sin(\\theta) &     e^{i \\varphi} \\cos(\\theta)
-        \\end{pmatrix}.
+        \begin{pmatrix}
+            \cos(\theta) & -e^{i \varphi} \sin(\theta) \\
+            \sin(\theta) &     e^{i \varphi} \cos(\theta)
+        \end{pmatrix}.
 
     Args:
         unitary_rows: A numpy array or matrix with orthonormal rows,
@@ -279,12 +279,12 @@ def givens_decomposition(unitary_rows):
             rotations. The list looks like [(G_1, ), (G_2, G_3), ... ].
             The Givens rotations within a tuple can be implemented in parallel.
             The description of a Givens rotation is itself a tuple of the
-            form :math:`(i, j, \\theta, \\varphi)`, which represents a
+            form :math:`(i, j, \theta, \varphi)`, which represents a
             Givens rotation of coordinates
-            :math:`i` and :math:`j` by angles :math:`\\theta` and
-            :math:`\\varphi`.
+            :math:`i` and :math:`j` by angles :math:`\theta` and
+            :math:`\varphi`.
         left_unitary (ndarray):
-            An :math:`m \\times m` numpy array representing the matrix
+            An :math:`m \times m` numpy array representing the matrix
             :math:`V`.
         diagonal (ndarray):
             A list of the nonzero entries of :math:`D`.
@@ -382,10 +382,10 @@ def givens_decomposition(unitary_rows):
 
 
 def fermionic_gaussian_decomposition(unitary_rows):
-    """Decompose a matrix into a sequence of Givens rotations and
+    r"""Decompose a matrix into a sequence of Givens rotations and
     particle-hole transformations on the last fermionic mode.
 
-    The input is an :math:`N \\times 2N` matrix :math:`W` with orthonormal
+    The input is an :math:`N \times 2N` matrix :math:`W` with orthonormal
     rows. Furthermore, :math:`W` must have the block form
 
     .. math::
@@ -426,9 +426,9 @@ def fermionic_gaussian_decomposition(unitary_rows):
     something like [('pht', ), (G_1, ), ('pht', G_2), ... ].
     The objects within a tuple are either the string 'pht', which indicates
     a particle-hole transformation on the last fermionic mode, or a tuple
-    of the form :math:`(i, j, \\theta, \\varphi)`, which indicates a
+    of the form :math:`(i, j, \theta, \varphi)`, which indicates a
     Givens rotation of rows :math:`i` and :math:`j` by angles
-    :math:`\\theta` and :math:`\\varphi`.
+    :math:`\theta` and :math:`\varphi`.
 
     The matrix :math:`V^T D^*` can also be decomposed as a sequence of
     Givens rotations. This decomposition is needed for a circuit that

--- a/src/openfermion/ops/_quadratic_hamiltonian.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian.py
@@ -27,20 +27,20 @@ class QuadraticHamiltonianError(Exception):
 
 
 class QuadraticHamiltonian(PolynomialTensor):
-    """Class for storing Hamiltonians that are quadratic in the fermionic
+    r"""Class for storing Hamiltonians that are quadratic in the fermionic
     ladder operators. The operators stored in this class take the form
 
     .. math::
 
         \sum_{p, q} (M_{pq} - \mu \delta_{pq}) a^\dagger_p a_q
-        + \\frac12 \sum_{p, q}
-            (\\Delta_{pq} a^\dagger_p a^\dagger_q + \\text{h.c.})
-        + \\text{constant}
+        + \frac12 \sum_{p, q}
+            (\Delta_{pq} a^\dagger_p a^\dagger_q + \text{h.c.})
+        + \text{constant}
 
     where
 
         - :math:`M` is a Hermitian `n_qubits` x `n_qubits` matrix.
-        - :math:`\\Delta` is an antisymmetric `n_qubits` x `n_qubits` matrix.
+        - :math:`\Delta` is an antisymmetric `n_qubits` x `n_qubits` matrix.
         - :math:`\mu` is a real number representing the chemical potential.
         - :math:`\delta_{pq}` is the Kronecker delta symbol.
 
@@ -54,7 +54,7 @@ class QuadraticHamiltonian(PolynomialTensor):
 
     def __init__(self, hermitian_part, antisymmetric_part=None,
                  constant=0., chemical_potential=0.):
-        """
+        r"""
         Initialize the QuadraticHamiltonian class.
 
         Args:
@@ -62,7 +62,7 @@ class QuadraticHamiltonian(PolynomialTensor):
                 coefficients of the particle-number-conserving terms.
                 This is an `n_qubits` x `n_qubits` numpy array of complex
                 numbers.
-            antisymmetric_part(ndarray): The matrix :math:`\\Delta`,
+            antisymmetric_part(ndarray): The matrix :math:`\Delta`,
                 which represents the coefficients of the
                 non-particle-number-conserving terms.
                 This is an `n_qubits` x `n_qubits` numpy array of complex
@@ -125,16 +125,16 @@ class QuadraticHamiltonian(PolynomialTensor):
         self.chemical_potential += chemical_potential
 
     def orbital_energies(self, non_negative=False):
-        """Return the orbital energies.
+        r"""Return the orbital energies.
 
         Any quadratic Hamiltonian is unitarily equivalent to a Hamiltonian
         of the form
 
         .. math::
 
-            \sum_{j} \\varepsilon_j b^\dagger_j b_j + \\text{constant}.
+            \sum_{j} \varepsilon_j b^\dagger_j b_j + \text{constant}.
 
-        We call the :math:`\\varepsilon_j` the orbital energies.
+        We call the :math:`\varepsilon_j` the orbital energies.
         The eigenvalues of the Hamiltonian are sums of subsets of the
         orbital energies (up to the additive constant).
 
@@ -147,7 +147,7 @@ class QuadraticHamiltonian(PolynomialTensor):
         Returns
         -------
         orbital_energies(ndarray)
-            A one-dimensional array containing the :math:`\\varepsilon_j`
+            A one-dimensional array containing the :math:`\varepsilon_j`
         constant(float)
             The constant
         """
@@ -172,21 +172,21 @@ class QuadraticHamiltonian(PolynomialTensor):
         return constant
 
     def majorana_form(self):
-        """Return the Majorana represention of the Hamiltonian.
+        r"""Return the Majorana represention of the Hamiltonian.
 
         Any quadratic Hamiltonian can be written in the form
 
         .. math::
 
-            \\frac{i}{2} \sum_{j, k} A_{jk} f_j f_k + \\text{constant}
+            \frac{i}{2} \sum_{j, k} A_{jk} f_j f_k + \text{constant}
 
         where the :math:`f_i` are normalized Majorana fermion operators:
 
         .. math::
 
-            f_j = \\frac{1}{\\sqrt{2}} (a^\dagger_j + a_j)
+            f_j = \frac{1}{\sqrt{2}} (a^\dagger_j + a_j)
 
-            f_{j + N} = \\frac{i}{\\sqrt{2}} (a^\dagger_j - a_j)
+            f_{j + N} = \frac{i}{\sqrt{2}} (a^\dagger_j - a_j)
 
         and :math:`A` is a (2 * `n_qubits`) x (2 * `n_qubits`) real
         antisymmetric matrix. This function returns the matrix
@@ -221,13 +221,13 @@ class QuadraticHamiltonian(PolynomialTensor):
         return majorana_matrix, majorana_constant
 
     def diagonalizing_bogoliubov_transform(self):
-        """Compute the unitary that diagonalizes a quadratic Hamiltonian.
+        r"""Compute the unitary that diagonalizes a quadratic Hamiltonian.
 
         Any quadratic Hamiltonian can be rewritten in the form
 
         .. math::
 
-            \sum_{j} \\varepsilon_j b^\dagger_j b_j + \\text{constant},
+            \sum_{j} \varepsilon_j b^\dagger_j b_j + \text{constant},
 
         where the :math:`b^\dagger_j` are a new set fermionic creation operators
         that satisfy the canonical anticommutation relations.
@@ -237,39 +237,39 @@ class QuadraticHamiltonian(PolynomialTensor):
 
         .. math::
 
-           \\begin{pmatrix}
-                b^\dagger_1 \\\\
-                \\vdots \\\\
-                b^\dagger_N \\\\
-           \\end{pmatrix}
+           \begin{pmatrix}
+                b^\dagger_1 \\
+                \vdots \\
+                b^\dagger_N \\
+           \end{pmatrix}
            = W
-           \\begin{pmatrix}
-                a^\dagger_1 \\\\
-                \\vdots \\\\
-                a^\dagger_N \\\\
-                a_1 \\\\
-                \\vdots \\\\
+           \begin{pmatrix}
+                a^\dagger_1 \\
+                \vdots \\
+                a^\dagger_N \\
+                a_1 \\
+                \vdots \\
                 a_N
-           \\end{pmatrix},
+           \end{pmatrix},
 
-        where :math:`W` is an :math:`N \\times (2N)` matrix.
+        where :math:`W` is an :math:`N \times (2N)` matrix.
         However, if the Hamiltonian conserves particle number then
         creation operators don't need to be mixed with annihilation operators
-        and :math:`W` only needs to be an :math:`N \\times N` matrix:
+        and :math:`W` only needs to be an :math:`N \times N` matrix:
 
         .. math::
 
-           \\begin{pmatrix}
-                b^\dagger_1 \\\\
-                \\vdots \\\\
-                b^\dagger_N \\\\
-           \\end{pmatrix}
+           \begin{pmatrix}
+                b^\dagger_1 \\
+                \vdots \\
+                b^\dagger_N \\
+           \end{pmatrix}
            = W
-           \\begin{pmatrix}
-                a^\dagger_1 \\\\
-                \\vdots \\\\
-                a^\dagger_N \\\\
-           \\end{pmatrix},
+           \begin{pmatrix}
+                a^\dagger_1 \\
+                \vdots \\
+                a^\dagger_N \\
+           \end{pmatrix},
 
         This method returns the matrix :math:`W`.
 
@@ -277,8 +277,8 @@ class QuadraticHamiltonian(PolynomialTensor):
             diagonalizing_unitary (ndarray):
                 A matrix representing the transformation :math:`W` of the
                 fermionic ladder operators. If the Hamiltonian conserves
-                particle number then this is :math:`N \\times N`; otherwise
-                it is :math:`N \\times 2N`.
+                particle number then this is :math:`N \times N`; otherwise
+                it is :math:`N \times 2N`.
         """
         if self.conserves_particle_number:
             _, diagonalizing_unitary_T = numpy.linalg.eigh(
@@ -311,14 +311,14 @@ class QuadraticHamiltonian(PolynomialTensor):
             return diagonalizing_unitary[:self.n_qubits]
 
     def diagonalizing_circuit(self):
-        """Get a circuit for a unitary that diagonalizes this Hamiltonian
+        r"""Get a circuit for a unitary that diagonalizes this Hamiltonian
 
         This circuit performs the transformation to a basis in which the
         Hamiltonian takes the diagonal form
 
         .. math::
 
-            \sum_{j} \\varepsilon_j b^\dagger_j b_j + \\text{constant}.
+            \sum_{j} \varepsilon_j b^\dagger_j b_j + \text{constant}.
 
         Returns
         -------
@@ -328,10 +328,10 @@ class QuadraticHamiltonian(PolynomialTensor):
                 can be performed in parallel. Each elementary operation
                 is either the string 'pht' indicating a particle-hole
                 transformation on the last fermionic mode, or a tuple of
-                the form :math:`(i, j, \\theta, \\varphi)`,
+                the form :math:`(i, j, \theta, \varphi)`,
                 indicating a Givens rotation
-                of modes :math:`i` and :math:`j` by angles :math:`\\theta`
-                and :math:`\\varphi`.
+                of modes :math:`i` and :math:`j` by angles :math:`\theta`
+                and :math:`\varphi`.
         """
         transformation_matrix = self.diagonalizing_bogoliubov_transform()
 

--- a/src/openfermion/ops/_symbolic_operator.py
+++ b/src/openfermion/ops/_symbolic_operator.py
@@ -566,13 +566,13 @@ class SymbolicOperator(object):
         self.terms = new_terms
 
     def induced_norm(self, order=1):
-        """
+        r"""
         Compute the induced p-norm of the operator.
 
         If we represent an operator as
         :math: `\sum_{j} w_j H_j`
         where :math: `w_j` are scalar coefficients then this norm is
-        :math: `\left(\sum_{j} \| w_j \|^p \\right)^{\\frac{1}{p}}
+        :math: `\left(\sum_{j} \| w_j \|^p \right)^{\frac{1}{p}}
         where :math: `p` is the order of the induced norm
 
         Args:

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -24,7 +24,7 @@ from openfermion.ops._givens_rotations import (
 
 def gaussian_state_preparation_circuit(
         quadratic_hamiltonian, occupied_orbitals=None):
-    """Obtain the description of a circuit which prepares a fermionic Gaussian
+    r"""Obtain the description of a circuit which prepares a fermionic Gaussian
     state.
 
     Fermionic Gaussian states can be regarded as eigenstates of quadratic
@@ -42,22 +42,22 @@ def gaussian_state_preparation_circuit(
 
       .. math::
 
-          \\begin{align}
-              \mathcal{B} a_N \mathcal{B}^\dagger &= a_N^\dagger,\\\\
-              \mathcal{B} a_j \mathcal{B}^\dagger &= a_j, \\quad
+          \begin{align}
+              \mathcal{B} a_N \mathcal{B}^\dagger &= a_N^\dagger,\\
+              \mathcal{B} a_j \mathcal{B}^\dagger &= a_j, \quad
                   j = 1, \ldots, N-1,
           \end{align}
 
       or
 
-    - a tuple :math:`(i, j, \\theta, \\varphi)`, indicating the operation
+    - a tuple :math:`(i, j, \theta, \varphi)`, indicating the operation
 
       .. math::
-          \exp[i \\varphi a_j^\dagger a_j]
-          \exp[\\theta (a_i^\dagger a_j - a_j^\dagger a_i)],
+          \exp[i \varphi a_j^\dagger a_j]
+          \exp[\theta (a_i^\dagger a_j - a_j^\dagger a_i)],
 
       a Givens rotation of modes :math:`i` and :math:`j` by angles
-      :math:`\\theta` and :math:`\\varphi`.
+      :math:`\theta` and :math:`\varphi`.
 
     Args:
         quadratic_hamiltonian(QuadraticHamiltonian):
@@ -76,10 +76,10 @@ def gaussian_state_preparation_circuit(
             can be performed in parallel. Each elementary operation
             is either the string 'pht', indicating a particle-hole
             transformation on the last fermionic mode, or a tuple of
-            the form :math:`(i, j, \\theta, \\varphi)`,
+            the form :math:`(i, j, \theta, \varphi)`,
             indicating a Givens rotation
-            of modes :math:`i` and :math:`j` by angles :math:`\\theta`
-            and :math:`\\varphi`.
+            of modes :math:`i` and :math:`j` by angles :math:`\theta`
+            and :math:`\varphi`.
         start_orbitals (list):
             The occupied orbitals to start with. This describes the
             initial state that the circuit should be applied to: it should
@@ -146,14 +146,14 @@ def gaussian_state_preparation_circuit(
 
 
 def slater_determinant_preparation_circuit(slater_determinant_matrix):
-    """Obtain the description of a circuit which prepares a Slater determinant.
+    r"""Obtain the description of a circuit which prepares a Slater determinant.
 
-    The input is an :math:`N_f \\times N` matrix :math:`Q` with orthonormal
+    The input is an :math:`N_f \times N` matrix :math:`Q` with orthonormal
     rows. Such a matrix describes the Slater determinant
 
     .. math::
 
-        b^\dagger_1 \cdots b^\dagger_{N_f} \lvert \\text{vac} \\rangle,
+        b^\dagger_1 \cdots b^\dagger_{N_f} \lvert \text{vac} \rangle,
 
     where
 
@@ -175,9 +175,9 @@ def slater_determinant_preparation_circuit(slater_determinant_matrix):
             A list of operations describing the circuit. Each operation
             is a tuple of elementary operations that can be performed in
             parallel. Each elementary operation is a tuple of the form
-            :math:`(i, j, \\theta, \\varphi)`, indicating a Givens rotation
-            of modes :math:`i` and :math:`j` by angles :math:`\\theta`
-            and :math:`\\varphi`.
+            :math:`(i, j, \theta, \varphi)`, indicating a Givens rotation
+            of modes :math:`i` and :math:`j` by angles :math:`\theta`
+            and :math:`\varphi`.
     """
     decomposition, left_unitary, diagonal = givens_decomposition(
         slater_determinant_matrix)

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -253,15 +253,15 @@ def jw_number_indices(n_electrons, n_qubits):
 
 
 def jw_sz_indices(sz_value, n_qubits, n_electrons=None):
-    """Return the indices of basis vectors with fixed Sz under JW encoding.
+    r"""Return the indices of basis vectors with fixed Sz under JW encoding.
 
     The returned indices label computational basis vectors which lie within
     the corresponding eigenspace of the Sz operator,
 
     .. math::
-        \\begin{align}
-        S^{z} = \\frac{1}{2}\sum_{i = 1}^{n}(n_{i, \\alpha} - n_{i, \\beta})
-        \\end{align}
+        \begin{align}
+        S^{z} = \frac{1}{2}\sum_{i = 1}^{n}(n_{i, \alpha} - n_{i, \beta})
+        \end{align}
 
     Args:
         sz_value(float): Desired Sz value. Should be an integer or
@@ -579,14 +579,14 @@ def jw_get_gaussian_state(quadratic_hamiltonian, occupied_orbitals=None):
 
 
 def jw_slater_determinant(slater_determinant_matrix):
-    """Obtain a Slater determinant.
+    r"""Obtain a Slater determinant.
 
-    The input is an :math:`N_f \\times N` matrix :math:`Q` with orthonormal
+    The input is an :math:`N_f \times N` matrix :math:`Q` with orthonormal
     rows. Such a matrix describes the Slater determinant
 
     .. math::
 
-        b^\dagger_1 \cdots b^\dagger_{N_f} \lvert \\text{vac} \\rangle,
+        b^\dagger_1 \cdots b^\dagger_{N_f} \lvert \text{vac} \rangle,
 
     where
 

--- a/src/openfermion/utils/_special_operators.py
+++ b/src/openfermion/utils/_special_operators.py
@@ -34,12 +34,12 @@ def down_index(index):
 
 
 def s_plus_operator(n_spatial_orbitals):
-    """Return the s+ operator.
+    r"""Return the s+ operator.
 
     .. math::
-        \\begin{align}
-        S^{+} = \sum_{i=1}^{n} a_{i, \\alpha}^{\dagger}a_{i, \\beta}
-        \\end{align}
+        \begin{align}
+        S^{+} = \sum_{i=1}^{n} a_{i, \alpha}^{\dagger}a_{i, \beta}
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits + 1 // 2).
@@ -64,12 +64,12 @@ def s_plus_operator(n_spatial_orbitals):
 
 
 def s_minus_operator(n_spatial_orbitals):
-    """Return the s+ operator.
+    r"""Return the s+ operator.
 
     .. math::
-        \\begin{align}
-        S^{-} = \sum_{i=1}^{n} a_{i, \\beta}^{\dagger}a_{i, \\alpha}
-        \\end{align}
+        \begin{align}
+        S^{-} = \sum_{i=1}^{n} a_{i, \beta}^{\dagger}a_{i, \alpha}
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits + 1 // 2).
@@ -94,12 +94,12 @@ def s_minus_operator(n_spatial_orbitals):
 
 
 def sx_operator(n_spatial_orbitals):
-    """Return the sx operator.
+    r"""Return the sx operator.
 
     .. math::
-        \\begin{align}
-        S^{x} = \\frac{1}{2}\sum_{i = 1}^{n}(S^{+} + S^{-})
-        \\end{align}
+        \begin{align}
+        S^{x} = \frac{1}{2}\sum_{i = 1}^{n}(S^{+} + S^{-})
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits // 2).
@@ -127,12 +127,12 @@ def sx_operator(n_spatial_orbitals):
 
 
 def sy_operator(n_spatial_orbitals):
-    """Return the sy operator.
+    r"""Return the sy operator.
 
     .. math::
-        \\begin{align}
-        S^{y} = \\frac{-i}{2}\sum_{i = 1}^{n}(S^{+} - S^{-})
-        \\end{align}
+        \begin{align}
+        S^{y} = \frac{-i}{2}\sum_{i = 1}^{n}(S^{+} - S^{-})
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits // 2).
@@ -160,12 +160,12 @@ def sy_operator(n_spatial_orbitals):
 
 
 def sz_operator(n_spatial_orbitals):
-    """Return the sz operator.
+    r"""Return the sz operator.
 
     .. math::
-        \\begin{align}
-        S^{z} = \\frac{1}{2}\sum_{i = 1}^{n}(n_{i, \\alpha} - n_{i, \\beta})
-        \\end{align}
+        \begin{align}
+        S^{z} = \frac{1}{2}\sum_{i = 1}^{n}(n_{i, \alpha} - n_{i, \beta})
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits // 2).
@@ -194,12 +194,12 @@ def sz_operator(n_spatial_orbitals):
 
 
 def s_squared_operator(n_spatial_orbitals):
-    """Return the s^{2} operator.
+    r"""Return the s^{2} operator.
 
     .. math::
-        \\begin{align}
+        \begin{align}
         S^{2} = S^{-} S^{+} + S^{z}( S^{z} + 1)
-        \\end{align}
+        \end{align}
 
     Args:
         n_spatial_orbitals: number of spatial orbitals (n_qubits + 1 // 2).


### PR DESCRIPTION
This way we don't need to use double slashes to override escape sequences.