### PR TITLE
Update scipy requirement to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.11.0
-scipy>=0.18.0
+scipy>=1.1.0
 h5py>=2.8
 future
 jupyter


### PR DESCRIPTION
The spatial low rank routine in `utils/_low_rank.py` uses `scipy.linalg.ldl`, which was introduced in Scipy version 1.1.0, which is the latest version.

https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.linalg.ldl.html#scipy.linalg.ldl