### PR TITLE
Diagonalize one-body matrix using eigh and in spatial basis for low rank decomposition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.11.0
-scipy>=0.18.0
+scipy>=1.1.0
 h5py>=2.8
 future
 jupyter

--- a/src/openfermion/hamiltonians/_jellium.py
+++ b/src/openfermion/hamiltonians/_jellium.py
@@ -17,7 +17,6 @@ import numpy
 
 from openfermion.ops import FermionOperator, QubitOperator
 from openfermion.utils._grid import Grid
-from openfermion.utils._operator_utils import normal_ordered
 
 
 def wigner_seitz_length_scale(wigner_seitz_radius, n_particles, dimension):
@@ -109,7 +108,7 @@ def plane_wave_potential(grid, spinless=False, e_cutoff=None,
     operator = FermionOperator((), 0.0)
     spins = [None] if spinless else [0, 1]
     if non_periodic and period_cutoff is None:
-      period_cutoff = grid.volume_scale() ** (1. / grid.dimensions)
+        period_cutoff = grid.volume_scale() ** (1. / grid.dimensions)
 
     # Pre-Computations.
     shifted_omega_indices_dict = {}
@@ -152,8 +151,8 @@ def plane_wave_potential(grid, spinless=False, e_cutoff=None,
         # Compute coefficient.
         coefficient = prefactor / momenta_squared
         if non_periodic:
-          coefficient *= 1. - numpy.cos(period_cutoff *
-                                        numpy.sqrt(momenta_squared))
+            coefficient *= 1.0 - numpy.cos(
+                    period_cutoff * numpy.sqrt(momenta_squared))
 
         for grid_indices_a in grid.all_points_indices():
             shifted_indices_d = (
@@ -204,11 +203,11 @@ def dual_basis_jellium_model(grid, spinless=False,
     """
     # Initialize.
     n_points = grid.num_points
-    position_prefactor = 2. * numpy.pi / grid.volume_scale()
+    position_prefactor = 2.0 * numpy.pi / grid.volume_scale()
     operator = FermionOperator()
     spins = [None] if spinless else [0, 1]
     if potential and non_periodic and period_cutoff is None:
-      period_cutoff = grid.volume_scale() ** (1. / grid.dimensions)
+        period_cutoff = grid.volume_scale() ** (1.0 / grid.dimensions)
 
     # Pre-Computations.
     position_vectors = {}

--- a/src/openfermion/utils/_low_rank.py
+++ b/src/openfermion/utils/_low_rank.py
@@ -19,7 +19,7 @@ import scipy.linalg
 
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import FermionOperator, InteractionOperator
-from openfermion.utils import count_qubits, normal_ordered
+from openfermion.utils import count_qubits, is_hermitian, normal_ordered
 
 
 def get_chemist_two_body_coefficients(two_body_operator):
@@ -314,7 +314,7 @@ def low_rank_spatial_two_body_decomposition(two_body_coefficients,
             one_body_correction)
 
 
-def prepare_one_body_squared_evolution(one_body_matrix):
+def prepare_one_body_squared_evolution(one_body_matrix, spin_basis=True):
     """Get Givens angles and DiagonalHamiltonian to simulate squared one-body.
 
     The goal here will be to prepare to simulate evolution under
@@ -335,9 +335,26 @@ def prepare_one_body_squared_evolution(one_body_matrix):
         basis_transformation_matrix (ndarray of floats) an N by N array
             storing the values of the basis transformation.
     """
+    # If the specification was in spin-orbitals, chop back down to spatial orbs
+    # assuming a spin-symmetric interaction
+    if spin_basis:
+        n_modes = one_body_matrix.shape[0]
+        alpha_indices = list(range(0, n_modes, 2))
+        one_body_matrix = one_body_matrix[
+                numpy.ix_(alpha_indices, alpha_indices)]
+
     # Diagonalize the one-body matrix.
-    eigenvalues, eigenvectors = numpy.linalg.eig(one_body_matrix)
+    if is_hermitian(one_body_matrix):
+        eigenvalues, eigenvectors = numpy.linalg.eigh(one_body_matrix)
+    else:
+        eigenvalues, eigenvectors = numpy.linalg.eig(one_body_matrix)
     basis_transformation_matrix = numpy.conjugate(eigenvectors.transpose())
+
+    # If the specification was in spin-orbitals, expand back
+    if spin_basis:
+        basis_transformation_matrix = numpy.kron(
+                basis_transformation_matrix, numpy.eye(2))
+        eigenvalues = numpy.kron(eigenvalues, numpy.ones(2))
 
     # Obtain the diagonal two-body matrix.
     density_density_matrix = numpy.outer(eigenvalues, eigenvalues)

--- a/src/openfermion/utils/_low_rank.py
+++ b/src/openfermion/utils/_low_rank.py
@@ -228,7 +228,6 @@ def low_rank_spatial_two_body_decomposition(two_body_coefficients,
             from reordering to chemist ordering.  Returned in spin-orbital
             basis.
 
-
     Raises:
         TypeError: Invalid two-body coefficient tensor specification.
         ValueError: Cannot provide both final_rank and truncation_value.
@@ -328,6 +327,8 @@ def prepare_one_body_squared_evolution(one_body_matrix, spin_basis=True):
         one_body_matrix (ndarray of floats): an N by N array storing the
             coefficients of a one-body operator to be squared. For instance,
             in the above the elements of this matrix are :math:`h_{pq}`.
+        spin_basis (bool): Whether the matrix is passed in the
+            spin orbital basis.
 
     Returns:
         density_density_matrix(ndarray of floats) an N by N array storing

--- a/src/openfermion/utils/_low_rank_test.py
+++ b/src/openfermion/utils/_low_rank_test.py
@@ -339,7 +339,8 @@ class LowRankTest(unittest.TestCase):
 
             # Get the squared one-body operator via one-body decomposition.
             density_density_matrix, basis_transformation_matrix = (
-                prepare_one_body_squared_evolution(one_body_squares[l]))
+                prepare_one_body_squared_evolution(
+                    one_body_squares[l], spin_basis=False))
             two_body_operator = FermionOperator()
             for p, q in itertools.product(range(n_qubits), repeat=2):
                 term = ((p, 1), (p, 0), (q, 1), (q, 0))


### PR DESCRIPTION
Fixes #427 .

It's necessary to check whether the matrices are Hermitian (and use eig if they're not) in order to pass the tests of the non-spatial routine.