### PR TITLE
Expose inline_sum

### DIFF
--- a/src/openfermion/transforms/_bravyi_kitaev.py
+++ b/src/openfermion/transforms/_bravyi_kitaev.py
@@ -13,7 +13,7 @@
 """Bravyi-Kitaev transform on fermionic operators."""
 
 from openfermion.ops import QubitOperator
-from openfermion.utils import count_qubits
+from openfermion.utils import count_qubits, inline_sum
 
 
 def bravyi_kitaev(operator, n_qubits=None):
@@ -53,7 +53,7 @@ def bravyi_kitaev(operator, n_qubits=None):
                                  n_qubits=n_qubits)
         for term in operator.terms
     )
-    return inline_sum(seed=QubitOperator(), summands=transformed_terms)
+    return inline_sum(summands=transformed_terms, seed=QubitOperator())
 
 
 def _update_set(index, n_qubits):
@@ -121,8 +121,9 @@ def _transform_operator_term(term, coefficient, n_qubits):
         _transform_ladder_operator(ladder_operator, n_qubits)
         for ladder_operator in term
     )
-    return inline_product(seed=QubitOperator((), coefficient),
-                          factors=transformed_ladder_ops)
+    return inline_product(factors=transformed_ladder_ops,
+                          seed=QubitOperator((), coefficient))
+                          
 
 
 def _transform_ladder_operator(ladder_operator, n_qubits):
@@ -162,20 +163,7 @@ def _transform_ladder_operator(ladder_operator, n_qubits):
     return transformed_operator
 
 
-def inline_sum(seed, summands):
-    """Computes a sum, using the __iadd__ operator.
-    Args:
-        seed (T): The starting total. The zero value.
-        summands (iterable[T]): Values to add (with +=) into the total.
-    Returns:
-        T: The result of adding all the factors into the zero value.
-    """
-    for r in summands:
-        seed += r
-    return seed
-
-
-def inline_product(seed, factors):
+def inline_product(factors, seed):
     """Computes a product, using the __imul__ operator.
     Args:
         seed (T): The starting total. The unit value.

--- a/src/openfermion/transforms/_bravyi_kitaev_tree.py
+++ b/src/openfermion/transforms/_bravyi_kitaev_tree.py
@@ -14,6 +14,8 @@
 from __future__ import absolute_import
 
 from openfermion.ops import QubitOperator
+from openfermion.utils import inline_sum
+from openfermion.transforms._bravyi_kitaev import inline_product
 from openfermion.transforms._fenwick_tree import FenwickTree
 
 
@@ -59,7 +61,7 @@ def bravyi_kitaev_tree(operator, n_qubits=None):
                                  fenwick_tree=fenwick_tree)
         for term in operator.terms
     )
-    return inline_sum(seed=QubitOperator(), summands=transformed_terms)
+    return inline_sum(summands=transformed_terms, seed=QubitOperator())
 
 
 def _transform_operator_term(term, coefficient, fenwick_tree):
@@ -78,8 +80,8 @@ def _transform_operator_term(term, coefficient, fenwick_tree):
         _transform_ladder_operator(ladder_operator, fenwick_tree)
         for ladder_operator in term
     )
-    return inline_product(seed=QubitOperator((), coefficient),
-                          factors=transformed_ladder_ops)
+    return inline_product(factors=transformed_ladder_ops,
+                          seed=QubitOperator((), coefficient))
 
 
 def _transform_ladder_operator(ladder_operator, fenwick_tree):
@@ -122,29 +124,3 @@ def _transform_ladder_operator(ladder_operator, fenwick_tree):
         0.5)
 
     return c_majorana_component + d_majorana_component
-
-
-def inline_sum(seed, summands):
-    """Computes a sum, using the __iadd__ operator.
-    Args:
-        seed (T): The starting total. The zero value.
-        summands (iterable[T]): Values to add (with +=) into the total.
-    Returns:
-        T: The result of adding all the factors into the zero value.
-    """
-    for r in summands:
-        seed += r
-    return seed
-
-
-def inline_product(seed, factors):
-    """Computes a product, using the __imul__ operator.
-    Args:
-        seed (T): The starting total. The unit value.
-        factors (iterable[T]): Values to multiply (with *=) into the total.
-    Returns:
-        T: The result of multiplying all the factors into the unit value.
-    """
-    for r in factors:
-        seed *= r
-    return seed

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -23,7 +23,8 @@ from ._lcu_util import preprocess_lcu_coefficients_for_reversible_sampling
 
 from ._operator_utils import (count_qubits, eigenspectrum, fourier_transform,
                               freeze_orbitals, get_file_path,
-                              hermitian_conjugated, inverse_fourier_transform,
+                              hermitian_conjugated, inline_sum,
+                              inverse_fourier_transform,
                               is_hermitian, is_identity, prune_unused_indices,
                               reorder, up_then_down,
                               load_operator, save_operator)

--- a/src/openfermion/utils/_operator_utils.py
+++ b/src/openfermion/utils/_operator_utils.py
@@ -32,6 +32,19 @@ class OperatorUtilsError(Exception):
     pass
 
 
+def inline_sum(summands, seed):
+    """Computes a sum, using the __iadd__ operator.
+    Args:
+        seed (T): The starting total. The zero value.
+        summands (iterable[T]): Values to add (with +=) into the total.
+    Returns:
+        T: The result of adding all the factors into the zero value.
+    """
+    for r in summands:
+        seed += r
+    return seed
+
+
 def freeze_orbitals(fermion_operator, occupied, unoccupied=None, prune=True):
     """Fix some orbitals to be occupied and others unoccupied.
 


### PR DESCRIPTION
Using this function is much more efficient than adding a list of SymbolicOperators using the built-in `sum`. Previously it was hidden in `bravyi_kitaev.py`. Changed the argument order to match up with the built-in `sum`.

Also changed the argument order of `inline_product` but did not expose it.