### PR TITLE
Add get_lienar_qubit_operator_diagonal to be used for Davidson algorithm.

### DIFF
--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -330,8 +330,8 @@ def get_linear_qubit_operator_diagonal(qubit_operator, n_qubits=None):
             vecs = [v for vp in vec_pairs for v in (vp[0], -vp[1])]
             tensor_factor = pauli_operator[0] + 1
         if not is_zero:
-            linear_operator_diagonal += qubit_operator.terms[qubit_term] * \
-                numpy.concatenate(vecs)
+            linear_operator_diagonal += (qubit_operator.terms[qubit_term] *
+                                         numpy.concatenate(vecs))
     return linear_operator_diagonal
 
 

--- a/src/openfermion/utils/_sparse_tools_test.py
+++ b/src/openfermion/utils/_sparse_tools_test.py
@@ -108,6 +108,16 @@ class JordanWignerSparseTest(unittest.TestCase):
             qubit_operator_sparse(QubitOperator('X1')).A,
             expected.A))
 
+    def test_get_linear_qubit_operator_wrong_n(self):
+        """Testing with wrong n_qubits."""
+        with self.assertRaises(ValueError):
+            get_linear_qubit_operator(QubitOperator('X3'), 1)
+
+    def test_get_linear_qubit_operator_wrong_vec_length(self):
+        """Testing with wrong vector length."""
+        with self.assertRaises(ValueError):
+            get_linear_qubit_operator(QubitOperator('X3')) * numpy.zeros(4)
+
     def test_get_linear_qubit_operator_0(self):
         """Testing with zero term."""
         qubit_operator = QubitOperator.zero()
@@ -182,6 +192,61 @@ class JordanWignerSparseTest(unittest.TestCase):
             numpy.array([get_linear_qubit_operator(qubit_operator) * v
                          for v in numpy.identity(16)])),
                                        mat_expected.A))
+
+    def test_get_linear_qubit_operator_diagonal_wrong_n(self):
+        """Testing with wrong n_qubits."""
+        with self.assertRaises(ValueError):
+            get_linear_qubit_operator_diagonal(QubitOperator('X3'), 1)
+
+    def test_get_linear_qubit_operator_diagonal_0(self):
+        """Testing with zero term."""
+        qubit_operator = QubitOperator.zero()
+        vec_expected = numpy.zeros(8)
+
+        self.assertTrue(numpy.allclose(
+            get_linear_qubit_operator_diagonal(qubit_operator, 3), vec_expected))
+
+    def test_get_linear_qubit_operator_diagonal_zero(self):
+        """Get zero diagonals from get_linear_qubit_operator_diagonal."""
+        qubit_operator = QubitOperator('X0 Y1')
+        vec_expected = numpy.zeros(4)
+
+        self.assertTrue(numpy.allclose(
+            get_linear_qubit_operator_diagonal(qubit_operator), vec_expected))
+
+    def test_get_linear_qubit_operator_diagonal_non_zero(self):
+        """Get non zero diagonals from get_linear_qubit_operator_diagonal."""
+        qubit_operator = QubitOperator('Z0 Z2')
+        vec_expected = numpy.array([1, -1, 1, -1, -1, 1, -1, 1])
+
+        self.assertTrue(numpy.allclose(
+            get_linear_qubit_operator_diagonal(qubit_operator), vec_expected))
+
+    def test_get_linear_qubit_operator_diagonal_cmp_zero(self):
+        """Compare get_linear_qubit_operator_diagonal with
+            get_linear_qubit_operator.
+        """
+        qubit_operator = QubitOperator('Z1 X2 Y5')
+
+        vec = get_linear_qubit_operator_diagonal(qubit_operator)
+        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) * \
+                                  numpy.eye(2 ** 6))
+
+        self.assertTrue(numpy.allclose(
+            get_linear_qubit_operator_diagonal(qubit_operator), vec_expected))
+
+    def test_get_linear_qubit_operator_diagonal_cmp_non_zero(self):
+        """Compare get_linear_qubit_operator_diagonal with
+            get_linear_qubit_operator.
+        """
+        qubit_operator = QubitOperator('Z1 Z2 Z5')
+
+        vec = get_linear_qubit_operator_diagonal(qubit_operator)
+        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) * \
+                                  numpy.eye(2 ** 6))
+
+        self.assertTrue(numpy.allclose(
+            get_linear_qubit_operator_diagonal(qubit_operator), vec_expected))
 
 class ComputationalBasisStateTest(unittest.TestCase):
     def test_computational_basis_state(self):

--- a/src/openfermion/utils/_sparse_tools_test.py
+++ b/src/openfermion/utils/_sparse_tools_test.py
@@ -173,12 +173,12 @@ class JordanWignerSparseTest(unittest.TestCase):
 
     def test_get_linear_qubit_operator_multiple_terms(self):
         """Testing with multiple terms."""
-        qubit_operator = QubitOperator.identity() + 2 * QubitOperator('Y2') + \
-            QubitOperator(((0, 'Z'), (1, 'X')), 10.0)
+        qubit_operator = (QubitOperator.identity() + 2 * QubitOperator('Y2') +
+                          QubitOperator(((0, 'Z'), (1, 'X')), 10.0))
 
         vec = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
-        matvec_expected = 10 * numpy.array([3, 4, 1, 2, -7, -8, -5, -6]) + \
-            2.j * numpy.array([-2, 1, -4, 3, -6, 5, -8, 7], dtype=complex) + vec
+        matvec_expected = (10 * numpy.array([3, 4, 1, 2, -7, -8, -5, -6]) +
+                           2j * numpy.array([-2, 1, -4, 3, -6, 5, -8, 7]) + vec)
 
         self.assertTrue(numpy.allclose(
             get_linear_qubit_operator(qubit_operator) * vec, matvec_expected))
@@ -224,12 +224,11 @@ class JordanWignerSparseTest(unittest.TestCase):
 
     def test_get_linear_qubit_operator_diagonal_cmp_zero(self):
         """Compare get_linear_qubit_operator_diagonal with
-            get_linear_qubit_operator.
-        """
+            get_linear_qubit_operator."""
         qubit_operator = QubitOperator('Z1 X2 Y5')
 
         vec = get_linear_qubit_operator_diagonal(qubit_operator)
-        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) * \
+        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) *
                                   numpy.eye(2 ** 6))
 
         self.assertTrue(numpy.allclose(
@@ -237,12 +236,11 @@ class JordanWignerSparseTest(unittest.TestCase):
 
     def test_get_linear_qubit_operator_diagonal_cmp_non_zero(self):
         """Compare get_linear_qubit_operator_diagonal with
-            get_linear_qubit_operator.
-        """
+            get_linear_qubit_operator."""
         qubit_operator = QubitOperator('Z1 Z2 Z5')
 
         vec = get_linear_qubit_operator_diagonal(qubit_operator)
-        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) * \
+        vec_expected = numpy.diag(get_linear_qubit_operator(qubit_operator) *
                                   numpy.eye(2 ** 6))
 
         self.assertTrue(numpy.allclose(


### PR DESCRIPTION
This's to get the diagonal elements for the matrix only, which is a critical input for Davidson algorithm.

See one reference at:
http://people.inf.ethz.ch/arbenz/ewp/Lnotes/chapter12.pdf