### PR TITLE
deprecated OpenFermion-ProjectQ

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Plugins
 OpenFermion relies on modular plugin libraries for significant functionality.
 Specifically, plugins are used to simulate and compile quantum circuits and to perform
 classical electronic structure calculations.
-Follow the links below to learn more about these useful plugins.
+Follow the links below to learn more!
 
 Circuit compilation and simulation plugins
 ------------------------------------------
@@ -37,8 +37,6 @@ Circuit compilation and simulation plugins
 * `Forest-OpenFermion <https://github.com/rigetticomputing/forestopenfermion>`__ to support integration with `Forest <https://www.rigetti.com/forest>`__.
 
 * `SFOpenBoson <https://github.com/XanaduAI/SFOpenBoson>`__ to support integration with `Strawberry Fields <https://github.com/XanaduAI/strawberryfields>`__.
-
-* `OpenFermion-ProjectQ <http://github.com/quantumlib/OpenFermion-ProjectQ>`__ to support integration with `ProjectQ <https://projectq.ch>`__.
 
 Electronic structure package plugins
 ------------------------------------


### PR DESCRIPTION
*Removed OpenFermion-ProjectQ from list of actively maintained plugins.

Note that the OpenFermion-ProjectQ repository will be archived. If any responsible developers would like to maintain OpenFermion-ProjectQ, contact us. We'd be happy to transfer that repo to your control so that open source development can continue. But we do not have the resources to continue to maintain it.