### PR TITLE
Refactor Hubbard module

### DIFF
--- a/src/openfermion/_version.py
+++ b/src/openfermion/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.8"
+__version__ = "0.8.1"

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -13,8 +13,7 @@
 """This module constructs Hamiltonians for the Fermi-Hubbard model."""
 
 from openfermion.ops import FermionOperator, BosonOperator
-from openfermion.utils import (hermitian_conjugated, number_operator,
-                               up_index, down_index)
+from openfermion.utils import number_operator, up_index, down_index
 
 
 def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -135,6 +135,13 @@ def _spinful_fermi_hubbard_model(
         bottom_neighbor = _bottom_neighbor(
                 site, x_dimension, y_dimension, periodic)
 
+        # Avoid double-counting edges when one of the dimensions is 2
+        # and the system is periodic
+        if x_dimension == 2 and periodic and site % 2 == 1:
+            right_neighbor = None
+        if y_dimension == 2 and periodic and site >= x_dimension:
+            bottom_neighbor = None
+
         # Add hopping terms with neighbors to the right and bottom.
         if right_neighbor is not None:
             hubbard_model += _hopping_term(
@@ -180,6 +187,13 @@ def _spinless_fermi_hubbard_model(
                 site, x_dimension, y_dimension, periodic)
         bottom_neighbor = _bottom_neighbor(
                 site, x_dimension, y_dimension, periodic)
+
+        # Avoid double-counting edges when one of the dimensions is 2
+        # and the system is periodic
+        if x_dimension == 2 and periodic and site % 2 == 1:
+            right_neighbor = None
+        if y_dimension == 2 and periodic and site >= x_dimension:
+            bottom_neighbor = None
 
         # Add terms that couple with neighbors to the right and bottom.
         if right_neighbor is not None:
@@ -261,6 +275,13 @@ def bose_hubbard(x_dimension, y_dimension, tunneling, interaction,
                 site, x_dimension, y_dimension, periodic)
         bottom_neighbor = _bottom_neighbor(
                 site, x_dimension, y_dimension, periodic)
+
+        # Avoid double-counting edges when one of the dimensions is 2
+        # and the system is periodic
+        if x_dimension == 2 and periodic and site % 2 == 1:
+            right_neighbor = None
+        if y_dimension == 2 and periodic and site >= x_dimension:
+            bottom_neighbor = None
 
         # Add terms that couple with neighbors to the right and bottom.
         if right_neighbor is not None:

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -218,10 +218,10 @@ def bose_hubbard(x_dimension, y_dimension, tunneling, interaction,
 
     .. math::
 
-        H = - t \sum_{\langle i, j \rangle} b_i^\dagger b_{j + 1}
-         + \frac{U}{2} \sum_{k=1}^{N-1} b_k^\dagger b_k (b_k^\dagger b_k - 1)
-         - \mu \sum_{k=1}^N b_k^\dagger b_k
-         + V \sum_{\langle i, j \rangle} b_i^\dagger b_i b_j^\dagger b_j.
+        H = - t \sum_{\langle i, j \rangle} (b_i^\dagger b_j + b_j^\dagger b_i)
+         + V \sum_{\langle i, j \rangle} b_i^\dagger b_i b_j^\dagger b_j
+         + \frac{U}{2} \sum_i b_i^\dagger b_i (b_i^\dagger b_i - 1)
+         - \mu \sum_i b_i^\dagger b_i.
 
     where
 

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -88,18 +88,13 @@ def _hubbard(parity, x_dimension, y_dimension, tunneling, local_interaction,
             hubbard_model += coulomb * operator_1 * operator_2
 
         # Index coupled orbitals.
-        right_neighbor = site + 1
-        bottom_neighbor = site + x_dimension
-
-        # Account for periodic boundaries.
-        if periodic:
-            if (x_dimension > 2) and ((site + 1) % x_dimension == 0):
-                right_neighbor -= x_dimension
-            if (y_dimension > 2) and (site + x_dimension + 1 > n_sites):
-                bottom_neighbor -= x_dimension * y_dimension
+        right_neighbor = _right_neighbor(
+                site, x_dimension, y_dimension, periodic)
+        bottom_neighbor = _bottom_neighbor(
+                site, x_dimension, y_dimension, periodic)
 
         # Add transition to neighbor on right.
-        if (right_neighbor) % x_dimension or (periodic and x_dimension > 2):
+        if right_neighbor % x_dimension or periodic and x_dimension > 2:
             if spinless:
                 # Add Coulomb term.
                 operator_1 = number_operator(
@@ -128,7 +123,7 @@ def _hubbard(parity, x_dimension, y_dimension, tunneling, local_interaction,
             hubbard_model += hermitian_conjugated(hopping_term)
 
         # Add transition to neighbor below.
-        if site + x_dimension + 1 <= n_sites or (periodic and y_dimension > 2):
+        if site + x_dimension + 1 <= n_sites or periodic and y_dimension > 2:
             if spinless:
                 # Add Coulomb term.
                 operator_1 = number_operator(
@@ -301,3 +296,18 @@ def bose_hubbard(x_dimension, y_dimension, tunneling, interaction,
                     chemical_potential, magnetic_field=0,
                     periodic=periodic, spinless=True,
                     particle_hole_symmetry=False)
+
+
+def _right_neighbor(site, x_dimension, y_dimension, periodic):
+    right_neighbor = site + 1
+    if periodic and x_dimension > 2 and (site + 1) % x_dimension == 0:
+        right_neighbor -= x_dimension
+    return right_neighbor
+
+
+def _bottom_neighbor(site, x_dimension, y_dimension, periodic):
+    bottom_neighbor = site + x_dimension
+    if (periodic and y_dimension > 2 and
+            site + x_dimension + 1 > x_dimension*y_dimension):
+        bottom_neighbor -= x_dimension * y_dimension
+    return bottom_neighbor

--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -10,7 +10,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""This module constructs Hamiltonians for the Fermi-Hubbard model."""
+"""This module constructs Hamiltonians for the Fermi- and Bose-Hubbard models.
+"""
 
 from openfermion.ops import FermionOperator, BosonOperator
 from openfermion.utils import number_operator, up_index, down_index

--- a/src/openfermion/hamiltonians/_hubbard_test.py
+++ b/src/openfermion/hamiltonians/_hubbard_test.py
@@ -11,284 +11,378 @@
 #   limitations under the License.
 
 """Tests for Hubbard model module."""
-from __future__ import absolute_import
 
-import unittest
-
-from openfermion.hamiltonians import (bose_hubbard,
-                                      fermi_hubbard)
+from openfermion.hamiltonians import bose_hubbard, fermi_hubbard
 
 
-class FermiHubbardTest(unittest.TestCase):
+def test_fermi_hubbard_2x2_spinless():
+    hubbard_model = fermi_hubbard(
+            2, 2, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+4.0 [0^ 0 2^ 2] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 3^ 3] +
+-1.0 [1^ 3] +
+-1.0 [2^ 0] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+-1.0 [2^ 3] +
+-1.0 [3^ 1] +
+-1.0 [3^ 2] +
+-0.5 [3^ 3]
+""".strip()
 
-    def setUp(self):
-        self.x_dimension = 2
-        self.y_dimension = 2
-        self.tunneling = 2.
-        self.coulomb = 1.
-        self.magnetic_field = 0.5
-        self.chemical_potential = 0.25
-        self.periodic = 0
-        self.spinless = 0
+def test_fermi_hubbard_2x3_spinless():
+    hubbard_model = fermi_hubbard(
+            2, 3, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+4.0 [0^ 0 2^ 2] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 3^ 3] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [2^ 0] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+4.0 [2^ 2 4^ 4] +
+-1.0 [2^ 3] +
+-1.0 [2^ 4] +
+-1.0 [3^ 1] +
+-1.0 [3^ 2] +
+-0.5 [3^ 3] +
+4.0 [3^ 3 5^ 5] +
+-1.0 [3^ 5] +
+-1.0 [4^ 0] +
+-1.0 [4^ 2] +
+-0.5 [4^ 4] +
+4.0 [4^ 4 0^ 0] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 5] +
+-1.0 [5^ 1] +
+-1.0 [5^ 3] +
+-1.0 [5^ 4] +
+-0.5 [5^ 5] +
+4.0 [5^ 5 1^ 1]
+""".strip()
 
-    def test_two_by_two_spinless(self):
+def test_fermi_hubbard_3x2_spinless():
+    hubbard_model = fermi_hubbard(
+            3, 2, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+4.0 [0^ 0 3^ 3] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 3] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 2^ 2] +
+4.0 [1^ 1 4^ 4] +
+-1.0 [1^ 2] +
+-1.0 [1^ 4] +
+-1.0 [2^ 0] +
+-1.0 [2^ 1] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 0^ 0] +
+4.0 [2^ 2 5^ 5] +
+-1.0 [2^ 5] +
+-1.0 [3^ 0] +
+-0.5 [3^ 3] +
+4.0 [3^ 3 4^ 4] +
+-1.0 [3^ 4] +
+-1.0 [3^ 5] +
+-1.0 [4^ 1] +
+-1.0 [4^ 3] +
+-0.5 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 5] +
+-1.0 [5^ 2] +
+-1.0 [5^ 3] +
+-1.0 [5^ 4] +
+-0.5 [5^ 5] +
+4.0 [5^ 5 3^ 3]
+""".strip()
 
-        # Initialize the Hamiltonian.
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            self.periodic, spinless=True)
+def test_fermi_hubbard_2x2_spinful():
+    hubbard_model = fermi_hubbard(
+            2, 2, 1.0, 4.0,
+            chemical_potential=0.5,
+            magnetic_field=0.3,
+            spinless=False)
+    assert str(hubbard_model).strip() == """
+-0.8 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-0.2 [1^ 1] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [2^ 0] +
+-0.8 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+-1.0 [2^ 6] +
+-1.0 [3^ 1] +
+-0.2 [3^ 3] +
+-1.0 [3^ 7] +
+-1.0 [4^ 0] +
+-0.8 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 6] +
+-1.0 [5^ 1] +
+-0.2 [5^ 5] +
+-1.0 [5^ 7] +
+-1.0 [6^ 2] +
+-1.0 [6^ 4] +
+-0.8 [6^ 6] +
+4.0 [6^ 6 7^ 7] +
+-1.0 [7^ 3] +
+-1.0 [7^ 5] +
+-0.2 [7^ 7]
+""".strip()
 
-        # Check on site terms and magnetic field.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0))], -0.25)
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (1, 0))], -0.25)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0))], -0.25)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (3, 0))], -0.25)
+def test_fermi_hubbard_2x2_spinful_phs():
+    hubbard_model = fermi_hubbard(
+            2, 2, 1.0, 4.0,
+            chemical_potential=0.5,
+            magnetic_field=0.3,
+            spinless=False,
+            particle_hole_symmetry=True)
+    assert str(hubbard_model).strip() == """
+4.0 [] +
+-2.8 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-2.2 [1^ 1] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [2^ 0] +
+-2.8 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+-1.0 [2^ 6] +
+-1.0 [3^ 1] +
+-2.2 [3^ 3] +
+-1.0 [3^ 7] +
+-1.0 [4^ 0] +
+-2.8 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 6] +
+-1.0 [5^ 1] +
+-2.2 [5^ 5] +
+-1.0 [5^ 7] +
+-1.0 [6^ 2] +
+-1.0 [6^ 4] +
+-2.8 [6^ 6] +
+4.0 [6^ 6 7^ 7] +
+-1.0 [7^ 3] +
+-1.0 [7^ 5] +
+-2.2 [7^ 7]
+""".strip()
 
