### PR TITLE
Use EQ_TOLERANCE to check for real numbers in Givens rotations code

### DIFF
--- a/src/openfermion/ops/_givens_rotations.py
+++ b/src/openfermion/ops/_givens_rotations.py
@@ -64,7 +64,9 @@ def givens_matrix_elements(a, b, which='left'):
     # Construct matrix and return
     if which == 'left':
         # We want to zero out a
-        if numpy.isreal(a) and numpy.isreal(b):
+        if (abs(numpy.imag(a)) < EQ_TOLERANCE and
+                abs(numpy.imag(b)) < EQ_TOLERANCE):
+            # a and b are real, so return a standard rotation matrix
             givens_rotation = numpy.array([[cosine, -phase * sine],
                                            [phase * sine, cosine]])
         else:
@@ -72,7 +74,9 @@ def givens_matrix_elements(a, b, which='left'):
                                            [sine, phase * cosine]])
     elif which == 'right':
         # We want to zero out b
-        if numpy.isreal(a) and numpy.isreal(b):
+        if (abs(numpy.imag(a)) < EQ_TOLERANCE and
+                abs(numpy.imag(b)) < EQ_TOLERANCE):
+            # a and b are real, so return a standard rotation matrix
             givens_rotation = numpy.array([[sine, phase * cosine],
                                            [-phase * cosine, sine]])
         else:

--- a/src/openfermion/ops/_givens_rotations_test.py
+++ b/src/openfermion/ops/_givens_rotations_test.py
@@ -50,6 +50,17 @@ class GivensMatrixElementsTest(unittest.TestCase):
             self.assertAlmostEqual(G_left.dot(v)[0], 0.)
             self.assertAlmostEqual(G_right.dot(v)[1], 0.)
 
+    def test_approximately_real(self):
+        """Test that the procedure throws out small imaginary components."""
+        for _ in range(self.num_test_repetitions):
+            v = numpy.random.randn(2) + 1.j * 1e-14
+            G_left = givens_matrix_elements(v[0], v[1], which='left')
+            G_right = givens_matrix_elements(v[0], v[1], which='right')
+            self.assertAlmostEqual(G_left[0, 0], G_left[1, 1])
+            self.assertAlmostEqual(G_right[0, 0], G_right[1, 1])
+            self.assertAlmostEqual(G_left.dot(v)[0], 0.)
+            self.assertAlmostEqual(G_right.dot(v)[1], 0.)
+
     def test_bad_input(self):
         """Test bad input."""
         with self.assertRaises(ValueError):


### PR DESCRIPTION
One of the optimizations used in the Givens rotation code is to use standard rotation matrices when dealing with only real numbers, but the check for whether a number is real should be satisfied with approximate real-ness.