### PR TITLE
Masking + caching for evaluating errors for different Trotter steps

### DIFF
--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -1,0 +1,297 @@
+import numpy
+
+from future.utils import iteritems
+
+from openfermion import count_qubits, FermionOperator
+from openfermion.utils._low_depth_trotter_error import (
+    simulation_ordered_grouped_low_depth_terms_with_info)
+from openfermion.utils._commutator_diagonal_coulomb_operator import (
+    commutator_ordered_diagonal_coulomb_with_two_body_operator)
+
+
+def potential_and_kinetic_terms_as_arrays(hamiltonian):
+    potential = FermionOperator.zero()
+    kinetic = FermionOperator.zero()
+
+    for term, coeff in iteritems(hamiltonian.terms):
+        acted = set(term[i][0] for i in range(len(term)))
+        if len(acted) == len(term) / 2:
+            potential += FermionOperator(term, coeff)
+        else:
+            kinetic += FermionOperator(term, coeff)
+
+    potential_terms = numpy.array(
+        [FermionOperator(term, coeff)
+         for term, coeff in iteritems(potential.terms)])
+
+    kinetic_terms = numpy.array(
+        [FermionOperator(term, coeff)
+         for term, coeff in iteritems(kinetic.terms)])
+
+    return (potential_terms, kinetic_terms)
+
+
+def bit_mask_of_modes_acted_on_by_fermionic_terms(
+        fermion_term_list, n_qubits=None):
+    if n_qubits is None:
+        n_qubits = 0
+        for term in fermion_term_list:
+            n_qubits = max(n_qubits, count_qubits(term))
+
+    mask = numpy.zeros((n_qubits, len(fermion_term_list)), dtype=bool)
+
+    for term_number, term in enumerate(fermion_term_list):
+        actions = term.terms
+        for action in actions:
+            for single_operator in action:
+                mode = single_operator[0]
+                mask[mode][term_number] = True
+
+    return mask
+
+
+def split_operator_trotter_error_operator_diagonal_two_body(hamiltonian,
+                                                            order):
+    n_qubits = count_qubits(hamiltonian)
+
+    potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
+        hamiltonian)
+    halved_potential_terms = potential_terms / 2.0
+    halved_kinetic_terms = kinetic_terms / 2.0
+    del hamiltonian
+
+    outer_potential_terms = (halved_potential_terms if order == 'T+V' else
+                             potential_terms)
+    outer_kinetic_terms = (halved_kinetic_terms if order == 'V+T' else
+                           kinetic_terms)
+
+    potential_mask = bit_mask_of_modes_acted_on_by_fermionic_terms(
+        potential_terms, n_qubits)
+    kinetic_mask = bit_mask_of_modes_acted_on_by_fermionic_terms(
+        kinetic_terms, n_qubits)
+
+    error_operator = FermionOperator.zero()
+
+    for potential_term in potential_terms:
+        modes_acted_on_by_potential_term = set()
+
+        for potential_term_action in potential_term.terms:
+            modes_acted_on_by_potential_term.update(
+                set(operator[0] for operator in potential_term_action))
+
+        potential_term_mode_mask = numpy.logical_or.reduce(
+            [kinetic_mask[mode] for mode in modes_acted_on_by_potential_term])
+
+        for kinetic_term in kinetic_terms[potential_term_mode_mask]:
+            inner_commutator_term = (
+                commutator_ordered_diagonal_coulomb_with_two_body_operator(
+                    potential_term, kinetic_term))
+
+            modes_acted_on_by_inner_commutator = set()
+            for inner_commutator_action in inner_commutator_term.terms:
+                modes_acted_on_by_inner_commutator.update(
+                    set(operator[0] for operator in inner_commutator_action))
+
+            if not modes_acted_on_by_inner_commutator:
+                continue
+
+            inner_commutator_mode_mask = numpy.logical_or.reduce(
+                [potential_mask[mode]
+                 for mode in modes_acted_on_by_inner_commutator])
+
+            # halved_potential_terms for T+V order, potential_terms for V+T
+            for outer_potential_term in outer_potential_terms[
+                    inner_commutator_mode_mask]:
+                commutator_ordered_diagonal_coulomb_with_two_body_operator(
+                    outer_potential_term, inner_commutator_term,
+                    prior_terms=error_operator)
+
+            inner_commutator_mode_mask = numpy.logical_or.reduce(
+                [kinetic_mask[qubit]
+                 for qubit in modes_acted_on_by_inner_commutator])
+
+            # kinetic_terms for T+V order, halved_kinetic_terms for V+T
+            for outer_kinetic_term in outer_kinetic_terms[
+                    inner_commutator_mode_mask]:
+                commutator_ordered_diagonal_coulomb_with_two_body_operator(
+                    outer_kinetic_term, inner_commutator_term,
+                    prior_terms=error_operator)
+
+    # Divide by 12 to match the error operator definition.
+    error_operator /= 12.0
+    return error_operator
+
+
+def fermionic_swap_trotter_error_operator_diagonal_two_body(hamiltonian):
+    single_terms = numpy.array(
+        simulation_ordered_grouped_low_depth_terms_with_info(
+            hamiltonian)[0])
+
+    # Cache the terms in the simulation divided by two.
+    halved_single_terms = single_terms / 2.0
+
+    term_mode_mask = bit_mask_of_modes_acted_on_by_fermionic_terms(
+        single_terms, count_qubits(hamiltonian))
+
+    error_operator = FermionOperator.zero()
+
+    for beta, term_beta in enumerate(single_terms):
+        modes_acted_on_by_term_beta = set()
+        for beta_action in term_beta.terms:
+            modes_acted_on_by_term_beta.update(
+                set(operator[0] for operator in beta_action))
+
+        beta_mode_mask = numpy.logical_or.reduce(
+            [term_mode_mask[mode] for mode in modes_acted_on_by_term_beta])
+
+        # alpha_prime indices that could have a nonzero commutator, i.e.
+        # there's overlap between the modes the corresponding terms act on.
+        valid_alpha_primes = numpy.where(beta_mode_mask)[0]
+
+        # Only alpha_prime < beta enters the error operator; filter for this.
+        valid_alpha_primes = valid_alpha_primes[valid_alpha_primes < beta]
+
+        for alpha_prime in valid_alpha_primes:
+            term_alpha_prime = single_terms[alpha_prime]
+
+            inner_commutator_term = (
+                commutator_ordered_diagonal_coulomb_with_two_body_operator(
+                    term_beta, term_alpha_prime))
+
+            modes_acted_on_by_inner_commutator = set()
+            for inner_commutator_action in inner_commutator_term.terms:
+                modes_acted_on_by_inner_commutator.update(
+                    set(operator[0] for operator in inner_commutator_action))
+
+            # If the inner commutator has no action, the commutator is zero.
+            if not modes_acted_on_by_inner_commutator:
+                continue
+
+            inner_commutator_mask = numpy.logical_or.reduce(
+                [term_mode_mask[mode]
+                 for mode in modes_acted_on_by_inner_commutator])
+
+            # alpha indices that could have a nonzero commutator.
+            valid_alphas = numpy.where(inner_commutator_mask)[0]
+            # Filter so alpha <= beta in the double commutator.
+            valid_alphas = valid_alphas[valid_alphas <= beta]
+
+            for alpha in valid_alphas:
+                # If alpha = beta, only use half the term.
+                if alpha != beta:
+                    outer_term_alpha = single_terms[alpha]
+                else:
+                    outer_term_alpha = halved_single_terms[alpha]
+
+                # Add the partial double commutator to the error operator.
+                commutator_ordered_diagonal_coulomb_with_two_body_operator(
+                    outer_term_alpha, inner_commutator_term,
+                    prior_terms=error_operator)
+
+    # Divide by 12 to match the error operator definition.
+    error_operator /= 12.0
+    return error_operator
+
+
+if __name__ == '__main__':
+    import time
+    import sys
+
+    from openfermion import normal_ordered
+    from openfermion.hamiltonians import (
+        fermi_hubbard,
+        jellium_model,
+        hypercube_grid_with_given_wigner_seitz_radius_and_filling)
+    from openfermion.utils._low_depth_trotter_error import (
+        low_depth_second_order_trotter_error_bound,
+        low_depth_second_order_trotter_error_operator)
+
+    compare_with_old_code = True
+
+    dimension = 2
+    side_length = int(sys.argv[1])
+    tunneling = 1.0
+    periodic = True
+
+    jellium = False
+
+    coulomb_data_points = numpy.array([4.])
+    fs_error_bounds = numpy.zeros(len(coulomb_data_points))
+    fs_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+    so_error_bounds = numpy.zeros(len(coulomb_data_points))
+    so_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+
+    for i, coulomb in enumerate(coulomb_data_points):
+        print('For 2D Fermi-Hubbard with side length %i, coulomb = %f:' % (
+            side_length, coulomb))
+
+        start = time.time()
+        if jellium:
+            hamiltonian = normal_ordered(jellium_model(
+                hypercube_grid_with_given_wigner_seitz_radius_and_filling(
+                    dimension, side_length, wigner_seitz_radius=10.,
+                    spinless=True), spinless=True,
+                plane_wave=False))
+            order = 'T+V'
+        else:
+            hamiltonian = normal_ordered(
+                fermi_hubbard(side_length, side_length,
+                              tunneling, coulomb, periodic=periodic))
+            order = 'V+T'
+
+        hamiltonian.compress()
+        print('Got Hamiltonian in %s' % str(time.time() - start))
+
+        start = time.time()
+        error_operator = (
+            split_operator_trotter_error_operator_diagonal_two_body(
+                hamiltonian, order))
+        error_operator.compress()
+
+        so_norm_bound = numpy.sum(numpy.absolute(
+            list(error_operator.terms.values())))
+
+        so_n_terms[i] = len(error_operator.terms)
+        so_error_bounds[i] = so_norm_bound
+        print('Took ' + str(time.time() - start) +
+              ' to compute SO error operator and info')
+
+        start = time.time()
+        error_operator = (
+            fermionic_swap_trotter_error_operator_diagonal_two_body(
+                hamiltonian))
+        error_operator.compress()
+
+        fs_norm_bound = numpy.sum(numpy.absolute(
+            list(error_operator.terms.values())))
+
+        fs_n_terms[i] = len(error_operator.terms)
+        fs_error_bounds[i] = fs_norm_bound
+        print('Took ' + str(time.time() - start) +
+              ' to compute FS error operator and info')
+
+        print('SO mask bound: ' + str(so_norm_bound))
+        print('FS mask bound: ' + str(fs_norm_bound))
+
+        if compare_with_old_code:
+            start = time.time()
+
+            # Unpack result into terms, indices they act on, and whether
+            # they're hopping operators.
+            result = simulation_ordered_grouped_low_depth_terms_with_info(
+                hamiltonian)
+            terms, indices, is_hopping = result
+
+            old_error_operator = low_depth_second_order_trotter_error_operator(
+                terms, indices, is_hopping, jellium_only=True)
+
+            print('Regular FS bound: ',
+                  low_depth_second_order_trotter_error_bound(
+                      terms, indices, is_hopping, jellium_only=True))
+            print('Took ' + str(time.time() - start) +
+                  ' to compute FS with old code')
+
+            old_error_operator -= error_operator
+            print('Difference between old and new methods:',
+                  numpy.sum(numpy.absolute(list(
+                      old_error_operator.terms.values()))))

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -1,3 +1,17 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Code for evaluating Trotter errors for diagonal Coulomb Hamiltonians."""
+
 import numpy
 
 from future.utils import iteritems

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -136,7 +136,13 @@ def split_operator_trotter_error_operator_diagonal_two_body(hamiltonian,
                     prior_terms=error_operator)
 
     # Divide by 12 to match the error operator definition.
-    error_operator /= 12.0
+    # If order='V+T', also flip the sign to account for inner_commutator_term
+    # not flipping between the different orderings.
+    if order == 'T+V':
+        error_operator /= 12.0
+    else:
+        error_operator /= -12.0
+
     return error_operator
 
 
@@ -209,107 +215,3 @@ def fermionic_swap_trotter_error_operator_diagonal_two_body(hamiltonian):
     # Divide by 12 to match the error operator definition.
     error_operator /= 12.0
     return error_operator
-
-
-if __name__ == '__main__':
-    import time
-    import sys
-
-    from openfermion import normal_ordered
-    from openfermion.hamiltonians import (
-        fermi_hubbard,
-        jellium_model,
-        hypercube_grid_with_given_wigner_seitz_radius_and_filling)
-    from openfermion.utils._low_depth_trotter_error import (
-        low_depth_second_order_trotter_error_bound,
-        low_depth_second_order_trotter_error_operator)
-
-    compare_with_old_code = True
-
-    dimension = 2
-    side_length = int(sys.argv[1])
-    tunneling = 1.0
-    periodic = True
-
-    jellium = False
-
-    coulomb_data_points = numpy.array([4.])
-    fs_error_bounds = numpy.zeros(len(coulomb_data_points))
-    fs_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
-    so_error_bounds = numpy.zeros(len(coulomb_data_points))
-    so_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
-
-    for i, coulomb in enumerate(coulomb_data_points):
-        print('For 2D Fermi-Hubbard with side length %i, coulomb = %f:' % (
-            side_length, coulomb))
-
-        start = time.time()
-        if jellium:
-            hamiltonian = normal_ordered(jellium_model(
-                hypercube_grid_with_given_wigner_seitz_radius_and_filling(
-                    dimension, side_length, wigner_seitz_radius=10.,
-                    spinless=True), spinless=True,
-                plane_wave=False))
-            order = 'T+V'
-        else:
-            hamiltonian = normal_ordered(
-                fermi_hubbard(side_length, side_length,
-                              tunneling, coulomb, periodic=periodic))
-            order = 'V+T'
-
-        hamiltonian.compress()
-        print('Got Hamiltonian in %s' % str(time.time() - start))
-
-        start = time.time()
-        error_operator = (
-            split_operator_trotter_error_operator_diagonal_two_body(
-                hamiltonian, order))
-        error_operator.compress()
-
-        so_norm_bound = numpy.sum(numpy.absolute(
-            list(error_operator.terms.values())))
-
-        so_n_terms[i] = len(error_operator.terms)
-        so_error_bounds[i] = so_norm_bound
-        print('Took ' + str(time.time() - start) +
-              ' to compute SO error operator and info')
-
-        start = time.time()
-        error_operator = (
-            fermionic_swap_trotter_error_operator_diagonal_two_body(
-                hamiltonian))
-        error_operator.compress()
-
-        fs_norm_bound = numpy.sum(numpy.absolute(
-            list(error_operator.terms.values())))
-
-        fs_n_terms[i] = len(error_operator.terms)
-        fs_error_bounds[i] = fs_norm_bound
-        print('Took ' + str(time.time() - start) +
-              ' to compute FS error operator and info')
-
-        print('SO mask bound: ' + str(so_norm_bound))
-        print('FS mask bound: ' + str(fs_norm_bound))
-
-        if compare_with_old_code:
-            start = time.time()
-
-            # Unpack result into terms, indices they act on, and whether
-            # they're hopping operators.
-            result = simulation_ordered_grouped_low_depth_terms_with_info(
-                hamiltonian)
-            terms, indices, is_hopping = result
-
-            old_error_operator = low_depth_second_order_trotter_error_operator(
-                terms, indices, is_hopping, jellium_only=True)
-
-            print('Regular FS bound: ',
-                  low_depth_second_order_trotter_error_bound(
-                      terms, indices, is_hopping, jellium_only=True))
-            print('Took ' + str(time.time() - start) +
-                  ' to compute FS with old code')
-
-            old_error_operator -= error_operator
-            print('Difference between old and new methods:',
-                  numpy.sum(numpy.absolute(list(
-                      old_error_operator.terms.values()))))

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -150,6 +150,9 @@ def split_operator_trotter_error_operator_diagonal_two_body(hamiltonian,
             modes_acted_on_by_potential_term.update(
                 set(operator[0] for operator in potential_term_action))
 
+        if not modes_acted_on_by_potential_term:
+            continue
+
         potential_term_mode_mask = numpy.logical_or.reduce(
             [kinetic_mask[mode] for mode in modes_acted_on_by_potential_term])
 

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -125,9 +125,12 @@ def split_operator_trotter_error_operator_diagonal_two_body(hamiltonian,
 
     potential_terms, kinetic_terms = (
         diagonal_coulomb_potential_and_kinetic_terms_as_arrays(hamiltonian))
+
+    # Cache halved potential and kinetic terms for the second commutator.
     halved_potential_terms = potential_terms / 2.0
     halved_kinetic_terms = kinetic_terms / 2.0
 
+    # Assign the outer term of the second commutator based on the ordering.
     outer_potential_terms = (halved_potential_terms if order == 'T+V' else
                              potential_terms)
     outer_kinetic_terms = (halved_kinetic_terms if order == 'V+T' else
@@ -218,7 +221,7 @@ def fermionic_swap_trotter_error_operator_diagonal_two_body(hamiltonian):
         simulation_ordered_grouped_low_depth_terms_with_info(
             hamiltonian)[0])
 
-    # Cache the terms in the simulation divided by two.
+    # Cache the halved terms for use in the second commutator.
     halved_single_terms = single_terms / 2.0
 
     term_mode_mask = bit_mask_of_modes_acted_on_by_fermionic_terms(

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -45,7 +45,11 @@ def bit_mask_of_modes_acted_on_by_fermionic_terms(
         for action in actions:
             for single_operator in action:
                 mode = single_operator[0]
-                mask[mode][term_number] = True
+                try:
+                    mask[mode][term_number] = True
+                except IndexError:
+                    raise ValueError('Bad n_qubits: must be greater than '
+                                     'highest mode in any FermionOperator.')
 
     return mask
 

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error.py
@@ -16,7 +16,10 @@ import numpy
 
 from future.utils import iteritems
 
-from openfermion import count_qubits, FermionOperator
+from openfermion import (count_qubits,
+                         FermionOperator,
+                         get_fermion_operator,
+                         normal_ordered)
 from openfermion.utils._low_depth_trotter_error import (
     simulation_ordered_grouped_low_depth_terms_with_info)
 from openfermion.utils._commutator_diagonal_coulomb_operator import (
@@ -37,6 +40,13 @@ def diagonal_coulomb_potential_and_kinetic_terms_as_arrays(hamiltonian):
         Tuple of (potential_terms, kinetic_terms). Both elements of the tuple
         are numpy arrays of FermionOperators.
     """
