### PR TITLE
test installed module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include NOTICE
 include README.rst
 include requirements.txt
 include setup.py
+include examples/*.py examples/*.ipynb
 recursive-include src *.py *.hdf5 *.npy bad_type_operator.data geometry_example.txt
-

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include NOTICE
 include README.rst
 include requirements.txt
 include setup.py
+recursive-include src *.py *.hdf5 *.npy bad_type_operator.data geometry_example.txt
 
-recursive-include src *.py *.hdf5 *.npy

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,11 @@ setup(
     package_data={
         '': [os.path.join('src', 'openfermion', 'data', '*.hdf5'),
              os.path.join('src', 'openfermion', 'data', '*.npy')]
-    })
+    },
+    data_files=[('openfermion/examples', [
+                 'examples/binary_code_transforms_demo.ipynb',
+                 'examples/bosonic_operator_tutorial.ipynb',
+                 'examples/jordan_wigner_and_bravyi_kitaev_transforms.ipynb',
+                 'examples/openfermion_tutorial.ipynb',
+                 'examples/performance_benchmarks.py'])],
+    )

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,9 @@ setup(
     include_package_data=True,
     package_data={
         '': [os.path.join('src', 'openfermion', 'data', '*.hdf5'),
-             os.path.join('src', 'openfermion', 'data', '*.npy')]
+             os.path.join('src', 'openfermion', 'data', '*.data'),
+             os.path.join('src', 'openfermion', 'data', '*.txt'),
+             os.path.join('src', 'openfermion', 'data', '*.npy'),
+             os.path.join('src', 'openfermion', 'tests', '*.hdf5'),
+             os.path.join('src', 'openfermion', 'tests', '*.py')]
     })

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,5 @@ setup(
     include_package_data=True,
     package_data={
         '': [os.path.join('src', 'openfermion', 'data', '*.hdf5'),
-             os.path.join('src', 'openfermion', 'data', '*.data'),
-             os.path.join('src', 'openfermion', 'data', '*.txt'),
-             os.path.join('src', 'openfermion', 'data', '*.npy'),
-             os.path.join('src', 'openfermion', 'tests', '*.hdf5'),
-             os.path.join('src', 'openfermion', 'tests', '*.py')]
+             os.path.join('src', 'openfermion', 'data', '*.npy')]
     })

--- a/src/openfermion/tests/_example_test.py
+++ b/src/openfermion/tests/_example_test.py
@@ -18,11 +18,29 @@ import sys
 import tempfile
 import unittest
 
-import nbformat
 import numpy
+import pytest
 
 from openfermion.config import THIS_DIRECTORY
 
+
+def _module_import(plug):
+    import sys
+    if sys.version_info >= (3, 4):
+        from importlib import util
+        plug_spec = util.find_spec(plug)
+    else:
+        import pkgutil
+        plug_spec = pkgutil.find_loader(plug)
+    if plug_spec is None:
+        print('no', plug)
+        return False
+    else:
+        print('yes', plug)
+        return True
+
+using_nbconvert = pytest.mark.skipif(_module_import('nbconvert') is False,
+                                     reason='Not detecting module nbconvert. Install package if necessary and add to envvar PYTHONPATH')
 
 class ExampleTest(unittest.TestCase):
     """Unit tests for example scripts."""
@@ -34,8 +52,11 @@ class ExampleTest(unittest.TestCase):
         self.binary_code_transforms_demo = 'binary_code_transforms_demo.ipynb'
         self.jw_bk_demo = 'jordan_wigner_and_bravyi_kitaev_transforms.ipynb'
 
+    @using_nbconvert
     def test_demo(self):
         """Unit test for demo."""
+        import nbformat
+
         # Determine if python 2 or 3 is being used.
         major_version, minor_version = sys.version_info[:2]
         if major_version == 2 or minor_version == 6:
@@ -66,8 +87,11 @@ class ExampleTest(unittest.TestCase):
             errors = []
         self.assertEqual(errors, [])
 
+    @using_nbconvert
     def test_binary_code_transforms_demo(self):
         """Unit test for demo."""
+        import nbformat
+
         # Determine if python 2 or 3 is being used.
         major_version, minor_version = sys.version_info[:2]
         if major_version == 2 or minor_version == 6:
@@ -98,8 +122,11 @@ class ExampleTest(unittest.TestCase):
             errors = []
         self.assertEqual(errors, [])
 
+    @using_nbconvert
     def test_jordan_wigner_and_bravyi_kitaev_transforms_demo(self):
         """Unit test for demo."""
+        import nbformat
+
         # Determine if python 2 or 3 is being used.
         major_version, minor_version = sys.version_info[:2]
         if major_version == 2 or minor_version == 6:

--- a/src/openfermion/tests/_example_test.py
+++ b/src/openfermion/tests/_example_test.py
@@ -33,14 +33,14 @@ def _module_import(plug):
         import pkgutil
         plug_spec = pkgutil.find_loader(plug)
     if plug_spec is None:
-        print('no', plug)
         return False
     else:
-        print('yes', plug)
         return True
 
-using_nbconvert = pytest.mark.skipif(_module_import('nbconvert') is False,
-                                     reason='Not detecting module nbconvert. Install package if necessary and add to envvar PYTHONPATH')
+using_nbtools = pytest.mark.skipif(not (_module_import('nbconvert') and _module_import('ipykernel')),
+                                reason='Not detecting module nbconvert. Install package if necessary and add to envvar PYTHONPATH')
+using_matplotlib = pytest.mark.skipif(_module_import('matplotlib') is False,
+                                reason='Note detecting module matplotlib. Install package if necessary and add to envvar PYTHONPATH')
 
 class ExampleTest(unittest.TestCase):
     """Unit tests for example scripts."""
@@ -58,7 +58,8 @@ class ExampleTest(unittest.TestCase):
         self.binary_code_transforms_demo = 'binary_code_transforms_demo.ipynb'
         self.jw_bk_demo = 'jordan_wigner_and_bravyi_kitaev_transforms.ipynb'
 
-    @using_nbconvert
+    @using_matplotlib
+    @using_nbtools
     def test_demo(self):
         """Unit test for demo."""
         import nbformat
@@ -93,7 +94,7 @@ class ExampleTest(unittest.TestCase):
             errors = []
         self.assertEqual(errors, [])
 
-    @using_nbconvert
+    @using_nbtools
     def test_binary_code_transforms_demo(self):
         """Unit test for demo."""
         import nbformat
@@ -128,7 +129,7 @@ class ExampleTest(unittest.TestCase):
             errors = []
         self.assertEqual(errors, [])
 
-    @using_nbconvert
+    @using_nbtools
     def test_jordan_wigner_and_bravyi_kitaev_transforms_demo(self):
         """Unit test for demo."""
         import nbformat

--- a/src/openfermion/tests/_example_test.py
+++ b/src/openfermion/tests/_example_test.py
@@ -22,25 +22,15 @@ import numpy
 import pytest
 
 from openfermion.config import THIS_DIRECTORY
+from openfermion.utils import *
 
 
-def _module_import(plug):
-    import sys
-    if sys.version_info >= (3, 4):
-        from importlib import util
-        plug_spec = util.find_spec(plug)
-    else:
-        import pkgutil
-        plug_spec = pkgutil.find_loader(plug)
-    if plug_spec is None:
-        return False
-    else:
-        return True
+using_nbtools = pytest.mark.skipif(not (module_importable('nbconvert') and
+                                   module_importable('ipykernel')),
+                                   reason='Not detecting `nbconvert`.')
+using_matplotlib = pytest.mark.skipif(module_importable('matplotlib') is False,
+                                      reason='Not detecting `matplotlib`.')
 
-using_nbtools = pytest.mark.skipif(not (_module_import('nbconvert') and _module_import('ipykernel')),
-                                reason='Not detecting module nbconvert. Install package if necessary and add to envvar PYTHONPATH')
-using_matplotlib = pytest.mark.skipif(_module_import('matplotlib') is False,
-                                reason='Note detecting module matplotlib. Install package if necessary and add to envvar PYTHONPATH')
 
 class ExampleTest(unittest.TestCase):
     """Unit tests for example scripts."""

--- a/src/openfermion/tests/_example_test.py
+++ b/src/openfermion/tests/_example_test.py
@@ -47,7 +47,13 @@ class ExampleTest(unittest.TestCase):
 
     def setUp(self):
         string_length = len(THIS_DIRECTORY)
-        self.directory = THIS_DIRECTORY[:(string_length - 15)] + 'examples/'
+        examples = THIS_DIRECTORY[:(string_length - 15)] + 'examples/'
+        if os.path.isdir(examples):
+            # source
+            self.directory = examples
+        else:
+            # installed
+            self.directory = THIS_DIRECTORY + '/examples/'
         self.demo_name = 'openfermion_tutorial.ipynb'
         self.binary_code_transforms_demo = 'binary_code_transforms_demo.ipynb'
         self.jw_bk_demo = 'jordan_wigner_and_bravyi_kitaev_transforms.ipynb'

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -57,7 +57,8 @@ from ._testing_utils import (random_antisymmetric_matrix,
                              random_hermitian_matrix,
                              random_interaction_operator,
                              random_quadratic_hamiltonian,
-                             random_unitary_matrix)
+                             random_unitary_matrix,
+                             module_importable)
 
 from ._trotter_error import error_bound, error_operator
 

--- a/src/openfermion/utils/_pubchem.py
+++ b/src/openfermion/utils/_pubchem.py
@@ -10,8 +10,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pubchempy
-
 
 def geometry_from_pubchem(name):
     """Function to extract geometry using the molecule's name from the PubChem
@@ -25,6 +23,7 @@ def geometry_from_pubchem(name):
         geometry: a list of tuples giving the coordinates of each atom with
         distances in Angstrom.
     """
+    import pubchempy
 
     pubchempy_2d_molecule = pubchempy.get_compounds(name, 'name',
                                                     record_type='2d')

--- a/src/openfermion/utils/_pubchem_test.py
+++ b/src/openfermion/utils/_pubchem_test.py
@@ -14,29 +14,16 @@
 from __future__ import absolute_import
 
 import numpy
+import pytest
 import unittest
 
-from openfermion.utils import geometry_from_pubchem
+from openfermion.utils import (geometry_from_pubchem,
+                               module_importable)
 
 
-import pytest
+using_pubchempy = pytest.mark.skipif(module_importable('pubchempy') is False,
+                                     reason='Not detecting `pubchempy`.')
 
-def _module_import(plug):
-    import sys
-    if sys.version_info >= (3, 4):
-        from importlib import util
-        plug_spec = util.find_spec(plug)
-    else:
-        import pkgutil
-        plug_spec = pkgutil.find_loader(plug)
-    if plug_spec is None:
-        return False
-    else:
-        return True
-
-
-using_pubchempy = pytest.mark.skipif(_module_import('pubchempy') is False,
-                                     reason='Not detecting module pubchempy. Install package if necessary and add to envvar PYTHONPATH')
 
 @using_pubchempy
 class OpenFermionPubChemTest(unittest.TestCase):

--- a/src/openfermion/utils/_pubchem_test.py
+++ b/src/openfermion/utils/_pubchem_test.py
@@ -19,6 +19,28 @@ import unittest
 from openfermion.utils import geometry_from_pubchem
 
 
+import pytest
+
+def _module_import(plug):
+    import sys
+    if sys.version_info >= (3, 4):
+        from importlib import util
+        plug_spec = util.find_spec(plug)
+    else:
+        import pkgutil
+        plug_spec = pkgutil.find_loader(plug)
+    if plug_spec is None:
+        print('no', plug)
+        return False
+    else:
+        print('yes', plug)
+        return True
+
+
+using_pubchempy = pytest.mark.skipif(_module_import('pubchempy') is False,
+                                     reason='Not detecting module pubchempy. Install package if necessary and add to envvar PYTHONPATH')
+
+@using_pubchempy
 class OpenFermionPubChemTest(unittest.TestCase):
 
     def test_water(self):

--- a/src/openfermion/utils/_pubchem_test.py
+++ b/src/openfermion/utils/_pubchem_test.py
@@ -30,10 +30,8 @@ def _module_import(plug):
         import pkgutil
         plug_spec = pkgutil.find_loader(plug)
     if plug_spec is None:
-        print('no', plug)
         return False
     else:
-        print('yes', plug)
         return True
 
 

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -246,3 +246,26 @@ class _ClassUnknownToSubjects(object):
 
     def __hash__(self):
         return hash(_ClassUnknownToSubjects)
+
+
+def module_importable(module):
+    """Without importing it, returns whether python module is importable.
+
+    Args:
+        module (string): Name of module.
+
+    Returns:
+        bool
+
+    """
+    import sys
+    if sys.version_info >= (3, 4):
+        from importlib import util
+        plug_spec = util.find_spec(module)
+    else:
+        import pkgutil
+        plug_spec = pkgutil.find_loader(module)
+    if plug_spec is None:
+        return False
+    else:
+        return True


### PR DESCRIPTION
### in this PR
- [ ] installs a few more files so that one can run pytest on an installation
- [ ] allows some of the heavier (i.e., jupyter, matplotlib) and noncore (i.e., pubchempy) dependencies to be optional by moving the imports and adding proper pytest skipping
- [ ] tested on py27, 35, 36
- [ ] fyi, the setup.py/MANIFEST.in handling of `examples/` works just fine for `python setup.py install` (that is, places the examples dir w/i the module). however, if you `python setup.py install --single-version-externally-managed`, that will place the examples dir into `PREFIX/openfermion/`.

### Q
- [ ] there's some repeated code (`_module_import()`). if you decide you like this PR, could you suggest a good shared access place for it?
- [ ] despite making some dependencies optional, I didn't interfere with `requirements.txt`, as I can control them independently through conda. but if you like this change, should be tweaked.

### longer term Q
- [ ] I tested this by conda packaging it (`conda install -c psi4/label/agg openfermion`, https://anaconda.org/psi4/openfermion/files, https://github.com/psi4/psi4meta/tree/master/conda-recipes/openfermion). Do you want that? If so, from your own channel, conda-forge (a community packaging channel), or psi4?
- [ ] If so (above) and if this PR gets pulled in, should master be packaged or this PR cherry-picked onto v0.6?
- [ ] The whole purpose of this exercise is to test openfermionpsi4 for the upcoming Psi4 1.2 release. What I'm finding for the psi plugin (https://github.com/quantumlib/OpenFermion-Psi4/tree/master/examples) are more in the nature of examples than tests. Are there tests out there?