-        # Check right/left hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (2, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (3, 0))], -2.)
-
-        # Check top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (2, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (3, 0))], -2.)
-
-        # Check left/right Coulomb terms.
-        self.assertAlmostEqual(
-            hubbard_model.terms[((0, 1), (0, 0), (1, 1), (1, 0))], 1.)
-        self.assertAlmostEqual(
-            hubbard_model.terms[((2, 1), (2, 0), (3, 1), (3, 0))], 1.)
-
-        # Check top/bottom Coulomb terms.
-        self.assertAlmostEqual(
-            hubbard_model.terms[((0, 1), (0, 0), (2, 1), (2, 0))], 1.)
-        self.assertAlmostEqual(
-            hubbard_model.terms[((1, 1), (1, 0), (3, 1), (3, 0))], 1.)
-
-        # Check that there are no other Coulomb terms.
-        self.assertNotIn(((0, 1), (0, 0), (3, 1), (3, 0)),
-                         hubbard_model.terms)
-        self.assertNotIn(((1, 1), (1, 0), (2, 1), (2, 0)),
-                         hubbard_model.terms)
-
-    def test_two_by_two_spinful(self):
-        # Initialize the Hamiltonian.
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            self.periodic, self.spinless, False)
-
-        # Check up spin on site terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0))], -.75)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0))], -.75)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0))], -.75)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0))], -.75)
-
-        # Check down spin on site terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (1, 0))], .25)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (3, 0))], .25)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (5, 0))], .25)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (7, 0))], .25)
-
-        # Check up right/left hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (2, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (6, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (4, 0))], -2.)
-
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (4, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (6, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (2, 0))], -2.)
-
-        # Check down right/left hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (3, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (7, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (5, 0))], -2.)
-
-        # Check down top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (5, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((5, 1), (1, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((3, 1), (7, 0))], -2.)
-        self.assertAlmostEqual(hubbard_model.terms[((7, 1), (3, 0))], -2.)
-
-        # Check on site interaction term.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (0, 0),
-                                                    (1, 1), (1, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (2, 0),
-                                                    (3, 1), (3, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (4, 0),
-                                                    (5, 1), (5, 0))], 1.)
-        self.assertAlmostEqual(hubbard_model.terms[((6, 1), (6, 0),
-                                                    (7, 1), (7, 0))], 1.)
-
-    def test_two_by_two_spinful_phs(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            self.periodic, self.spinless, False)
-
-        hubbard_model_phs = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            self.periodic, self.spinless, True)
-
-        # Compute difference between the models with and without
-        # spin symmetry.
-        difference = hubbard_model_phs - hubbard_model
-
-        # Check constant term in difference.
-        self.assertAlmostEqual(difference.terms[()], 1.0)
-
-        # Check up spin on site terms in difference.
-        self.assertAlmostEqual(difference.terms[((0, 1), (0, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((2, 1), (2, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((4, 1), (4, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((6, 1), (6, 0))], -.50)
-
-        # Check down spin on site terms in difference.
-        self.assertAlmostEqual(difference.terms[((1, 1), (1, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((3, 1), (3, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((5, 1), (5, 0))], -.50)
-        self.assertAlmostEqual(difference.terms[((7, 1), (7, 0))], -.50)
-
-    def test_two_by_two_spinful_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=False, particle_hole_symmetry=False)
-
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=False, particle_hole_symmetry=True)
-
-    def test_two_by_two_spinful_aperiodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=False, spinless=False, particle_hole_symmetry=False)
-
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=False, spinless=False, particle_hole_symmetry=True)
-
-    def test_two_by_two_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True, particle_hole_symmetry=False)
-
-        hubbard_model = fermi_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True, particle_hole_symmetry=True)
-
-    def test_two_by_three_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            2, 3, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True, particle_hole_symmetry=False)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((4, 1), (0, 0))],
-                               -self.tunneling)
-
-    def test_three_by_two_spinless_periodic_rudimentary(self):
-        hubbard_model = fermi_hubbard(
-            3, 2, self.tunneling, self.coulomb,
-            self.chemical_potential, self.magnetic_field,
-            periodic=True, spinless=True, particle_hole_symmetry=False)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (0, 0))],
-                               -self.tunneling)
+def test_fermi_hubbard_2x2_spinful_aperiodic():
+    hubbard_model = fermi_hubbard(
+            2, 2, 1.0, 4.0,
+            chemical_potential=0.5,
+            magnetic_field=0.3,
+            spinless=False,
+            periodic=False)
+    assert str(hubbard_model).strip() == """
+-0.8 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-0.2 [1^ 1] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [2^ 0] +
+-0.8 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+-1.0 [2^ 6] +
+-1.0 [3^ 1] +
+-0.2 [3^ 3] +
+-1.0 [3^ 7] +
+-1.0 [4^ 0] +
+-0.8 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 6] +
+-1.0 [5^ 1] +
+-0.2 [5^ 5] +
+-1.0 [5^ 7] +
+-1.0 [6^ 2] +
+-1.0 [6^ 4] +
+-0.8 [6^ 6] +
+4.0 [6^ 6 7^ 7] +
+-1.0 [7^ 3] +
+-1.0 [7^ 5] +
+-0.2 [7^ 7]
+""".strip()
 
 
-class BoseHubbardTest(unittest.TestCase):
+def test_bose_hubbard_2x2():
+    hubbard_model = bose_hubbard(
+        2, 2, 1.0, 4.0,
+        chemical_potential=0.5,
+        dipole=0.3)
+    assert str(hubbard_model).strip() == """
+-1.0 [0 1^] +
+-1.0 [0 2^] +
+-2.5 [0^ 0] +
+2.0 [0^ 0 0^ 0] +
+0.3 [0^ 0 1^ 1] +
+0.3 [0^ 0 2^ 2] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [1 3^] +
+-2.5 [1^ 1] +
+2.0 [1^ 1 1^ 1] +
+0.3 [1^ 1 3^ 3] +
+-1.0 [1^ 3] +
+-1.0 [2 3^] +
+-2.5 [2^ 2] +
+2.0 [2^ 2 2^ 2] +
+0.3 [2^ 2 3^ 3] +
+-1.0 [2^ 3] +
+-2.5 [3^ 3] +
+2.0 [3^ 3 3^ 3]
+""".strip()
 
