### PR TITLE
Spatial low rank

### DIFF
--- a/src/openfermion/hamiltonians/_molecular_data.py
+++ b/src/openfermion/hamiltonians/_molecular_data.py
@@ -868,22 +868,20 @@ class MolecularData(object):
                         
                         # Require p,s and q,r to have same spin. Handle mixed
                         # spins.
-                        two_body_coefficients[2 * p, 2 * q + 1, 2 * r + 1,
-                                              2 * s] = (
+                        two_body_coefficients[2 * p, 2 * q + 1,
+                                              2 * r + 1, 2 * s] = (
                                 two_body_integrals[p, q, r, s] / 2.)
-                        two_body_coefficients[2 * p + 1, 2 * q, 2 * r,
-                                              2 * s + 1] = (
+                        two_body_coefficients[2 * p + 1, 2 * q,
+                                              2 * r, 2 * s + 1] = (
                                 two_body_integrals[p, q, r, s] / 2.)
 
-                        # Avoid having two electrons in same orbital. Handle
-                        # same spins.
-                        if p != q and r != s:
-                            two_body_coefficients[2 * p, 2 * q, 2 * r,
-                                                  2 * s] = (
-                                    two_body_integrals[p, q, r, s] / 2.)
-                            two_body_coefficients[2 * p + 1, 2 * q + 1,
-                                                  2 * r + 1, 2 * s + 1] = (
-                                    two_body_integrals[p, q, r, s] / 2.)
+
+                        two_body_coefficients[2 * p, 2 * q,
+                                              2 * r, 2 * s] = (
+                                two_body_integrals[p, q, r, s] / 2.)
+                        two_body_coefficients[2 * p + 1, 2 * q + 1,
+                                              2 * r + 1, 2 * s + 1] = (
+                            two_body_integrals[p, q, r, s] / 2.)
 
         # Truncate.
         one_body_coefficients[

--- a/src/openfermion/hamiltonians/_molecular_data.py
+++ b/src/openfermion/hamiltonians/_molecular_data.py
@@ -865,20 +865,19 @@ class MolecularData(object):
                 # Continue looping to prepare 2-body coefficients.
                 for r in range(n_qubits // 2):
                     for s in range(n_qubits // 2):
-                        
-                        # Require p,s and q,r to have same spin. Handle mixed
-                        # spins.
+
+                        # Mixed spin
                         two_body_coefficients[2 * p, 2 * q + 1,
                                               2 * r + 1, 2 * s] = (
-                                two_body_integrals[p, q, r, s] / 2.)
+                            two_body_integrals[p, q, r, s] / 2.)
                         two_body_coefficients[2 * p + 1, 2 * q,
                                               2 * r, 2 * s + 1] = (
-                                two_body_integrals[p, q, r, s] / 2.)
+                            two_body_integrals[p, q, r, s] / 2.)
 
-
+                        # Same spin
                         two_body_coefficients[2 * p, 2 * q,
                                               2 * r, 2 * s] = (
-                                two_body_integrals[p, q, r, s] / 2.)
+                            two_body_integrals[p, q, r, s] / 2.)
                         two_body_coefficients[2 * p + 1, 2 * q + 1,
                                               2 * r + 1, 2 * s + 1] = (
                             two_body_integrals[p, q, r, s] / 2.)

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -78,6 +78,7 @@ from ._jellium_hf_state import hartree_fock_state_jellium
 
 from ._low_rank import (get_chemist_two_body_coefficients,
                         low_rank_two_body_decomposition,
+                        low_rank_spatial_two_body_decomposition,
                         prepare_one_body_squared_evolution)
 
 from ._low_depth_trotter_error import (

--- a/src/openfermion/utils/_low_rank.py
+++ b/src/openfermion/utils/_low_rank.py
@@ -268,7 +268,7 @@ def low_rank_spatial_two_body_decomposition(two_body_coefficients,
     if asymmetry > EQ_TOLERANCE or imaginary_norm > EQ_TOLERANCE:
         raise TypeError('Invalid two-body coefficient tensor specification.')
 
-    # Decompose, first attempt Cholesky with small positive shift
+    # Decompose using LDL decomposition, closely related to Choleksy
     cholesky_vecs, cholesky_diag, _ = scipy.linalg.ldl(interaction_array)
     cholesky_diag = numpy.diag(cholesky_diag)
 

--- a/src/openfermion/utils/_low_rank.py
+++ b/src/openfermion/utils/_low_rank.py
@@ -15,6 +15,7 @@
 import itertools
 import numpy
 import numpy.linalg
+import scipy.linalg
 
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import FermionOperator, InteractionOperator
@@ -192,6 +193,103 @@ def low_rank_two_body_decomposition(chemist_two_body_coefficients,
     return (eigenvalues[:max_rank],
             one_body_squares[:max_rank],
             truncation_value)
+
+
+def low_rank_spatial_two_body_decomposition(chemist_two_body_coefficients,
+                                            truncation_threshold=None,
+                                            final_rank=None):
+    """Convert spatial two-body operator into sum of squared one-body spin ops.
+
+    This function decomposes
+    :math:`\sum_{pqrs} h_{pqrs} a^\dagger_p a_q a^\dagger_r a_s`
+    as :math:`\sum_{l} \lambda_l (\sum_{pq} g_{lpq} a^\dagger_p a_q)^2`
+    l is truncated to take max value L so that
+    :math:`\sum_{l=0}^{L-1} (\sum_{pq} |g_{lpq}|)^2 |\lambda_l| < x`
+
+    Args:
+        chemist_two_body_coefficients (ndarray): an N x N x N x N
+            numpy array giving the :math:`h_{pqrs}` tensor in chemist notation
+            at the level of spatial orbitals
+        truncation_threshold (optional Float): the value of x in the expression
+            above. If None, then L = N ** 2 and no truncation will occur.
+        final_rank (optional int): if provided, this specifies the value of
+            L at which to truncate.
+
+    Returns:
+        cholesky_diag (ndarray of floats): length L array
+            giving the :math:`\lambda_l`.
+        one_body_squares (ndarray of floats): L x N x N array of floats
+            corresponding to the value of :math:`g_{pql}`.
+        truncation_value (optional float): after truncation, this is the value
+            :math:`\sum_{l=0}^{L-1} (\sum_{pq} |g_{lpq}|)^2 |\lambda_l| < x`
+
+    Raises:
+        TypeError: Invalid two-body coefficient tensor specification.
+        ValueError: Cannot provide both final_rank and truncation_value.
+    """
+    # Initialize N^2 by N^2 interaction array.
+    n_orbitals = chemist_two_body_coefficients.shape[0]
+    full_rank = n_orbitals ** 2
+    interaction_array = numpy.reshape(chemist_two_body_coefficients,
+                                      (full_rank, full_rank))
+
+    # Make sure interaction array is symmetric and real.
+    asymmetry = numpy.sum(numpy.absolute(
+        interaction_array - interaction_array.transpose()))
+    imaginary_norm = numpy.sum(numpy.absolute(interaction_array.imag))
+    if asymmetry > EQ_TOLERANCE or imaginary_norm > EQ_TOLERANCE:
+        raise TypeError('Invalid two-body coefficient tensor specification.')
+
+    # Diagonalize.
+    try:
+        cholesky_vecs, cholesky_diag = scipy.linalg.ldl(interaction_array)
+    except:
+        print("Non-positive interaction matrix, attempting eigendecomp")
+        cholesky_diag, cholesky_vecs = scipy.linalg.eigh(interaction_array)
+
+    # Get one-body squares and compute weights.
+    term_weights = numpy.zeros(full_rank)
+    one_body_squares = numpy.zeros((full_rank,
+                                    2 * n_orbitals, 2 * n_orbitals), complex)
+    for l in range(full_rank):
+        # Reshape and add spin back in
+        one_body_squares[l] = numpy.kron(
+            numpy.reshape(cholesky_vecs[:, l],
+                          (n_orbitals, n_orbitals)),
+            numpy.eye(2))
+
+        term_weights[l] = abs(cholesky_diag[l]) * numpy.sum(
+            numpy.absolute(one_body_squares[l])) ** 2
+
+    # Sort by weight.
+    indices = numpy.argsort(term_weights)[::-1]
+    cholesky_diag = cholesky_diag[indices]
+    term_weights = term_weights[indices]
+    one_body_squares = one_body_squares[indices]
+
+    # Determine upper-bound on truncation errors that would occur.
+    cumulative_error_sum = numpy.cumsum(term_weights)
+    truncation_errors = cumulative_error_sum[-1] - cumulative_error_sum
+
+    # Optionally truncate rank and return.
+    if truncation_threshold is None and final_rank is None:
+        max_rank = full_rank
+    elif truncation_threshold is None:
+        max_rank = final_rank
+    elif final_rank is None:
+        max_rank = 1 + numpy.argmax(truncation_errors <= truncation_threshold)
+    else:
+        raise ValueError(
+            'Cannot provide both final_rank and truncation_value.')
+    truncation_value = truncation_errors[max_rank - 1]
+
+    # Determine a one body correction in the spatial basis
+    
+
+    return (cholesky_diag[:max_rank],
+            one_body_squares[:max_rank],
+            truncation_value,
+            one_body_correction)
 
 
 def prepare_one_body_squared_evolution(one_body_matrix):

--- a/src/openfermion/utils/_low_rank_test.py
+++ b/src/openfermion/utils/_low_rank_test.py
@@ -23,6 +23,7 @@ from openfermion.utils import (chemist_ordered, eigenspectrum,
                                get_chemist_two_body_coefficients,
                                is_hermitian,
                                low_rank_two_body_decomposition,
+                               low_rank_spatial_two_body_decomposition,
                                normal_ordered,
                                prepare_one_body_squared_evolution,
                                random_interaction_operator)
@@ -135,38 +136,44 @@ class LowRankTest(unittest.TestCase):
         difference = normal_ordered(decomposed_operator - random_operator)
         self.assertAlmostEqual(0., difference.induced_norm())
 
-    def test_molecule_operator_consistency(self):
+    def test_spatial_operator_consistency(self):
 
         # Initialize a random two-body FermionOperator.
         n_qubits = 4
-        random_operator = get_fermion_operator(
-            random_interaction_operator(n_qubits, seed=28644))
+        filename = os.path.join(THIS_DIRECTORY, 'data',
+                                'H2_sto-3g_singlet_0.7414')
+        molecule = MolecularData(filename=filename)
+        molecule_interaction = molecule.get_molecular_hamiltonian()
+        molecule_operator = get_fermion_operator(molecule_interaction)
 
-        # Convert to chemist tensor.
-        constant, one_body_coefficients, chemist_tensor = (
-            get_chemist_two_body_coefficients(random_operator))
+        constant = molecule_interaction.constant
+        one_body_coefficients = molecule_interaction.one_body_tensor[:, :]
+        two_body_coefficients = (
+            molecule_interaction.two_body_tensor[:, :, :, :])
+
+        # Perform decomposition.
+        eigenvalues, one_body_squares, trunc_error, one_body_corrections = (
+            low_rank_spatial_two_body_decomposition(two_body_coefficients))
+        self.assertFalse(trunc_error)
 
         # Build back operator constant and one-body components.
         decomposed_operator = FermionOperator((), constant)
         for p, q in itertools.product(range(n_qubits), repeat=2):
             term = ((p, 1), (q, 0))
-            coefficient = one_body_coefficients[p, q]
+            coefficient = (one_body_coefficients[p, q] +
+                           one_body_corrections[p, q])
             decomposed_operator += FermionOperator(term, coefficient)
-
-        # Perform decomposition.
-        eigenvalues, one_body_squares, trunc_error = (
-            low_rank_two_body_decomposition(chemist_tensor))
-        self.assertFalse(trunc_error)
 
         # Check for exception.
         with self.assertRaises(ValueError):
             eigenvalues, one_body_squares, trunc_error = (
-                low_rank_two_body_decomposition(chemist_tensor,
-                                                truncation_threshold=1.,
-                                                final_rank=1))
+                low_rank_spatial_two_body_decomposition(
+                    two_body_coefficients,
+                    truncation_threshold=1.,
+                    final_rank=1))
 
         # Build back two-body component.
-        for l in range(n_qubits ** 2):
+        for l in range(one_body_squares.shape[0]):
             one_body_operator = FermionOperator()
             for p, q in itertools.product(range(n_qubits), repeat=2):
                 term = ((p, 1), (q, 0))
@@ -175,8 +182,16 @@ class LowRankTest(unittest.TestCase):
             decomposed_operator += eigenvalues[l] * (one_body_operator ** 2)
 
         # Test for consistency.
-        difference = normal_ordered(decomposed_operator - random_operator)
+        difference = normal_ordered(decomposed_operator - molecule_operator)
         self.assertAlmostEqual(0., difference.induced_norm())
+
+        # Decompose with slightly negative operator that must use eigen
+        molecule = MolecularData(filename=filename)
+        molecule.two_body_integrals[0, 0, 0, 0] -= 1
+
+        eigenvalues, one_body_squares, trunc_error, one_body_corrections = (
+            low_rank_spatial_two_body_decomposition(two_body_coefficients))
+        self.assertFalse(trunc_error)
 
     def test_rank_reduction(self):
 

--- a/src/openfermion/utils/_low_rank_test.py
+++ b/src/openfermion/utils/_low_rank_test.py
@@ -193,6 +193,30 @@ class LowRankTest(unittest.TestCase):
             low_rank_spatial_two_body_decomposition(two_body_coefficients))
         self.assertFalse(trunc_error)
 
+        # Check for property errors
+        with self.assertRaises(TypeError):
+            eigenvalues, one_body_squares, trunc_error = (
+                low_rank_spatial_two_body_decomposition(
+                    two_body_coefficients + 0.01j,
+                    truncation_threshold=1.,
+                    final_rank=1))
+
+        # Perform decomposition with threshold
+        test_eigenvalues, one_body_squares, trunc_error, _ = (
+            low_rank_spatial_two_body_decomposition(two_body_coefficients,
+                                                    truncation_threshold=1.0))
+        self.assertTrue(len(test_eigenvalues) < len(eigenvalues))
+        self.assertTrue(len(one_body_squares) == len(test_eigenvalues))
+        self.assertTrue(trunc_error > 0.)
+
+        # Perform decomposition with threshold
+        test_eigenvalues, one_body_squares, trunc_error, _ = (
+            low_rank_spatial_two_body_decomposition(two_body_coefficients,
+                                                    final_rank=1))
+        self.assertTrue(len(test_eigenvalues) == 1)
+        self.assertTrue(len(one_body_squares) == 1)
+        self.assertTrue(trunc_error > 0.)
+
     def test_rank_reduction(self):
 
         # Initialize H2.


### PR DESCRIPTION
Adds a low-rank decomposition that acts on the spatial orbitals, which can take advantage of the PSD symmetry more effectively.  Also corrects a fundamental conflation of integral and fermionic symmetry in the promotion from spatial to spin integrals in the original molecular data structure.