### PR TITLE
fix RNG seeding in testing functions

### DIFF
--- a/src/openfermion/utils/_low_rank_test.py
+++ b/src/openfermion/utils/_low_rank_test.py
@@ -34,7 +34,8 @@ class ChemistTwoBodyTest(unittest.TestCase):
 
         # Initialize a random InteractionOperator and FermionOperator.
         n_qubits = 4
-        random_interaction = random_interaction_operator(n_qubits, real=False)
+        random_interaction = random_interaction_operator(
+                n_qubits, real=False, seed=34281)
         random_fermion = get_fermion_operator(random_interaction)
 
         # Convert to chemist ordered tensor.
@@ -78,7 +79,7 @@ class ChemistTwoBodyTest(unittest.TestCase):
 
         # Initialize a bad FermionOperator.
         n_qubits = 4
-        random_interaction = random_interaction_operator(n_qubits)
+        random_interaction = random_interaction_operator(n_qubits, seed=36229)
         random_fermion = get_fermion_operator(random_interaction)
         bad_term = ((1, 1), (2, 1))
         random_fermion += FermionOperator(bad_term)
@@ -96,7 +97,7 @@ class LowRankTest(unittest.TestCase):
         # Initialize a random two-body FermionOperator.
         n_qubits = 4
         random_operator = get_fermion_operator(
-            random_interaction_operator(n_qubits))
+            random_interaction_operator(n_qubits, seed=28644))
 
         # Convert to chemist tensor.
         constant, one_body_coefficients, chemist_tensor = (
@@ -233,7 +234,7 @@ class LowRankTest(unittest.TestCase):
         # Initialize a random two-body FermionOperator.
         n_qubits = 4
         random_operator = get_fermion_operator(
-            random_interaction_operator(n_qubits))
+            random_interaction_operator(n_qubits, seed=17004))
 
         # Convert to chemist tensor.
         constant, one_body_coefficients, chemist_tensor = (

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -25,7 +25,9 @@ from openfermion.ops import (DiagonalCoulombHamiltonian,
 
 def random_antisymmetric_matrix(n, real=False, seed=None):
     """Generate a random n x n antisymmetric matrix."""
-    numpy.random.seed(seed)
+    if seed is not None:
+        numpy.random.seed(seed)
+
     if real:
         rand_mat = numpy.random.randn(n, n)
     else:
@@ -41,17 +43,20 @@ def random_diagonal_coulomb_hamiltonian(n_qubits, real=False, seed=None):
         n_qubits: The number of qubits
         real: Whether to use only real numbers in the one-body term
     """
-    numpy.random.seed(seed)
-    seed1, seed2 = numpy.random.randint(4294967296, size=2)
-    one_body = random_hermitian_matrix(n_qubits, real=real, seed=seed1)
-    two_body = random_hermitian_matrix(n_qubits, real=True, seed=seed2)
+    if seed is not None:
+        numpy.random.seed(seed)
+
+    one_body = random_hermitian_matrix(n_qubits, real=real)
+    two_body = random_hermitian_matrix(n_qubits, real=True)
     constant = numpy.random.randn()
     return DiagonalCoulombHamiltonian(one_body, two_body, constant)
 
 
 def random_hermitian_matrix(n, real=False, seed=None):
     """Generate a random n x n Hermitian matrix."""
-    numpy.random.seed(seed)
+    if seed is not None:
+        numpy.random.seed(seed)
+
     if real:
         rand_mat = numpy.random.randn(n, n)
     else:
@@ -62,7 +67,9 @@ def random_hermitian_matrix(n, real=False, seed=None):
 
 def random_interaction_operator(n_qubits, real=True, seed=None):
     """Generate a random instance of InteractionOperator."""
-    numpy.random.seed(seed)
+    if seed is not None:
+        numpy.random.seed(seed)
+
     if real:
         dtype = float
     else:
@@ -72,8 +79,7 @@ def random_interaction_operator(n_qubits, real=True, seed=None):
     constant = numpy.random.randn()
 
     # The one-body tensor is a random Hermitian matrix.
-    seed1 = numpy.random.randint(4294967296)
-    one_body_coefficients = random_hermitian_matrix(n_qubits, real, seed=seed1)
+    one_body_coefficients = random_hermitian_matrix(n_qubits, real)
 
     # Generate random two-body coefficients.
     two_body_coefficients = numpy.zeros((n_qubits, n_qubits,
@@ -123,23 +129,25 @@ def random_quadratic_hamiltonian(n_qubits,
     Returns:
         QuadraticHamiltonian
     """
-    numpy.random.seed(seed)
+    if seed is not None:
+        numpy.random.seed(seed)
+
     constant = numpy.random.randn()
     chemical_potential = numpy.random.randn()
-    seed1, seed2 = numpy.random.randint(4294967296, size=2)
-    hermitian_mat = random_hermitian_matrix(n_qubits, real, seed=seed1)
+    hermitian_mat = random_hermitian_matrix(n_qubits, real)
     if conserves_particle_number:
         antisymmetric_mat = None
     else:
-        antisymmetric_mat = random_antisymmetric_matrix(n_qubits, real,
-                                                        seed=seed2)
+        antisymmetric_mat = random_antisymmetric_matrix(n_qubits, real)
     return QuadraticHamiltonian(hermitian_mat, antisymmetric_mat,
                                 constant, chemical_potential)
 
 
 def random_unitary_matrix(n, real=False, seed=None):
     """Obtain a random n x n unitary matrix."""
-    numpy.random.seed(seed)
+    if seed is not None:
+        numpy.random.seed(seed)
+
     if real:
         rand_mat = numpy.random.randn(n, n)
     else:

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -23,7 +23,7 @@ from openfermion.ops import (DiagonalCoulombHamiltonian,
                              QuadraticHamiltonian)
 
 
-def random_antisymmetric_matrix(n, real=False, seed=0):
+def random_antisymmetric_matrix(n, real=False, seed=None):
     """Generate a random n x n antisymmetric matrix."""
     numpy.random.seed(seed)
     if real:
@@ -34,7 +34,7 @@ def random_antisymmetric_matrix(n, real=False, seed=0):
     return antisymmetric_mat
 
 
-def random_diagonal_coulomb_hamiltonian(n_qubits, real=False, seed=0):
+def random_diagonal_coulomb_hamiltonian(n_qubits, real=False, seed=None):
     """Generate a random instance of DiagonalCoulombHamiltonian.
 
     Args:
@@ -48,7 +48,7 @@ def random_diagonal_coulomb_hamiltonian(n_qubits, real=False, seed=0):
     return DiagonalCoulombHamiltonian(one_body, two_body, constant)
 
 
-def random_hermitian_matrix(n, real=False, seed=0):
+def random_hermitian_matrix(n, real=False, seed=None):
     """Generate a random n x n Hermitian matrix."""
     numpy.random.seed(seed)
     if real:
@@ -59,7 +59,7 @@ def random_hermitian_matrix(n, real=False, seed=0):
     return hermitian_mat
 
 
-def random_interaction_operator(n_qubits, real=True, seed=0):
+def random_interaction_operator(n_qubits, real=True, seed=None):
     """Generate a random instance of InteractionOperator."""
     numpy.random.seed(seed)
     if real:
@@ -71,7 +71,7 @@ def random_interaction_operator(n_qubits, real=True, seed=0):
     constant = numpy.random.randn()
 
     # The one-body tensor is a random Hermitian matrix.
-    one_body_coefficients = random_hermitian_matrix(n_qubits, real)
+    one_body_coefficients = random_hermitian_matrix(n_qubits, real, seed=seed)
 
     # Generate random two-body coefficients.
     two_body_coefficients = numpy.zeros((n_qubits, n_qubits,
@@ -85,7 +85,6 @@ def random_interaction_operator(n_qubits, real=True, seed=0):
         two_body_coefficients[q, p, q, p] = coeff
 
     # Generate the rest of the terms.
-    #for p, q, r, s in itertools.combinations(range(n_qubits), 4):
     for (p, q), (r, s) in itertools.combinations(
             itertools.combinations(range(n_qubits), 2), 2):
         coeff = numpy.random.randn()
@@ -110,7 +109,7 @@ def random_interaction_operator(n_qubits, real=True, seed=0):
 
 def random_quadratic_hamiltonian(n_qubits,
                                  conserves_particle_number=False,
-                                 real=False, seed=0):
+                                 real=False, seed=None):
     """Generate a random instance of QuadraticHamiltonian.
 
     Args:
@@ -134,7 +133,7 @@ def random_quadratic_hamiltonian(n_qubits,
                                 constant, chemical_potential)
 
 
-def random_unitary_matrix(n, real=False, seed=0):
+def random_unitary_matrix(n, real=False, seed=None):
     """Obtain a random n x n unitary matrix."""
     numpy.random.seed(seed)
     if real:

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -117,7 +117,8 @@ def random_interaction_operator(n_qubits, real=True, seed=None):
 
 def random_quadratic_hamiltonian(n_qubits,
                                  conserves_particle_number=False,
-                                 real=False, seed=None):
+                                 real=False,
+                                 seed=None):
     """Generate a random instance of QuadraticHamiltonian.
 
     Args:

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -42,8 +42,9 @@ def random_diagonal_coulomb_hamiltonian(n_qubits, real=False, seed=None):
         real: Whether to use only real numbers in the one-body term
     """
     numpy.random.seed(seed)
-    one_body = random_hermitian_matrix(n_qubits, real=real)
-    two_body = random_hermitian_matrix(n_qubits, real=True)
+    seed1, seed2 = numpy.random.randint(4294967296, size=2)
+    one_body = random_hermitian_matrix(n_qubits, real=real, seed=seed1)
+    two_body = random_hermitian_matrix(n_qubits, real=True, seed=seed2)
     constant = numpy.random.randn()
     return DiagonalCoulombHamiltonian(one_body, two_body, constant)
 
@@ -71,7 +72,8 @@ def random_interaction_operator(n_qubits, real=True, seed=None):
     constant = numpy.random.randn()
 
     # The one-body tensor is a random Hermitian matrix.
-    one_body_coefficients = random_hermitian_matrix(n_qubits, real, seed=seed)
+    seed1 = numpy.random.randint(4294967296)
+    one_body_coefficients = random_hermitian_matrix(n_qubits, real, seed=seed1)
 
     # Generate random two-body coefficients.
     two_body_coefficients = numpy.zeros((n_qubits, n_qubits,
@@ -124,11 +126,13 @@ def random_quadratic_hamiltonian(n_qubits,
     numpy.random.seed(seed)
     constant = numpy.random.randn()
     chemical_potential = numpy.random.randn()
-    hermitian_mat = random_hermitian_matrix(n_qubits, real)
+    seed1, seed2 = numpy.random.randint(4294967296, size=2)
+    hermitian_mat = random_hermitian_matrix(n_qubits, real, seed=seed1)
     if conserves_particle_number:
         antisymmetric_mat = None
     else:
-        antisymmetric_mat = random_antisymmetric_matrix(n_qubits, real)
+        antisymmetric_mat = random_antisymmetric_matrix(n_qubits, real,
+                                                        seed=seed2)
     return QuadraticHamiltonian(hermitian_mat, antisymmetric_mat,
                                 constant, chemical_potential)
 

--- a/src/openfermion/utils/_testing_utils_test.py
+++ b/src/openfermion/utils/_testing_utils_test.py
@@ -13,10 +13,16 @@
 import fractions
 import unittest
 
+import numpy
+
 from openfermion.transforms import get_fermion_operator
 from openfermion.utils import is_hermitian
-from openfermion.utils._testing_utils import (EqualsTester,
-                                              random_interaction_operator)
+from openfermion.utils._testing_utils import (
+        EqualsTester,
+        random_diagonal_coulomb_hamiltonian,
+        random_interaction_operator,
+        random_quadratic_hamiltonian,
+        random_interaction_operator)
 
 
 class EqualsTesterTest(unittest.TestCase):
@@ -215,3 +221,24 @@ class RandomInteractionOperatorTest(unittest.TestCase):
         iop = random_interaction_operator(n_qubits, False)
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
+
+
+class RandomSeedingTest(unittest.TestCase):
+
+    def test_random_operators_are_reproducible(self):
+        op1 = random_diagonal_coulomb_hamiltonian(5, seed=5947)
+        op2 = random_diagonal_coulomb_hamiltonian(5, seed=5947)
+        numpy.testing.assert_allclose(op1.one_body, op2.one_body)
+        numpy.testing.assert_allclose(op1.two_body, op2.two_body)
+
+        op1 = random_interaction_operator(5, seed=8911)
+        op2 = random_interaction_operator(5, seed=8911)
+        numpy.testing.assert_allclose(op1.one_body_tensor, op2.one_body_tensor)
+        numpy.testing.assert_allclose(op1.two_body_tensor, op2.two_body_tensor)
+
+        op1 = random_quadratic_hamiltonian(5, seed=17711)
+        op2 = random_quadratic_hamiltonian(5, seed=17711)
+        numpy.testing.assert_allclose(op1.combined_hermitian_part,
+                                      op2.combined_hermitian_part)
+        numpy.testing.assert_allclose(op1.antisymmetric_part,
+                                      op2.antisymmetric_part)

--- a/src/openfermion/utils/_testing_utils_test.py
+++ b/src/openfermion/utils/_testing_utils_test.py
@@ -19,10 +19,12 @@ from openfermion.transforms import get_fermion_operator
 from openfermion.utils import is_hermitian
 from openfermion.utils._testing_utils import (
         EqualsTester,
+        random_antisymmetric_matrix,
         random_diagonal_coulomb_hamiltonian,
+        random_hermitian_matrix,
         random_interaction_operator,
         random_quadratic_hamiltonian,
-        random_interaction_operator)
+        random_unitary_matrix)
 
 
 class EqualsTesterTest(unittest.TestCase):
@@ -242,3 +244,15 @@ class RandomSeedingTest(unittest.TestCase):
                                       op2.combined_hermitian_part)
         numpy.testing.assert_allclose(op1.antisymmetric_part,
                                       op2.antisymmetric_part)
+
+        op1 = random_antisymmetric_matrix(5, seed=24074)
+        op2 = random_antisymmetric_matrix(5, seed=24074)
+        numpy.testing.assert_allclose(op1, op2)
+
+        op1 = random_hermitian_matrix(5, seed=56753)
+        op2 = random_hermitian_matrix(5, seed=56753)
+        numpy.testing.assert_allclose(op1, op2)
+
+        op1 = random_unitary_matrix(5, seed=56486)
+        op2 = random_unitary_matrix(5, seed=56486)
+        numpy.testing.assert_allclose(op1, op2)


### PR DESCRIPTION
Calling a function like `random_interaction_operator(5)` twice in a row should not return the same object. Tests should explicitly set the seeds, preferably to random-ish values.

Also fixes an issue where `random_interaction_operator` always uses the same one-body tensor and other related issues.