+    if not isinstance(hamiltonian, FermionOperator):
+        try:
+            hamiltonian = normal_ordered(get_fermion_operator(hamiltonian))
+        except TypeError:
+            raise TypeError('hamiltonian must be either a FermionOperator '
+                            'or DiagonalCoulombHamiltonian.')
+
     potential = FermionOperator.zero()
     kinetic = FermionOperator.zero()
 
@@ -214,11 +224,8 @@ def fermionic_swap_trotter_error_operator_diagonal_two_body(hamiltonian):
         error_operator: The second-order Trotter error operator.
 
     Notes:
-        Follows Equation 9 of Poulin et al.'s work in "The Trotter Step
-        Size Required for Accurate Quantum Simulation of Quantum Chemistry",
-        applied to the "stagger"-based Trotter step for detailed in
-        Kivlichan et al., "Quantum Simulation of Electronic Structure with
-        Linear Depth and Connectivity", arxiv:1711.04789.
+        Follows Eq 9 of Poulin et al., arXiv:1406.4920, applied to the
+        Trotter step detailed in Kivlichan et al., arxiv:1711.04789.
     """
     single_terms = numpy.array(
         simulation_ordered_grouped_low_depth_terms_with_info(

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -28,7 +28,7 @@ from openfermion.utils._low_depth_trotter_error import (
     low_depth_second_order_trotter_error_operator,
     simulation_ordered_grouped_low_depth_terms_with_info)
 from openfermion.utils._diagonal_coulomb_trotter_error import (
-    potential_and_kinetic_terms_as_arrays,
+    diagonal_coulomb_potential_and_kinetic_terms_as_arrays,
     bit_mask_of_modes_acted_on_by_fermionic_terms,
     split_operator_trotter_error_operator_diagonal_two_body,
     fermionic_swap_trotter_error_operator_diagonal_two_body)
@@ -41,8 +41,9 @@ class BreakHamiltonianIntoPotentialKineticArraysTest(unittest.TestCase):
                        FermionOperator('1^ 1') - FermionOperator('1^ 2') -
                        FermionOperator('2^ 1'))
 
-        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
-            hamiltonian)
+        potential_terms, kinetic_terms = (
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                hamiltonian))
 
         potential = sum(potential_terms, FermionOperator.zero())
         kinetic = sum(kinetic_terms, FermionOperator.zero())
@@ -57,8 +58,9 @@ class BreakHamiltonianIntoPotentialKineticArraysTest(unittest.TestCase):
 
         hamiltonian = jellium_model(grid, spinless=True, plane_wave=False)
 
-        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
-            hamiltonian)
+        potential_terms, kinetic_terms = (
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                hamiltonian))
 
         potential = sum(potential_terms, FermionOperator.zero())
         kinetic = sum(kinetic_terms, FermionOperator.zero())
@@ -77,16 +79,18 @@ class BreakHamiltonianIntoPotentialKineticArraysTest(unittest.TestCase):
         self.assertEqual(kinetic, true_kinetic)
 
     def test_identity_recognized_as_potential_term(self):
-        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
-            FermionOperator.identity())
+        potential_terms, kinetic_terms = (
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                FermionOperator.identity()))
 
         self.assertListEqual(list(potential_terms),
                              [FermionOperator.identity()])
         self.assertListEqual(list(kinetic_terms), [])
 
     def test_zero_hamiltonian(self):
-        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
-            FermionOperator.zero())
+        potential_terms, kinetic_terms = (
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                FermionOperator.zero()))
 
         self.assertListEqual(list(potential_terms), [])
         self.assertListEqual(list(kinetic_terms), [])
@@ -197,7 +201,8 @@ class SplitOperatorTrotterErrorTest(unittest.TestCase):
         hamiltonian = (normal_ordered(fermi_hubbard(3, 3, 1., 4.0)) -
                        2.3 * FermionOperator.identity())
         potential_terms, kinetic_terms = (
-            potential_and_kinetic_terms_as_arrays(hamiltonian))
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                hamiltonian))
         potential = sum(potential_terms, FermionOperator.zero())
         kinetic = sum(kinetic_terms, FermionOperator.zero())
 
@@ -219,7 +224,8 @@ class SplitOperatorTrotterErrorTest(unittest.TestCase):
         hamiltonian = (normal_ordered(fermi_hubbard(3, 3, 1., 4.0)) -
                        2.3 * FermionOperator.identity())
         potential_terms, kinetic_terms = (
-            potential_and_kinetic_terms_as_arrays(hamiltonian))
+            diagonal_coulomb_potential_and_kinetic_terms_as_arrays(
+                hamiltonian))
         potential = sum(potential_terms, FermionOperator.zero())
         kinetic = sum(kinetic_terms, FermionOperator.zero())
 

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -1,12 +1,13 @@
 import time
 import unittest
 
-from openfermion import normal_ordered
+from openfermion import count_qubits, FermionOperator, Grid, normal_ordered
 
 from openfermion.hamiltonians import (
+    dual_basis_jellium_model,
     fermi_hubbard,
-    jellium_model,
-    hypercube_grid_with_given_wigner_seitz_radius_and_filling)
+    hypercube_grid_with_given_wigner_seitz_radius_and_filling,
+    jellium_model)
 from openfermion.utils._low_depth_trotter_error import (
     low_depth_second_order_trotter_error_bound,
     low_depth_second_order_trotter_error_operator)
@@ -17,93 +18,145 @@ from openfermion.utils._diagonal_coulomb_trotter_error import (
     fermionic_swap_trotter_error_operator_diagonal_two_body)
 
 
+class BreakHamiltonianIntoPotentialKineticArraysTest(unittest.TestCase):
+
+    def test_simple_hamiltonian(self):
+        hamiltonian = (FermionOperator('3^ 1^ 3 1') +
+                       FermionOperator('1^ 1') - FermionOperator('1^ 2')
+                       - FermionOperator('2^ 1'))
+
+        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
+            hamiltonian)
+
+        potential = sum(potential_terms, FermionOperator.zero())
+        kinetic = sum(kinetic_terms, FermionOperator.zero())
+
+        self.assertEqual(potential, (FermionOperator('1^ 1') +
+                                     FermionOperator('3^ 1^ 3 1')))
+        self.assertEqual(kinetic, (-FermionOperator('1^ 2') -
+                                   FermionOperator('2^ 1')))
+
+    def test_jellium_hamiltonian_correctly_broken_up(self):
+        grid = Grid(2, 3, 1.)
+
+        hamiltonian = jellium_model(grid, spinless=True, plane_wave=False)
+
+        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
+            hamiltonian)
+
+        potential = sum(potential_terms, FermionOperator.zero())
+        kinetic = sum(kinetic_terms, FermionOperator.zero())
+
+        true_potential = dual_basis_jellium_model(grid, spinless=True,
+                                                  kinetic=False)
+        true_kinetic = dual_basis_jellium_model(grid, spinless=True,
+                                                potential=False)
+        for i in range(count_qubits(true_kinetic)):
+            coeff = true_kinetic.terms.get(((i, 1), (i, 0)))
+            if coeff:
+                true_kinetic -= FermionOperator(((i, 1), (i, 0)), coeff)
+                true_potential += FermionOperator(((i, 1), (i, 0)), coeff)
+
+        self.assertEqual(potential, true_potential)
+        self.assertEqual(kinetic, true_kinetic)
+
+    def test_identity_recognized_as_potential_term(self):
+        potential_terms, kinetic_terms = potential_and_kinetic_terms_as_arrays(
+            FermionOperator.identity())
+
+        self.assertListEqual(list(potential_terms),
+                             [FermionOperator.identity()])
+        self.assertListEqual(list(kinetic_terms), [])
+
+
 if __name__ == '__main__':
-    compare_with_old_code = True
+    unittest.main()
+    #compare_with_old_code = True
 
-    dimension = 2
-    side_length = int(sys.argv[1])
-    tunneling = 1.0
-    periodic = True
+    #dimension = 2
+    #side_length = int(sys.argv[1])
+    #tunneling = 1.0
+    #periodic = True
 
-    jellium = False
+    #jellium = False
 
-    coulomb_data_points = numpy.array([4.])
-    fs_error_bounds = numpy.zeros(len(coulomb_data_points))
-    fs_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
-    so_error_bounds = numpy.zeros(len(coulomb_data_points))
-    so_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+    #coulomb_data_points = numpy.array([4.])
+    #fs_error_bounds = numpy.zeros(len(coulomb_data_points))
+    #fs_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+    #so_error_bounds = numpy.zeros(len(coulomb_data_points))
+    #so_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
 
-    for i, coulomb in enumerate(coulomb_data_points):
-        print('For 2D Fermi-Hubbard with side length %i, coulomb = %f:' % (
-            side_length, coulomb))
+    #for i, coulomb in enumerate(coulomb_data_points):
+        #print('For 2D Fermi-Hubbard with side length %i, coulomb = %f:' % (
+            #side_length, coulomb))
 
-        start = time.time()
-        if jellium:
-            hamiltonian = normal_ordered(jellium_model(
-                hypercube_grid_with_given_wigner_seitz_radius_and_filling(
-                    dimension, side_length, wigner_seitz_radius=10.,
-                    spinless=True), spinless=True,
-                plane_wave=False))
-            order = 'T+V'
-        else:
-            hamiltonian = normal_ordered(
-                fermi_hubbard(side_length, side_length,
-                              tunneling, coulomb, periodic=periodic))
-            order = 'V+T'
+        #start = time.time()
+        #if jellium:
+            #hamiltonian = normal_ordered(jellium_model(
+                #hypercube_grid_with_given_wigner_seitz_radius_and_filling(
+                    #dimension, side_length, wigner_seitz_radius=10.,
+                    #spinless=True), spinless=True,
+                #plane_wave=False))
+            #order = 'T+V'
+        #else:
+            #hamiltonian = normal_ordered(
+                #fermi_hubbard(side_length, side_length,
+                              #tunneling, coulomb, periodic=periodic))
+            #order = 'V+T'
 
-        hamiltonian.compress()
-        print('Got Hamiltonian in %s' % str(time.time() - start))
+        #hamiltonian.compress()
+        #print('Got Hamiltonian in %s' % str(time.time() - start))
 
-        start = time.time()
-        error_operator = (
-            split_operator_trotter_error_operator_diagonal_two_body(
-                hamiltonian, order))
-        error_operator.compress()
+        #start = time.time()
+        #error_operator = (
+            #split_operator_trotter_error_operator_diagonal_two_body(
+                #hamiltonian, order))
+        #error_operator.compress()
 
-        so_norm_bound = numpy.sum(numpy.absolute(
-            list(error_operator.terms.values())))
+        #so_norm_bound = numpy.sum(numpy.absolute(
+            #list(error_operator.terms.values())))
 
-        so_n_terms[i] = len(error_operator.terms)
-        so_error_bounds[i] = so_norm_bound
-        print('Took ' + str(time.time() - start) +
-              ' to compute SO error operator and info')
+        #so_n_terms[i] = len(error_operator.terms)
+        #so_error_bounds[i] = so_norm_bound
+        #print('Took ' + str(time.time() - start) +
+              #' to compute SO error operator and info')
 
-        start = time.time()
-        error_operator = (
-            fermionic_swap_trotter_error_operator_diagonal_two_body(
-                hamiltonian))
-        error_operator.compress()
+        #start = time.time()
+        #error_operator = (
+            #fermionic_swap_trotter_error_operator_diagonal_two_body(
+                #hamiltonian))
+        #error_operator.compress()
 
-        fs_norm_bound = numpy.sum(numpy.absolute(
-            list(error_operator.terms.values())))
+        #fs_norm_bound = numpy.sum(numpy.absolute(
+            #list(error_operator.terms.values())))
 
-        fs_n_terms[i] = len(error_operator.terms)
-        fs_error_bounds[i] = fs_norm_bound
-        print('Took ' + str(time.time() - start) +
-              ' to compute FS error operator and info')
+        #fs_n_terms[i] = len(error_operator.terms)
+        #fs_error_bounds[i] = fs_norm_bound
+        #print('Took ' + str(time.time() - start) +
+              #' to compute FS error operator and info')
 
-        print('SO mask bound: ' + str(so_norm_bound))
-        print('FS mask bound: ' + str(fs_norm_bound))
+        #print('SO mask bound: ' + str(so_norm_bound))
+        #print('FS mask bound: ' + str(fs_norm_bound))
 
-        if compare_with_old_code:
-            start = time.time()
+        #if compare_with_old_code:
+            #start = time.time()
 
-            # Unpack result into terms, indices they act on, and whether
-            # they're hopping operators.
-            result = simulation_ordered_grouped_low_depth_terms_with_info(
-                hamiltonian)
-            terms, indices, is_hopping = result
+            ## Unpack result into terms, indices they act on, and whether
+            ## they're hopping operators.
+            #result = simulation_ordered_grouped_low_depth_terms_with_info(
+                #hamiltonian)
+            #terms, indices, is_hopping = result
 
-            old_error_operator = low_depth_second_order_trotter_error_operator(
-                terms, indices, is_hopping, jellium_only=True)
+            #old_error_operator = low_depth_second_order_trotter_error_operator(
+                #terms, indices, is_hopping, jellium_only=True)
 
-            print('Regular FS bound: ',
-                  low_depth_second_order_trotter_error_bound(
-                      terms, indices, is_hopping, jellium_only=True))
-            print('Took ' + str(time.time() - start) +
-                  ' to compute FS with old code')
+            #print('Regular FS bound: ',
+                  #low_depth_second_order_trotter_error_bound(
+                      #terms, indices, is_hopping, jellium_only=True))
+            #print('Took ' + str(time.time() - start) +
+                  #' to compute FS with old code')
 
-            old_error_operator -= error_operator
-            print('Difference between old and new methods:',
-                  numpy.sum(numpy.absolute(list(
-                      old_error_operator.terms.values()))))
+            #old_error_operator -= error_operator
+            #print('Difference between old and new methods:',
+                  #numpy.sum(numpy.absolute(list(
+                      #old_error_operator.terms.values()))))

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -148,6 +148,13 @@ class BitMaskModesActedOnByFermionTermsTest(unittest.TestCase):
 
         self.assertTrue(numpy.array_equal(mask, expected_mask))
 
+    def test_bit_mask_n_qubits_not_specified(self):
+        mask = bit_mask_of_modes_acted_on_by_fermionic_terms(
+            [FermionOperator('0^ 0') + FermionOperator('2^ 2')])
+
+        self.assertTrue(numpy.array_equal(mask, numpy.array(
+            [[True], [False], [True]])))
+
 
 class FermionicSwapNetworkTrotterErrorTest(unittest.TestCase):
 

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -291,7 +291,3 @@ class SplitOperatorTrotterErrorTest(unittest.TestCase):
             list(VT_error_operator.terms.values())))
 
         self.assertGreater(VT_error_bound, TV_error_bound)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -335,3 +335,23 @@ class SplitOperatorTrotterErrorTest(unittest.TestCase):
             list(VT_error_operator.terms.values())))
 
         self.assertGreater(VT_error_bound, TV_error_bound)
+
+    def test_1d_jellium_wigner_seitz_10_VT_order_gives_larger_error(self):
+        hamiltonian = normal_ordered(jellium_model(
+            hypercube_grid_with_given_wigner_seitz_radius_and_filling(
+                1, 5, wigner_seitz_radius=10.,
+                spinless=True), spinless=True, plane_wave=False))
+
+        TV_error_operator = (
+            split_operator_trotter_error_operator_diagonal_two_body(
+                hamiltonian, order='T+V'))
+        TV_error_bound = numpy.sum(numpy.absolute(
+            list(TV_error_operator.terms.values())))
+
+        VT_error_operator = (
+            split_operator_trotter_error_operator_diagonal_two_body(
+                hamiltonian, order='V+T'))
+        VT_error_bound = numpy.sum(numpy.absolute(
+            list(VT_error_operator.terms.values())))
+
+        self.assertGreater(VT_error_bound, TV_error_bound)

--- a/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
+++ b/src/openfermion/utils/_diagonal_coulomb_trotter_error_test.py
@@ -1,0 +1,109 @@
+import time
+import unittest
+
+from openfermion import normal_ordered
+
+from openfermion.hamiltonians import (
+    fermi_hubbard,
+    jellium_model,
+    hypercube_grid_with_given_wigner_seitz_radius_and_filling)
+from openfermion.utils._low_depth_trotter_error import (
+    low_depth_second_order_trotter_error_bound,
+    low_depth_second_order_trotter_error_operator)
+from openfermion.utils._diagonal_coulomb_trotter_error import (
+    potential_and_kinetic_terms_as_arrays,
+    bit_mask_of_modes_acted_on_by_fermionic_terms,
+    split_operator_trotter_error_operator_diagonal_two_body,
+    fermionic_swap_trotter_error_operator_diagonal_two_body)
+
+
+if __name__ == '__main__':
+    compare_with_old_code = True
+
+    dimension = 2
+    side_length = int(sys.argv[1])
+    tunneling = 1.0
+    periodic = True
+
+    jellium = False
+
+    coulomb_data_points = numpy.array([4.])
+    fs_error_bounds = numpy.zeros(len(coulomb_data_points))
+    fs_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+    so_error_bounds = numpy.zeros(len(coulomb_data_points))
+    so_n_terms = numpy.zeros(len(coulomb_data_points), dtype=int)
+
+    for i, coulomb in enumerate(coulomb_data_points):
+        print('For 2D Fermi-Hubbard with side length %i, coulomb = %f:' % (
+            side_length, coulomb))
+
+        start = time.time()
+        if jellium:
+            hamiltonian = normal_ordered(jellium_model(
+                hypercube_grid_with_given_wigner_seitz_radius_and_filling(
+                    dimension, side_length, wigner_seitz_radius=10.,
+                    spinless=True), spinless=True,
+                plane_wave=False))
+            order = 'T+V'
+        else:
+            hamiltonian = normal_ordered(
+                fermi_hubbard(side_length, side_length,
+                              tunneling, coulomb, periodic=periodic))
+            order = 'V+T'
+
+        hamiltonian.compress()
+        print('Got Hamiltonian in %s' % str(time.time() - start))
+
+        start = time.time()
+        error_operator = (
+            split_operator_trotter_error_operator_diagonal_two_body(
+                hamiltonian, order))
+        error_operator.compress()
+
+        so_norm_bound = numpy.sum(numpy.absolute(
+            list(error_operator.terms.values())))
+
+        so_n_terms[i] = len(error_operator.terms)
+        so_error_bounds[i] = so_norm_bound
+        print('Took ' + str(time.time() - start) +
+              ' to compute SO error operator and info')
+
+        start = time.time()
+        error_operator = (
+            fermionic_swap_trotter_error_operator_diagonal_two_body(
+                hamiltonian))
+        error_operator.compress()
+
+        fs_norm_bound = numpy.sum(numpy.absolute(
+            list(error_operator.terms.values())))
+
+        fs_n_terms[i] = len(error_operator.terms)
+        fs_error_bounds[i] = fs_norm_bound
+        print('Took ' + str(time.time() - start) +
+              ' to compute FS error operator and info')
+
+        print('SO mask bound: ' + str(so_norm_bound))
+        print('FS mask bound: ' + str(fs_norm_bound))
+
+        if compare_with_old_code:
+            start = time.time()
+
+            # Unpack result into terms, indices they act on, and whether
+            # they're hopping operators.
+            result = simulation_ordered_grouped_low_depth_terms_with_info(
+                hamiltonian)
+            terms, indices, is_hopping = result
+
+            old_error_operator = low_depth_second_order_trotter_error_operator(
+                terms, indices, is_hopping, jellium_only=True)
+
+            print('Regular FS bound: ',
+                  low_depth_second_order_trotter_error_bound(
+                      terms, indices, is_hopping, jellium_only=True))
+            print('Took ' + str(time.time() - start) +
+                  ' to compute FS with old code')
+
+            old_error_operator -= error_operator
+            print('Difference between old and new methods:',
+                  numpy.sum(numpy.absolute(list(
+                      old_error_operator.terms.values()))))


### PR DESCRIPTION
Computes Trotter error operators for both the split-operator and fermionic swap network Trotter steps.

The fermionic swap network functionality covers the same use cases as in https://github.com/quantumlib/OpenFermion/blob/master/src/openfermion/utils/_low_depth_trotter_error.py, though the new code is quite a bit faster. That code is much simpler, so I'm not sure we should replace it outright, though we probably could. The new split-operator code uses similar tricks to get a comparable speedup, though evaluating the split-operator Trotter error should be easier in general since there are effectively only two terms in the Trotter ordering.

The highest speedup I've seen so far in testing is ~200x for the 32x32 Hubbard model.