-    def setUp(self):
-        self.x_dimension = 2
-        self.y_dimension = 2
-        self.tunneling = 2.
-        self.interaction = 1.
-        self.chemical_potential = 0.25
-        self.dipole = 1.
-        self.periodic = 0
+def test_bose_hubbard_2x3():
+    hubbard_model = bose_hubbard(
+        2, 3, 1.0, 4.0,
+        chemical_potential=0.5,
+        dipole=0.3)
+    assert str(hubbard_model).strip() == """
+-1.0 [0 1^] +
+-1.0 [0 2^] +
+-1.0 [0 4^] +
+-2.5 [0^ 0] +
+2.0 [0^ 0 0^ 0] +
+0.3 [0^ 0 1^ 1] +
+0.3 [0^ 0 2^ 2] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-1.0 [1 3^] +
+-1.0 [1 5^] +
+-2.5 [1^ 1] +
+2.0 [1^ 1 1^ 1] +
+0.3 [1^ 1 3^ 3] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [2 3^] +
+-1.0 [2 4^] +
+-2.5 [2^ 2] +
+2.0 [2^ 2 2^ 2] +
+0.3 [2^ 2 3^ 3] +
+0.3 [2^ 2 4^ 4] +
+-1.0 [2^ 3] +
+-1.0 [2^ 4] +
+-1.0 [3 5^] +
+-2.5 [3^ 3] +
+2.0 [3^ 3 3^ 3] +
+0.3 [3^ 3 5^ 5] +
+-1.0 [3^ 5] +
+-1.0 [4 5^] +
+-2.5 [4^ 4] +
+0.3 [4^ 4 0^ 0] +
+2.0 [4^ 4 4^ 4] +
+0.3 [4^ 4 5^ 5] +
+-1.0 [4^ 5] +
+-2.5 [5^ 5] +
+0.3 [5^ 5 1^ 1] +
+2.0 [5^ 5 5^ 5]
+""".strip()
 
