### PR TITLE
Add README link to run Example Notebooks in MyBinder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Hamiltonians. For more information, see our
 
 
 Run the interactive Jupyter Notebooks on MyBinder:
+
 .. image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/quantumlib/OpenFermion/master?filepath=examples
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,11 @@ Hamiltonians. For more information, see our
 
 .. image:: https://img.shields.io/badge/python-2.7%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg
 
+
+Run the interactive Jupyter Notebooks on MyBinder:
+.. image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/quantumlib/OpenFermion/master?filepath=examples
+
 Plugins
 =======
 


### PR DESCRIPTION
The MyBinder website provides free, cloud-based hosting of jupyter notebooks, built from public git repos!! :)

I was able to just enter this repo's URL into the builder on https://mybinder.org/, and it correctly set up the repo based on the Dockerfile and everything seems to work! :) This means with one-click, people can open a browser-based environment and start interacting with the tutorial! :)


Sorry i've never contributed to this Repo before, but i was curious to try this out. The easiest way for me to get started was to plug it in to MyBinder, and so i thought i'd share that back with you!!