### PR TITLE
Add option to generate random InteractionOperators with spin symmetry

### DIFF
--- a/src/openfermion/__init__.py
+++ b/src/openfermion/__init__.py
@@ -18,10 +18,10 @@ For more information, examples, or tutorials visit our website:
 www.openfermion.org
 """
 
-from ._version import __version__
-
 from openfermion.hamiltonians import *
 from openfermion.measurements import *
 from openfermion.ops import *
 from openfermion.transforms import *
 from openfermion.utils import *
+
+from ._version import __version__

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -76,12 +76,12 @@ def random_hermitian_matrix(n, real=False, seed=None):
 
 
 def random_interaction_operator(
-        n_orbitals, expand_to_spin=False, real=True, seed=None):
+        n_orbitals, expand_spin=False, real=True, seed=None):
     """Generate a random instance of InteractionOperator.
     
     Args:
         n_orbitals: The number of orbitals.
-        expand_to_spin: Whether to expand each orbital symmetrically into two
+        expand_spin: Whether to expand each orbital symmetrically into two
             spin orbitals. Note that if this option is set to True, then
             the total number of orbitals will be doubled.
         real: Whether to use only real numbers.
@@ -129,7 +129,7 @@ def random_interaction_operator(
         two_body_coefficients[r, s, p, q] = coeff.conjugate()
 
     # If requested, expand to spin orbitals.
-    if expand_to_spin:
+    if expand_spin:
         n_spin_orbitals = 2 * n_orbitals
 
         # Expand one-body tensor

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -77,7 +77,16 @@ def random_hermitian_matrix(n, real=False, seed=None):
 
 def random_interaction_operator(
         n_orbitals, expand_to_spin=False, real=True, seed=None):
-    """Generate a random instance of InteractionOperator."""
+    """Generate a random instance of InteractionOperator.
+    
+    Args:
+        n_orbitals: The number of orbitals.
+        expand_to_spin: Whether to expand each orbital symmetrically into two
+            spin orbitals. Note that if this option is set to True, then
+            the total number of orbitals will be doubled.
+        real: Whether to use only real numbers.
+        seed: A random number generator seed.
+    """
     if seed is not None:
         numpy.random.seed(seed)
 

--- a/src/openfermion/utils/_testing_utils_test.py
+++ b/src/openfermion/utils/_testing_utils_test.py
@@ -213,15 +213,27 @@ class EqualsTesterTest(unittest.TestCase):
 class RandomInteractionOperatorTest(unittest.TestCase):
 
     def test_hermiticity(self):
-        n_qubits = 5
+        n_orbitals = 5
 
-        # Real case
-        iop = random_interaction_operator(n_qubits, True)
+        # Real, no spin
+        iop = random_interaction_operator(n_orbitals, real=True)
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
 
-        # Complex case
-        iop = random_interaction_operator(n_qubits, False)
+        # Real, spin
+        iop = random_interaction_operator(
+                n_orbitals, expand_to_spin=True, real=True)
+        ferm_op = get_fermion_operator(iop)
+        self.assertTrue(is_hermitian(ferm_op))
+
+        # Complex, no spin
+        iop = random_interaction_operator(n_orbitals, real=False)
+        ferm_op = get_fermion_operator(iop)
+        self.assertTrue(is_hermitian(ferm_op))
+
+        # Complex, spin
+        iop = random_interaction_operator(
+                n_orbitals, expand_to_spin=True, real=False)
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
 

--- a/src/openfermion/utils/_testing_utils_test.py
+++ b/src/openfermion/utils/_testing_utils_test.py
@@ -222,7 +222,7 @@ class RandomInteractionOperatorTest(unittest.TestCase):
 
         # Real, spin
         iop = random_interaction_operator(
-                n_orbitals, expand_to_spin=True, real=True)
+                n_orbitals, expand_spin=True, real=True)
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
 
@@ -233,7 +233,7 @@ class RandomInteractionOperatorTest(unittest.TestCase):
 
         # Complex, spin
         iop = random_interaction_operator(
-                n_orbitals, expand_to_spin=True, real=False)
+                n_orbitals, expand_spin=True, real=False)
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
 

--- a/src/openfermion/utils/_testing_utils_test.py
+++ b/src/openfermion/utils/_testing_utils_test.py
@@ -237,6 +237,23 @@ class RandomInteractionOperatorTest(unittest.TestCase):
         ferm_op = get_fermion_operator(iop)
         self.assertTrue(is_hermitian(ferm_op))
 
+    def test_expand_spin_norm(self):
+        n_orbitals = 5
+
+        iop_without_spin = random_interaction_operator(
+                n_orbitals, real=True, seed=39460)
+        iop_with_spin = random_interaction_operator(
+                n_orbitals, expand_spin=True, real=True, seed=39460)
+
+        ferm_op_without_spin = get_fermion_operator(iop_without_spin)
+        ferm_op_without_spin.terms[()] = 0.0
+        ferm_op_with_spin = get_fermion_operator(iop_with_spin)
+        ferm_op_with_spin.terms[()] = 0.0
+
+        self.assertAlmostEqual(
+                2.0 * ferm_op_without_spin.induced_norm(1),
+                ferm_op_with_spin.induced_norm(1))
+
 
 class HaarRandomVectorTest(unittest.TestCase):
 


### PR DESCRIPTION
Setting `expand_spin` to True will cause each orbital to be expanded symmetrically into two (so the input number of orbitals is taken to refer to spatial orbitals).