-    def test_two_by_two(self):
+def test_bose_hubbard_3x2():
+    hubbard_model = bose_hubbard(
+        3, 2, 1.0, 4.0,
+        chemical_potential=0.5,
+        dipole=0.3)
+    assert str(hubbard_model).strip() == """
+-1.0 [0 1^] +
+-1.0 [0 2^] +
+-1.0 [0 3^] +
+-2.5 [0^ 0] +
+2.0 [0^ 0 0^ 0] +
+0.3 [0^ 0 1^ 1] +
+0.3 [0^ 0 3^ 3] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 3] +
+-1.0 [1 2^] +
+-1.0 [1 4^] +
+-2.5 [1^ 1] +
+2.0 [1^ 1 1^ 1] +
+0.3 [1^ 1 2^ 2] +
+0.3 [1^ 1 4^ 4] +
+-1.0 [1^ 2] +
+-1.0 [1^ 4] +
+-1.0 [2 5^] +
+-2.5 [2^ 2] +
+0.3 [2^ 2 0^ 0] +
+2.0 [2^ 2 2^ 2] +
+0.3 [2^ 2 5^ 5] +
+-1.0 [2^ 5] +
+-1.0 [3 4^] +
+-1.0 [3 5^] +
+-2.5 [3^ 3] +
+2.0 [3^ 3 3^ 3] +
+0.3 [3^ 3 4^ 4] +
+-1.0 [3^ 4] +
+-1.0 [3^ 5] +
+-1.0 [4 5^] +
+-2.5 [4^ 4] +
+2.0 [4^ 4 4^ 4] +
+0.3 [4^ 4 5^ 5] +
+-1.0 [4^ 5] +
+-2.5 [5^ 5] +
+0.3 [5^ 5 3^ 3] +
+2.0 [5^ 5 5^ 5]
+""".strip()
 
