### PR TITLE
Automatically detect spin symmetry in Bogoliubov transformation matrix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.11.0
+numpy>=1.13.0
 scipy>=1.1.0
 h5py>=2.8
 future

--- a/src/openfermion/ops/_quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/_quadratic_hamiltonian_test.py
@@ -239,6 +239,29 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         quad_ham = get_quadratic_hamiltonian(
                 reorder(get_fermion_operator(quad_ham), up_then_down))
 
+        orbital_energies, transformation_matrix, _ = (
+                quad_ham.diagonalizing_bogoliubov_transform()
+        )
+        max_upper_right = numpy.max(numpy.abs(transformation_matrix[:5, 5:]))
+        max_lower_left = numpy.max(numpy.abs(transformation_matrix[5:, :5]))
+
+        numpy.testing.assert_allclose(
+                orbital_energies[:5], orbital_energies[5:])
+        numpy.testing.assert_allclose(
+                transformation_matrix.dot(
+                    quad_ham.combined_hermitian_part.T.dot(
+                        transformation_matrix.T.conj())),
+                numpy.diag(orbital_energies),
+                atol=1e-7)
+        numpy.testing.assert_allclose(max_upper_right, 0.0)
+        numpy.testing.assert_allclose(max_lower_left, 0.0)
+
+        # Specific spin sector
+        quad_ham = random_quadratic_hamiltonian(
+                5, conserves_particle_number=True, expand_spin=True)
+        quad_ham = get_quadratic_hamiltonian(
+                reorder(get_fermion_operator(quad_ham), up_then_down))
+
         for spin_sector in range(2):
             orbital_energies, transformation_matrix, _ = (
                     quad_ham.diagonalizing_bogoliubov_transform(

--- a/src/openfermion/utils/_slater_determinants.py
+++ b/src/openfermion/utils/_slater_determinants.py
@@ -105,8 +105,7 @@ def gaussian_state_preparation_circuit(
         if occupied_orbitals is None:
             # The ground state is desired, so we fill the orbitals that have
             # negative energy
-            num_negative_energies = numpy.count_nonzero(orbital_energies < 0.0)
-            occupied_orbitals = range(num_negative_energies)
+            occupied_orbitals = numpy.where(orbital_energies < 0.0)[0]
 
         # Get the unitary rows which represent the Slater determinant
         slater_determinant_matrix = transformation_matrix[occupied_orbitals]
@@ -114,7 +113,7 @@ def gaussian_state_preparation_circuit(
         # Get the circuit description
         circuit_description = slater_determinant_preparation_circuit(
             slater_determinant_matrix)
-        start_orbitals = range(len(occupied_orbitals))
+        start_orbitals = occupied_orbitals
     else:
         # TODO implement this
         if spin_sector is not None:


### PR DESCRIPTION
If the quadratic Hamiltonian is block diagonal with two equal-sized blocks, then it will diagonalize each block separately. Note that in this case, the orbital energies will be sorted in ascending order within each block (rather than being all being sorted together).