### PR TITLE
Allow get_ground_state to be applied to LinearOperators

### DIFF
--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -758,9 +758,6 @@ def get_ground_state(sparse_operator, initial_guess=None):
         eigenstate:
             The lowest eigenstate in scipy.sparse csc format.
     """
-    if not is_hermitian(sparse_operator):
-        raise ValueError('sparse_operator must be Hermitian.')
-
     values, vectors = scipy.sparse.linalg.eigsh(
         sparse_operator, k=1, v0=initial_guess, which='SA', maxiter=1e7)
 

--- a/src/openfermion/utils/_sparse_tools_test.py
+++ b/src/openfermion/utils/_sparse_tools_test.py
@@ -696,10 +696,6 @@ class GroundStateTest(unittest.TestCase):
             numpy.absolute(
                 expected_state.T.conj().dot(ground[1]))[0], 1.)
 
-    def test_get_ground_state_nonhermitian(self):
-        with self.assertRaises(ValueError):
-            get_ground_state(get_sparse_operator(1j * QubitOperator('X1')))
-
 
 class ExpectationTest(unittest.TestCase):
     def test_expectation_correct(self):


### PR DESCRIPTION
I don't think there's a good way to check if a LinearOperator is Hermitian, and in any case I'm not sure this is the place to be checking for that.