-        # Initialize the Hamiltonian.
-        hubbard_model = bose_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling,
-            self.interaction, self.chemical_potential, self.dipole,
-            self.periodic)
-
-        # Check on on-site interaction and chemical-potential terms.
-        chem_coeff = -self.interaction/2 - self.chemical_potential
-        on_site_coeff = self.interaction/2
-        for i in range(4):
-            self.assertAlmostEqual(
-                hubbard_model.terms[((i, 1), (i, 0))], chem_coeff)
-            self.assertAlmostEqual(
-                hubbard_model.terms[((i, 1), (i, 0), (i, 1), (i, 0))],
-                on_site_coeff)
-
-        # Check right/left hopping terms.
-        t_coeff = -self.tunneling
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (1, 0))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((0, 0), (1, 1))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 0), (3, 1))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((2, 1), (3, 0))], t_coeff)
-
-        # Check top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 1), (2, 0))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((0, 0), (2, 1))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((1, 0), (3, 1))], t_coeff)
-        self.assertAlmostEqual(hubbard_model.terms[((1, 1), (3, 0))], t_coeff)
-
-        # Check left/right dipole interaction terms.
-        d_coeff = self.dipole
-        self.assertAlmostEqual(
-            hubbard_model.terms[((0, 1), (0, 0), (1, 1), (1, 0))], d_coeff)
-        self.assertAlmostEqual(
-            hubbard_model.terms[((2, 1), (2, 0), (3, 1), (3, 0))], d_coeff)
-
-        # Check top/bottom interaction terms.
-        self.assertAlmostEqual(
-            hubbard_model.terms[((0, 1), (0, 0), (2, 1), (2, 0))], d_coeff)
-        self.assertAlmostEqual(
-            hubbard_model.terms[((1, 1), (1, 0), (3, 1), (3, 0))], d_coeff)
-
-        # Check that there are no other interaction terms.
-        self.assertNotIn(((0, 1), (0, 0), (3, 1), (3, 0)),
-                         hubbard_model.terms)
-        self.assertNotIn(((1, 1), (1, 0), (2, 1), (2, 0)),
-                         hubbard_model.terms)
-
-    def test_two_by_two_periodic_rudimentary(self):
-        hubbard_model = bose_hubbard(
-            self.x_dimension, self.y_dimension, self.tunneling,
-            self.interaction, self.chemical_potential, self.dipole,
-            periodic=True)
-
-    def test_two_by_three_periodic_rudimentary(self):
-        hubbard_model = bose_hubbard(
-            2, 3, self.tunneling, self.interaction,
-            self.chemical_potential, self.dipole, periodic=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 0), (4, 1))],
-                               -self.tunneling)
-
-    def test_three_by_two_periodic_rudimentary(self):
-        hubbard_model = bose_hubbard(
-            3, 2, self.tunneling, self.interaction,
-            self.chemical_potential, self.dipole, periodic=True)
-        # Check up top/bottom hopping terms.
-        self.assertAlmostEqual(hubbard_model.terms[((0, 0), (2, 1))],
-                               -self.tunneling)
+def test_bose_hubbard_2x2_aperiodic():
+    hubbard_model = bose_hubbard(
+        2, 2, 1.0, 4.0,
+        chemical_potential=0.5,
+        dipole=0.3,
+        periodic=False)
+    assert str(hubbard_model).strip() == """
+-1.0 [0 1^] +
+-1.0 [0 2^] +
+-2.5 [0^ 0] +
+2.0 [0^ 0 0^ 0] +
+0.3 [0^ 0 1^ 1] +
+0.3 [0^ 0 2^ 2] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [1 3^] +
+-2.5 [1^ 1] +
+2.0 [1^ 1 1^ 1] +
+0.3 [1^ 1 3^ 3] +
+-1.0 [1^ 3] +
+-1.0 [2 3^] +
+-2.5 [2^ 2] +
+2.0 [2^ 2 2^ 2] +
+0.3 [2^ 2 3^ 3] +
+-1.0 [2^ 3] +
+-2.5 [3^ 3] +
+2.0 [3^ 3 3^ 3]
+""".strip()

