### PR TITLE
Add option to specify spin sector when obtaining Bogoliubov transformation matrix

### DIFF
--- a/src/openfermion/hamiltonians/_hubbard.py
+++ b/src/openfermion/hamiltonians/_hubbard.py
@@ -13,8 +13,8 @@
 """This module constructs Hamiltonians for the Fermi- and Bose-Hubbard models.
 """
 
-from openfermion.ops import FermionOperator, BosonOperator
-from openfermion.utils import number_operator, up_index, down_index
+from openfermion.ops import BosonOperator, FermionOperator, down_index, up_index
+from openfermion.utils import number_operator
 
 
 def fermi_hubbard(x_dimension, y_dimension, tunneling, coulomb,

--- a/src/openfermion/hamiltonians/_mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/_mean_field_dwave.py
@@ -11,11 +11,9 @@
 #   limitations under the License.
 
 """This module constructs Hamiltonians for the BCS mean-field d-wave model."""
-from __future__ import absolute_import
 
-from openfermion.ops import FermionOperator
-from openfermion.utils import (hermitian_conjugated, number_operator,
-                               up_index, down_index)
+from openfermion.ops import FermionOperator, down_index, up_index
+from openfermion.utils import hermitian_conjugated, number_operator
 
 
 def mean_field_dwave(x_dimension, y_dimension, tunneling, sc_gap,

--- a/src/openfermion/ops/__init__.py
+++ b/src/openfermion/ops/__init__.py
@@ -12,6 +12,7 @@
 
 from ._binary_polynomial import BinaryPolynomial
 from ._diagonal_coulomb_hamiltonian import DiagonalCoulombHamiltonian
+from ._indexing import down_index, up_index
 from ._polynomial_tensor import PolynomialTensor, general_basis_change
 from ._quadratic_hamiltonian import QuadraticHamiltonian
 from ._symbolic_operator import SymbolicOperator

--- a/src/openfermion/ops/_indexing.py
+++ b/src/openfermion/ops/_indexing.py
@@ -1,0 +1,37 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Defines index mappings."""
+
+
+def up_index(index):
+    """Function to return up-orbital index given a spatial orbital index.
+
+    Args:
+        index (int): spatial orbital index
+
+    Returns:
+        An integer representing the index of the associated spin-up orbital
+    """
+    return 2 * index
+
+
+def down_index(index):
+    """Function to return down-orbital index given a spatial orbital index.
+
+    Args:
+        index (int): spatial orbital index
+
+    Returns:
+        An integer representing the index of the associated spin-down orbital
+    """
+    return 2 * index + 1

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -174,8 +174,8 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         self.assertTrue(
             normal_ordered(majorana_op) == fermion_operator)
 
-    def test_diagonalizing_bogoliubov_transform(self):
-        """Test getting the diagonalizing Bogoliubov transformation."""
+    def test_diagonalizing_bogoliubov_transform_non_particle_conserving(self):
+        """Test non-particle-conserving diagonalizing Bogoliubov transform."""
         hermitian_part = self.quad_ham_npc.combined_hermitian_part
         antisymmetric_part = self.quad_ham_npc.antisymmetric_part
         block_matrix = numpy.zeros((2 * self.n_qubits, 2 * self.n_qubits),
@@ -223,6 +223,37 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         for i in numpy.ndindex((self.n_qubits, self.n_qubits)):
             self.assertAlmostEqual(identity[i], constraint_matrix_1[i])
             self.assertAlmostEqual(0., constraint_matrix_2[i])
+
+    def test_diagonalizing_bogoliubov_transform_particle_conserving(self):
+        """Test particle-conserving diagonalizing Bogoliubov transform."""
+
+        # Spin-symmetric
+        quad_ham = random_quadratic_hamiltonian(
+                5, conserves_particle_number=True, expand_spin=True)
+        orbital_energies, _ = quad_ham.orbital_energies()
+
+        transformation_matrix = quad_ham.diagonalizing_bogoliubov_transform(
+                spin_symmetry=True)
+        numpy.testing.assert_allclose(
+                transformation_matrix.dot(
+                    quad_ham.combined_hermitian_part.T.dot(
+                        transformation_matrix.T.conj())),
+                numpy.diag(orbital_energies),
+                atol=1e-7)
+
+        # Not spin-symmetric
+        quad_ham = random_quadratic_hamiltonian(
+                5, conserves_particle_number=True, expand_spin=False)
+        orbital_energies, _ = quad_ham.orbital_energies()
+
+        transformation_matrix = quad_ham.diagonalizing_bogoliubov_transform(
+                spin_symmetry=False)
+        numpy.testing.assert_allclose(
+                transformation_matrix.dot(
+                    quad_ham.combined_hermitian_part.T.dot(
+                        transformation_matrix.T.conj())),
+                numpy.diag(orbital_energies),
+                atol=1e-7)
 
 
 class DiagonalizingCircuitTest(unittest.TestCase):

--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -49,8 +49,7 @@ from ._slater_determinants import (gaussian_state_preparation_circuit,
 from ._special_operators import (majorana_operator, number_operator,
                                  s_minus_operator, s_plus_operator,
                                  s_squared_operator,
-                                 sx_operator, sy_operator, sz_operator,
-                                 up_index, down_index)
+                                 sx_operator, sy_operator, sz_operator)
 
 from ._testing_utils import (haar_random_vector,
                              random_antisymmetric_matrix,

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -12,7 +12,6 @@
 
 """This module contains functions for compiling circuits to prepare
 Slater determinants and fermionic Gaussian states."""
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/openfermion/utils/_sparse_tools.py
+++ b/src/openfermion/utils/_sparse_tools.py
@@ -26,11 +26,10 @@ import scipy.sparse.linalg
 from openfermion.config import EQ_TOLERANCE
 from openfermion.ops import (FermionOperator, QuadraticHamiltonian,
                              QubitOperator, BosonOperator,
-                             QuadOperator)
+                             QuadOperator, up_index, down_index)
 from openfermion.utils import (count_qubits, gaussian_state_preparation_circuit,
                                is_hermitian,
-                               slater_determinant_preparation_circuit,
-                               up_index, down_index)
+                               slater_determinant_preparation_circuit)
 
 
 # Make global definitions.

--- a/src/openfermion/utils/_sparse_tools_test.py
+++ b/src/openfermion/utils/_sparse_tools_test.py
@@ -23,11 +23,11 @@ from scipy.special import comb
 
 from openfermion.hamiltonians import (fermi_hubbard, jellium_model,
                                       wigner_seitz_length_scale)
-from openfermion.ops import FermionOperator
+from openfermion.ops import FermionOperator, up_index, down_index
 from openfermion.transforms import (get_fermion_operator, get_sparse_operator,
                                     jordan_wigner)
-from openfermion.utils import (Grid, fourier_transform, normal_ordered,
-                               number_operator, up_index, down_index)
+from openfermion.utils import (
+        Grid, fourier_transform, normal_ordered, number_operator)
 from openfermion.utils._jellium_hf_state import (
     lowest_single_particle_energy_states)
 from openfermion.utils._linear_qubit_operator import LinearQubitOperator

--- a/src/openfermion/utils/_special_operators.py
+++ b/src/openfermion/utils/_special_operators.py
@@ -11,9 +11,11 @@
 #   limitations under the License.
 
 """Commonly used operators (mainly instances of SymbolicOperator)."""
+
 import numpy
-from openfermion.ops import (FermionOperator, BosonOperator)
 from six import string_types
+
+from openfermion.ops import BosonOperator, FermionOperator, down_index, up_index
 
 
 def up_index(index):

--- a/src/openfermion/utils/_testing_utils.py
+++ b/src/openfermion/utils/_testing_utils.py
@@ -155,17 +155,21 @@ def random_interaction_operator(
     return interaction_operator
 
 
-def random_quadratic_hamiltonian(n_qubits,
+def random_quadratic_hamiltonian(n_orbitals,
                                  conserves_particle_number=False,
                                  real=False,
+                                 expand_spin=False,
                                  seed=None):
     """Generate a random instance of QuadraticHamiltonian.
 
     Args:
-        n_qubits(int): the number of qubits
+        n_orbitals(int): the number of orbitals
         conserves_particle_number(bool): whether the returned Hamiltonian
             should conserve particle number
         real(bool): whether to use only real numbers
+        expand_spin: Whether to expand each orbital symmetrically into two
+            spin orbitals. Note that if this option is set to True, then
+            the total number of orbitals will be doubled.
 
     Returns:
         QuadraticHamiltonian
@@ -175,11 +179,18 @@ def random_quadratic_hamiltonian(n_qubits,
 
     constant = numpy.random.randn()
     chemical_potential = numpy.random.randn()
-    hermitian_mat = random_hermitian_matrix(n_qubits, real)
+    hermitian_mat = random_hermitian_matrix(n_orbitals, real)
+
     if conserves_particle_number:
         antisymmetric_mat = None
     else:
-        antisymmetric_mat = random_antisymmetric_matrix(n_qubits, real)
+        antisymmetric_mat = random_antisymmetric_matrix(n_orbitals, real)
+
+    if expand_spin:
+        hermitian_mat = numpy.kron(hermitian_mat, numpy.eye(2))
+        if antisymmetric_mat is not None:
+            antisymmetric_mat = numpy.kron(antisymmetric_mat, numpy.eye(2))
+
     return QuadraticHamiltonian(hermitian_mat, antisymmetric_mat,
                                 constant, chemical_potential)
 

--- a/src/openfermion/utils/_unitary_cc.py
+++ b/src/openfermion/utils/_unitary_cc.py
@@ -17,8 +17,7 @@ from __future__ import division
 import itertools
 
 import numpy
-from openfermion.ops import FermionOperator, QubitOperator
-from openfermion.utils import up_index, down_index
+from openfermion.ops import FermionOperator, QubitOperator, down_index, up_index
 
 
 def uccsd_generator(single_amplitudes, double_amplitudes, anti_hermitian=True):


### PR DESCRIPTION
Adds the `spin_sector` option to the `diagonalizing_bogoliubov_transform` method of QuadraticHamiltonian. Specifying an integer value will cause the method to assume that different spins don't interact, and will return a transformation matrix that has dimensions of half the number of modes, representing a tranformation of orbitals only with the specified spin. 0 for spin-up and 1 for spin-down.