### PR TITLE
New function which returns MolecularData geometry of input PubChem names.

### DIFF
--- a/examples/openfermion_tutorial.ipynb
+++ b/examples/openfermion_tutorial.ipynb
@@ -1018,6 +1018,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The geometry data needed to generate MolecularData can also be retreived from the PubChem online database by inputting the molecule's name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('C', (0, 0, 0)), ('H', (0.5541, 0.7996, 0.4965)), ('H', (0.6833, -0.8134, -0.2536)), ('H', (-0.7782, -0.3735, 0.6692)), ('H', (-0.4593, 0.3874, -0.9121))]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from openfermion.utils import geometry_from_pubchem\n",
+    "\n",
+    "methane_geometry = geometry_from_pubchem('methane')\n",
+    "print(methane_geometry)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## InteractionOperator and InteractionRDM for efficient numerical representations\n",
     "\n",
     "Fermion Hamiltonians can be expressed as $H = h_0 + \\sum_{pq} h_{pq}\\, a^\\dagger_p a_q + \\frac{1}{2} \\sum_{pqrs} h_{pqrs} \\, a^\\dagger_p a^\\dagger_q a_r a_s$ where $h_0$ is a constant shift due to the nuclear repulsion and $h_{pq}$ and $h_{pqrs}$ are the famous molecular integrals. Since fermions interact pairwise, their energy is thus a unique function of the one-particle and two-particle reduced density matrices which are expressed in second quantization as $\\rho_{pq} = \\left \\langle p \\mid a^\\dagger_p a_q \\mid q \\right \\rangle$ and $\\rho_{pqrs} = \\left \\langle pq \\mid a^\\dagger_p a^\\dagger_q a_r a_s \\mid rs \\right \\rangle$, respectively.\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ h5py
 jupyter
 networkx
 matplotlib
+pubchempy

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -88,3 +88,5 @@ from ._sparse_tools import (expectation,
                             qubit_operator_sparse,
                             sparse_eigenspectrum,
                             variance)
+
+from ._openfermion_pubchem import geometry_from_pubchem

--- a/src/openfermion/utils/_openfermion_pubchem.py
+++ b/src/openfermion/utils/_openfermion_pubchem.py
@@ -1,0 +1,54 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pubchempy
+
+
+def geometry_from_pubchem(name):
+    """Function to extract geometry using the molecule's name from the PubChem
+    database.
+
+    Args:
+        name: a string giving the molecule's name as required by the PubChem
+            database.
+
+    Returns:
+        geometry: a list of tuples giving the coordinates of each atom with
+        distances in Angstrom.
+    """
+
+    pubchempy_2d_molecule = pubchempy.get_compounds(name, 'name',
+                                                    record_type='2d')
+
+    # Check if 2-D geometry is available. If not then no geometry is.
+    if not pubchempy_2d_molecule:
+        print('Unable to find molecule in the PubChem database.')
+        return None
+
+    # Ideally get the 3-D geometry if available.
+    pubchempy_3d_molecule = pubchempy.get_compounds(name, 'name',
+                                                    record_type='3d')
+
+    if pubchempy_3d_molecule:
+        pubchempy_geometry = \
+            pubchempy_3d_molecule[0].to_dict(properties=['atoms'])['atoms']
+        geometry = [(atom['element'], (atom['x'], atom['y'], atom['z']))
+                    for atom in pubchempy_geometry]
+        return geometry
+
+    # If the 3-D geometry isn't available, get the 2-D geometry instead.
+    pubchempy_geometry = \
+        pubchempy_2d_molecule[0].to_dict(properties=['atoms'])['atoms']
+    geometry = [(atom['element'], (atom['x'], atom['y'], 0))
+                for atom in pubchempy_geometry]
+
+    return geometry


### PR DESCRIPTION
This allows easy geometry specification by non-specialists as the PubChem names are very flexible, e.g. 'H2O', 'water' or 'dihydrogen oxide' for the same molecule. Colloquial names like 'dry ice' or 'sugar' are also accepted. Requires the PubChemPy library.