--- a/src/openfermion/hamiltonians/_hubbard_test.py
+++ b/src/openfermion/hamiltonians/_hubbard_test.py
@@ -15,6 +15,48 @@
 from openfermion.hamiltonians import bose_hubbard, fermi_hubbard
 
 
+def test_fermi_hubbard_1x3_spinless():
+    hubbard_model = fermi_hubbard(
+            1, 3, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 2^ 2] +
+-1.0 [1^ 2] +
+-1.0 [2^ 0] +
+-1.0 [2^ 1] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 0^ 0]
+""".strip()
+
+
+def test_fermi_hubbard_3x1_spinless():
+    hubbard_model = fermi_hubbard(
+            3, 1, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 2^ 2] +
+-1.0 [1^ 2] +
+-1.0 [2^ 0] +
+-1.0 [2^ 1] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 0^ 0]
+""".strip()
+
+
 def test_fermi_hubbard_2x2_spinless():
     hubbard_model = fermi_hubbard(
             2, 2, 1.0, 4.0,
@@ -38,6 +80,7 @@ def test_fermi_hubbard_2x2_spinless():
 -1.0 [3^ 2] +
 -0.5 [3^ 3]
 """.strip()
+
 
 def test_fermi_hubbard_2x3_spinless():
     hubbard_model = fermi_hubbard(
@@ -80,6 +123,7 @@ def test_fermi_hubbard_2x3_spinless():
 4.0 [5^ 5 1^ 1]
 """.strip()
 
+
 def test_fermi_hubbard_3x2_spinless():
     hubbard_model = fermi_hubbard(
             3, 2, 1.0, 4.0,
@@ -121,6 +165,79 @@ def test_fermi_hubbard_3x2_spinless():
 4.0 [5^ 5 3^ 3]
 """.strip()
 
+
+def test_fermi_hubbard_3x3_spinless():
+    hubbard_model = fermi_hubbard(
+            3, 3, 1.0, 4.0,
+            chemical_potential=0.5,
+            spinless=True)
+    assert str(hubbard_model).strip() == """
+-0.5 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+4.0 [0^ 0 3^ 3] +
+-1.0 [0^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 3] +
+-1.0 [0^ 6] +
+-1.0 [1^ 0] +
+-0.5 [1^ 1] +
+4.0 [1^ 1 2^ 2] +
+4.0 [1^ 1 4^ 4] +
+-1.0 [1^ 2] +
+-1.0 [1^ 4] +
+-1.0 [1^ 7] +
+-1.0 [2^ 0] +
+-1.0 [2^ 1] +
+-0.5 [2^ 2] +
+4.0 [2^ 2 0^ 0] +
+4.0 [2^ 2 5^ 5] +
+-1.0 [2^ 5] +
+-1.0 [2^ 8] +
+-1.0 [3^ 0] +
+-0.5 [3^ 3] +
+4.0 [3^ 3 4^ 4] +
+4.0 [3^ 3 6^ 6] +
+-1.0 [3^ 4] +
+-1.0 [3^ 5] +
+-1.0 [3^ 6] +
+-1.0 [4^ 1] +
+-1.0 [4^ 3] +
+-0.5 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+4.0 [4^ 4 7^ 7] +
+-1.0 [4^ 5] +
+-1.0 [4^ 7] +
+-1.0 [5^ 2] +
+-1.0 [5^ 3] +
+-1.0 [5^ 4] +
+-0.5 [5^ 5] +
+4.0 [5^ 5 3^ 3] +
+4.0 [5^ 5 8^ 8] +
+-1.0 [5^ 8] +
+-1.0 [6^ 0] +
+-1.0 [6^ 3] +
+-0.5 [6^ 6] +
+4.0 [6^ 6 0^ 0] +
+4.0 [6^ 6 7^ 7] +
+-1.0 [6^ 7] +
+-1.0 [6^ 8] +
+-1.0 [7^ 1] +
+-1.0 [7^ 4] +
+-1.0 [7^ 6] +
+-0.5 [7^ 7] +
+4.0 [7^ 7 1^ 1] +
+4.0 [7^ 7 8^ 8] +
+-1.0 [7^ 8] +
+-1.0 [8^ 2] +
+-1.0 [8^ 5] +
+-1.0 [8^ 6] +
+-1.0 [8^ 7] +
+-0.5 [8^ 8] +
+4.0 [8^ 8 2^ 2] +
+4.0 [8^ 8 6^ 6]
+""".strip()
+
+
 def test_fermi_hubbard_2x2_spinful():
     hubbard_model = fermi_hubbard(
             2, 2, 1.0, 4.0,
@@ -157,6 +274,71 @@ def test_fermi_hubbard_2x2_spinful():
 -1.0 [7^ 5] +
 -0.2 [7^ 7]
 """.strip()
+
+
+def test_fermi_hubbard_2x3_spinful():
+    hubbard_model = fermi_hubbard(
+            2, 3, 1.0, 4.0,
+            chemical_potential=0.5,
+            magnetic_field=0.3,
+            spinless=False)
+    assert str(hubbard_model).strip() == """
+-0.8 [0^ 0] +
+4.0 [0^ 0 1^ 1] +
+-1.0 [0^ 2] +
+-1.0 [0^ 4] +
+-1.0 [0^ 8] +
+-0.2 [1^ 1] +
+-1.0 [1^ 3] +
+-1.0 [1^ 5] +
+-1.0 [1^ 9] +
+-1.0 [2^ 0] +
+-0.8 [2^ 2] +
+4.0 [2^ 2 3^ 3] +
+-1.0 [2^ 6] +
+-1.0 [2^ 10] +
+-1.0 [3^ 1] +
+-0.2 [3^ 3] +
+-1.0 [3^ 7] +
+-1.0 [3^ 11] +
+-1.0 [4^ 0] +
+-0.8 [4^ 4] +
+4.0 [4^ 4 5^ 5] +
+-1.0 [4^ 6] +
+-1.0 [4^ 8] +
+-1.0 [5^ 1] +
+-0.2 [5^ 5] +
+-1.0 [5^ 7] +
+-1.0 [5^ 9] +
+-1.0 [6^ 2] +
+-1.0 [6^ 4] +
+-0.8 [6^ 6] +
+4.0 [6^ 6 7^ 7] +
+-1.0 [6^ 10] +
+-1.0 [7^ 3] +
+-1.0 [7^ 5] +
+-0.2 [7^ 7] +
+-1.0 [7^ 11] +
+-1.0 [8^ 0] +
+-1.0 [8^ 4] +
+-0.8 [8^ 8] +
+4.0 [8^ 8 9^ 9] +
+-1.0 [8^ 10] +
+-1.0 [9^ 1] +
+-1.0 [9^ 5] +
+-0.2 [9^ 9] +
+-1.0 [9^ 11] +
+-1.0 [10^ 2] +
+-1.0 [10^ 6] +
+-1.0 [10^ 8] +
+-0.8 [10^ 10] +
+4.0 [10^ 10 11^ 11] +
+-1.0 [11^ 3] +
+-1.0 [11^ 7] +
+-1.0 [11^ 9] +
+-0.2 [11^ 11]
+""".strip()
+
 
 def test_fermi_hubbard_2x2_spinful_phs():
     hubbard_model = fermi_hubbard(
@@ -196,6 +378,7 @@ def test_fermi_hubbard_2x2_spinful_phs():
 -1.0 [7^ 5] +
 -2.2 [7^ 7]
 """.strip()
+
 
 def test_fermi_hubbard_2x2_spinful_aperiodic():
     hubbard_model = fermi_hubbard(
@@ -264,6 +447,7 @@ def test_bose_hubbard_2x2():
 2.0 [3^ 3 3^ 3]
 """.strip()
 
+
 def test_bose_hubbard_2x3():
     hubbard_model = bose_hubbard(
         2, 3, 1.0, 4.0,
@@ -311,6 +495,7 @@ def test_bose_hubbard_2x3():
 2.0 [5^ 5 5^ 5]
 """.strip()
 
+
 def test_bose_hubbard_3x2():
     hubbard_model = bose_hubbard(
         3, 2, 1.0, 4.0,
@@ -357,6 +542,7 @@ def test_bose_hubbard_3x2():
 0.3 [5^ 5 3^ 3] +
 2.0 [5^ 5 5^ 5]
 """.strip()
+
 
 def test_bose_hubbard_2x2_aperiodic():
     hubbard_model = bose_hubbard(


### PR DESCRIPTION
I broke up the giant "general" Hubbard model function into separate functions for Bose-, spinful Fermi-, and spinless Fermi-Hubbard models, defining some helper functions used throughout. I think this greatly improves the source code readability.