### PR TITLE
Add page in docs for collecting projects and papers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ You might also want to explore the alpha release of the
 `OpenFermion Cloud Library <https://github.com/quantumlib/OpenFermion/tree/master/cloud_library>`__
 where users can share and download precomputed molecular benchmark files.
 
-Check out other `projects and papers using OpenFermion <docs/other_projects.md>`__ for inspiration, and let us know if you've
-been using OpenFermion!
+Check out other `projects and papers using OpenFermion <docs/other_projects.md>`__ for inspiration,
+and let us know if you've been using OpenFermion!
 
 Developer install
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,8 @@ You might also want to explore the alpha release of the
 `OpenFermion Cloud Library <https://github.com/quantumlib/OpenFermion/tree/master/cloud_library>`__
 where users can share and download precomputed molecular benchmark files.
 
+Check out other `projects and papers using OpenFermion <docs/other_projects.md>`__ for inspiration, and let us know if you've
+been using OpenFermion!
 
 Developer install
 -----------------

--- a/docs/other_projects.md
+++ b/docs/other_projects.md
@@ -1,0 +1,64 @@
+## Projects and Papers using OpenFermion
+In this document we assemble known projects and papers that use OpenFermion to
+both provide example use cases and document the ways its helping to impact
+electronic structure on quantum computers.  If you'd like to include your own
+projects or papers, please contact us or submit a pull request updating this page.
+
+### Projects
+[Hackathon Quantum Autoencoder](https://github.com/hsim13372/QCompress)
+
+The winning project of the Rigetti quantum computing hackathon that combined
+OpenFermion with Rigetti's framework, compressing molecular representations
+with an autoencoder.
+
+### Papers
+
+***Low Depth Quantum Simulation of Electronic Structure.*** Ryan Babbush, Nathan Wiebe, 
+Jarrod McClean, James McClain, Hartmut Neven and Garnet Chan. 
+[arXiv:1706.00023](https://arxiv.org/abs/1706.00023) 2017.
+
+***Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians.***
+Dominic Berry, Mária Kieferová, Artur Scherer, Yuval Sanders, 
+Guang Hao Low, Nathan Wiebe, Craig Gidney and Ryan Babbush. 
+[arXiv:1711.10460](https://arxiv.org/abs/1711.10460). 2017.
+
+***Bravyi-Kitaev Superfast simulation of fermions on a quantum computer.***
+Kanav Setia, James D. Whitfield. 
+[arXiv:1712.00446v1](https://arxiv.org/abs/1712.00446). 2017
+
+***Quantum algorithms to simulate many-body physics of correlated fermions.***
+Zhang Jiang, Kevin J. Sung, Kostyantyn Kechedzhi, Vadim N. Smelyanskiy, and Sergio Boixo. 
+[arXiv:1711.05395](https://arxiv.org/abs/1711.05395). 2017.
+
+***Quantum simulation of electronic structure with linear depth and connectivity.*** 
+Ian D. Kivlichan, Jarrod McClean, Nathan Wiebe, Craig Gidney, 
+Alán Aspuru-Guzik, Garnet Kin-Lic Chan, Ryan Babbush. 
+[arXiv:1711.04789](https://arxiv.org/abs/1711.04789) 2017.
+
+***Application of fermionic marginal constraints to hybrid quantum algorithms***
+Nicholas C. Rubin, Ryan Babbush, Jarrod McClean. 
+[arXiv:1801.03524](https://arxiv.org/abs/1801.03524) 2018.
+
+***Strawberry Fields: A Software Platform for Photonic Quantum Computing***
+Nathan Killoran, Josh Izaac, Nicolás Quesada, Ville Bergholm, Matthew Amy, and
+Christian Weedbrook
+[arXiv:1804.03159](https://arxiv.org/abs/1804.03159) 2018.
+
+***Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity***
+Ryan Babbush, Craig Gidney, Dominic W. Berry, Nathan Wiebe, Jarrod McClean, 
+Alexandru Paler, Austin Fowler, Hartmut Neven
+[arXiv:1805.03662](https://arxiv.org/abs/1805.03662) 2018.
+
+***A Universal Quantum Computing Virtual Machine***
+Qian-Tan Hong, Zi-Yong Ge, Wen Wang, Hai-Feng Lang, Zheng-An Wang, Yi Peng, 
+Jin-Jun Chen, Li-Hang Ren, Yu Zeng, Liang-Zhu Mu, Heng Fan
+[arXiv:1806.06511](https://arxiv.org/abs/1806.06511) 2018.
+
+***Accounting for Errors in Quantum Algorithms via Individual Error Reduction***
+Matthew Otten, Stephen Gray
+[arXiv:1804.06969](https://arxiv.org/abs/1804.06969) 2018.
+
+***Cloud Quantum Computing of an Atomic Nucleus***
+E. F. Dumitrescu, A. J. McCaskey, G. Hagen, G. R. Jansen, T. D. Morris, 
+T. Papenbrock, R. C. Pooser, D. J. Dean, and P. Lougovski
+[arXiv:1801.03897](https://arxiv.org/abs/1801.03897) 2018.


### PR DESCRIPTION
Adds a page to collect project and papers using OpenFermion that hopefully both inspire new projects and let people advertise their own work using OpenFermion there.  I left all the links as ArXiv so that people don't need journal descriptions to see the papers.