### PR TITLE
Hamiltonian separation by stabilizers and QSE tools

### DIFF
--- a/src/openfermion/measurements/__init__.py
+++ b/src/openfermion/measurements/__init__.py
@@ -15,6 +15,11 @@ from ._equality_constraint_projection import (apply_constraints,
                                               linearize_term,
                                               unlinearize_term)
 
+from ._hamiltonian_stabilizers_sets import (get_hamiltonian_subsets)
+
+from ._quantum_subspace_expansion import (calculate_qse_spectrum,
+                                          get_additional_operators)
+
 from ._rdm_equality_constraints import (one_body_fermion_constraints,
                                         two_body_fermion_constraints)
 

--- a/src/openfermion/measurements/_hamiltonian_stabilizers_sets.py
+++ b/src/openfermion/measurements/_hamiltonian_stabilizers_sets.py
@@ -1,0 +1,134 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tools to split the Hamiltonian into subsets based on the support of
+its stabilizers."""
+
+import numpy
+import copy
+from openfermion.ops import QubitOperator
+
+
+def _check_stabilizer_overlap(pauli_op, stabilizer):
+    """
+    Auxiliar function of get Hamiltonian subsets.
+
+    Checks if a Pauli string has support on a stabilizer.
+
+    Args:
+        pauli_op(QubitOperator): Single Pauli string.
+        stabilizer(QubitOperator): Single Pauli string.
+
+    Returns:
+        overlap (Boolean): True if the operator and stabilizer overlap.
+    """
+    # Find qubits involved
+    qbts_in_stab = [qbt for (qbt, p) in list(stabilizer.terms.keys())[0]]
+
+    overlap = False
+    for qp in list(pauli_op.terms.keys())[0]:
+        if qp == ():
+            overlap = False
+        if qp[0] in qbts_in_stab:
+            overlap = True
+    return overlap
+
+
+def _check_missing_paulis(hamiltonian, subsets):
+    """
+    Auxiliar function of Hamiltonian subset splitting.
+
+    This function checks which Pauli strings are not included
+    in any subset.
+    The missing strings overlap with all stabilizers, and will need
+    to be measured even when an error occured.
+
+    Args:
+        Hamiltonian(QubitOperator): Hamiltonian to be split.
+        subsets(list): List of QubitOperators in which the Hamiltonian
+            has been split into.
+    Return:
+        left_paulis(QubitOperator): Only if there are left strings.
+            If no missing Paulis, returns an empyt QubitOperator.
+    """
+    # This functions uses python object sets to compare missing tuples.
+    # Hamiltonian keys as a set.
+    ham_set_form = set(hamiltonian.terms.keys())
+
+    # Hamiltonian subsets as a single set object.
+    aux_set = set()
+    for sb in subsets:
+        aux_set.update(set(sb.terms.keys()))
+
+    # Find any missing tuple in the Hamiltonian set compared to
+    # all subsets.
+    left_set = ham_set_form - aux_set
+
+    # Save missing Pauli strings in QubitOperator
+    # If no missing Paulis, returns 0
+    left_paulis = QubitOperator()
+    for p in left_set:
+        left_paulis += QubitOperator(p, hamiltonian.terms[p])
+    return left_paulis
+
+
+def get_hamiltonian_subsets(hamiltonian, stabilizers):
+    """
+    Create subsets of Hamiltonian.
+
+    This function splits a Hamiltonian into subsets of Pauli strings that do
+    not overlap with stabilizers.
+    The Pauli strings that overlap with all stabilizers will be stored with a
+    separate set.
+    It can be used to perform SV and not disregarding all data if only a single
+    stabilizers signals an error.
+
+    Args:
+        hamiltonian(QubitOperator): Hamiltonian to be split.
+        stabilizers(list or QubitOperator): List of stabilizers as
+            QubitOperators.
+    Return:
+        hamiltonian_subsets(list): List of QubitOperator which are a subset of
+            the Hamiltonian.
+            Each QubitOperator does not overlap with the stabilizer at the same
+            position in the list.
+        rest_paulis(QubitOperator): Operator that contains the Pauli
+            strings that overlap with all the stabilizers.
+            If there are no paulis left an empty QubitOperator is returned.
+    Raises:
+        TypeError: Input hamiltonian must be QubitOperator.
+        TypeError: Input stabilizer_list must be QubitOperator or list.
+    """
+    if not isinstance(hamiltonian, QubitOperator):
+        raise TypeError('Input terms must be QubitOperator.')
+    if not isinstance(stabilizers, (QubitOperator, list,
+                                    tuple, numpy.ndarray)):
+        raise TypeError('Input stabilizers must be QubitOperator or list.')
+
+    stabilizer_list = list(copy.deepcopy(stabilizers))
+    ham = copy.deepcopy(hamiltonian)
+
+    hamiltonian_subsets = []
+    for stab in stabilizer_list:
+        # Initialize subset
+        ham_subset = QubitOperator()
+        for pauli in ham:
+            if _check_stabilizer_overlap(pauli, stab) is False:
+                ham_subset += pauli
+
+        # Adds the subset to the list.
+        hamiltonian_subsets.append(ham_subset)
+
+    # Check if there are missing strings
+    rest_paulis = _check_missing_paulis(ham, hamiltonian_subsets)
+
+    return hamiltonian_subsets, rest_paulis

--- a/src/openfermion/measurements/_hamiltonian_stabilizers_sets_test.py
+++ b/src/openfermion/measurements/_hamiltonian_stabilizers_sets_test.py
@@ -1,0 +1,110 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Test for hamiltonian stabilizer sets."""
+
+import unittest
+
+from openfermion.transforms import jordan_wigner
+from openfermion.hamiltonians import fermi_hubbard
+from openfermion import QubitOperator
+
+from openfermion.measurements import get_hamiltonian_subsets
+from openfermion.measurements._hamiltonian_stabilizers_sets import (
+    _check_stabilizer_overlap, _check_missing_paulis)
+
+
+def hubbard_ham():
+    """
+    Generate Hubbard model Hamiltonian to test functions.
+
+    Args:
+        None
+        Return:
+        hamiltonian: QubitOperator in Jordan-Wigner
+        spectrum: List of energies.
+    """
+    # Set model.
+    x_dimension = 2
+    y_dimension = 1
+    tunneling = 1
+    coulomb = 2
+    magnetic_field = 0.
+    chemical_potential = 0.
+    periodic = 1
+    spinless = 0
+
+    # Get fermion operator.
+    hubbard_model = fermi_hubbard(
+        x_dimension, y_dimension, tunneling, coulomb, chemical_potential,
+        magnetic_field, periodic, spinless)
+
+    # Get qubit operator under Jordan-Wigner.
+    jw_hamiltonian = jordan_wigner(hubbard_model)
+    jw_hamiltonian.compress()
+
+    return jw_hamiltonian
+
+
+class HamiltonianSetTest(unittest.TestCase):
+    """Hamiltonian subset test class."""
+
+    def test_function_errors(self):
+        """Test error of main function."""
+        stab1 = QubitOperator('Z0 Z2', -1.0)
+        stab2 = QubitOperator('Z1 Z3', -1.0)
+        stab3 = QubitOperator('Z0 Z1 Z2 Z3', 1.0)
+        ham = hubbard_ham()
+
+        with self.assertRaises(TypeError):
+            get_hamiltonian_subsets(hamiltonian=1.0, stabilizers=[
+                                    stab1, stab2, stab3])
+        with self.assertRaises(TypeError):
+            get_hamiltonian_subsets(hamiltonian=ham, stabilizers=1.0)
+
+    def test_check_stabilizer_overlap(self):
+        """Test function _check_stabilizer_overlap."""
+        pauli = QubitOperator('Z0 X1', 1.0)
+        stab1 = QubitOperator('X2 Y3', -1.0)
+        stab2 = QubitOperator('Z0 Z2', -1.0)
+        self.assertFalse(_check_stabilizer_overlap(QubitOperator(' '), stab1))
+        self.assertFalse(_check_stabilizer_overlap(pauli, stab1))
+        self.assertTrue(_check_stabilizer_overlap(pauli, stab2))
+
+    def test_missing_paulis(self):
+        """Test _check_missing_paulis function."""
+        stab1 = QubitOperator('Z0 Z2', -1.0)
+        stab2 = QubitOperator('Z1 Z3', -1.0)
+        ham = hubbard_ham()
+
+        ham_subsets, pauli_rest = get_hamiltonian_subsets(
+            ham, [stab1, stab2])
+
+        # Will compare the number of Pauli strings in the Hamiltonian,
+        # with respect to the sum of the strings in the subsets
+        # and in Pauli rest.
+
+        num_paulis_ham = len(ham.terms)
+        num_paulis_left = len(pauli_rest.terms)
+        aux_set = set()
+        for sb in ham_subsets:
+            aux_set.update(set(sb.terms.keys()))
+        num_paulis_in_subsets = len(aux_set)
+        self.assertTrue(num_paulis_ham == (
+            num_paulis_in_subsets + num_paulis_left))
+
+    def test_no_missing_paulis(self):
+        """Test return when no paulis are missing."""
+        op = QubitOperator('Z0 X1 X2', 1.0)
+        sub_list = [QubitOperator('Z0 X1 X2', 1.0)]
+        self.assertIsInstance(_check_missing_paulis(
+            op, sub_list), QubitOperator)

--- a/src/openfermion/measurements/_quantum_subspace_expansion.py
+++ b/src/openfermion/measurements/_quantum_subspace_expansion.py
@@ -1,0 +1,146 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Quantum subspace expansion functions."""
+
+import copy
+import numpy
+
+import scipy.linalg
+
+from openfermion.ops import QubitOperator
+
+
+def get_additional_operators(hamiltonian, expansion_operators):
+    """
+    Generate an operator with additional Pauli strings.
+
+    Quantum subspace expansion requires additional Pauli strings.
+    This function generates a QubitOperator with all the Pauli
+    operator to be measured to perform QSE given the expansion
+    operator.
+
+    Args:
+        hamiltonian(QubitOperator): Hamiltonian.
+        stabilizer_list(list): List of QubitOperators.
+
+    Returns:
+        additional_ops(QubitOperator): Operator with all terms needed
+                for QSE with the given expansion operators.
+
+    Notes:
+        Be aware that the coefficient of the additional_ops operator
+        are meaningless.
+        This function is only useful to know which terms are required
+    to be measured to perform QSE.
+
+    Raises:
+        TypeError: if hamiltonian is not QubitOperator.
+        TypeError: if expansion_operators is not an array-like.
+    """
+    if not isinstance(hamiltonian, QubitOperator):
+        raise TypeError('Hamiltonian must be a QubitOperator object.')
+    if not isinstance(expansion_operators, (QubitOperator, list,
+                                            numpy.ndarray)):
+        raise TypeError('List of stabilizers must be an array-like.')
+    if isinstance(expansion_operators, QubitOperator):
+        expansion_operators = list(expansion_operators)
+
+    ham = copy.deepcopy(hamiltonian)
+    additional_ops = QubitOperator()
+
+    for op1 in expansion_operators:
+        for op2 in expansion_operators:
+            additional_ops += op2 * ham * op1
+
+    additional_ops = additional_ops + ham
+    return additional_ops
+
+
+def calculate_qse_spectrum(hamiltonian, expansion_operators,
+                           expectation_values):
+    """
+    Calculate quantum subspace expansion.
+
+    Quantum subspace expansion (QSE) was described in
+    https://arxiv.org/abs/1603.05681.
+    An extension to perform error mitigation based on QSE was proposed in
+    https://arxiv.org/abs/1807.10050.
+    If the expansion operators are symmetries or stabilizers
+    S-QSE is performed.
+
+    This function calculates the quantum subspace expansion of a given
+    Hamiltonian.
+    It is necessary to pass the expectation values of the Hamiltonian and the
+    additional operators.
+
+    Args:
+        hamiltonian(QubitOperator): Hamiltonian a QubitOperator.
+        expansion_operators(list, QubitOperator): List of QubitOperators
+        of the expansion.
+        expectation_values(QubitOperator): Expectation values as QubitOperator.
+
+    Returns:
+        spectrum_qse(list): Energy spectrum after QSE.
+
+    Raises:
+        TypeError: if hamiltonian is not a QubitOperator.
+        TypeError: if expansion_operators is not an array-like or
+                   QubitOperator.
+        TypeError: if expectation_values is not a QubitOperator.
+        ValueError: if length of expanded operator and length of expectation
+                    values is not equal.
+    """
+    if not isinstance(hamiltonian, QubitOperator):
+        raise TypeError('Hamiltonian must be a QubitOperator object.')
+    if not isinstance(expectation_values, QubitOperator):
+        raise TypeError('Hamiltonian must be a QubitOperator object.')
+    if not isinstance(expansion_operators, (QubitOperator, list,
+                                            numpy.ndarray)):
+        raise TypeError('List of stabilizers must be an array-like.')
+    # Write expansion operators as a list
+    if isinstance(expansion_operators, QubitOperator):
+        expansion_operators = list(expansion_operators)
+
+    # Check if the length of additional operator equals the length of
+    # expectation values.
+    additional_op = get_additional_operators(hamiltonian, expansion_operators)
+    if len(additional_op.terms) != len(expectation_values.terms):
+        raise ValueError('The number of Pauli strings do not match '
+                         'the number of expectation values.')
+
+    # Initialize matrices to store calculated values.
+    ham_mat = numpy.zeros((len(expansion_operators),
+                           len(expansion_operators)))
+    overlap_mat = numpy.zeros((len(expansion_operators),
+                               len(expansion_operators)))
+
+    for i in range(len(expansion_operators)):
+        for j in range(len(expansion_operators)):
+            op_to_trace = expectation_values * \
+                expansion_operators[j] * expansion_operators[i]
+            hop_to_trace = expectation_values * \
+                expansion_operators[j] * hamiltonian * expansion_operators[i]
+
+            # If an entry is 0 it will not be in the operators.
+            # An error will arise, hence we use try, expect to
+            # set the value in the matrix to 0.0
+            try:
+                ham_mat[i, j] = numpy.real(hop_to_trace.terms[()])
+                overlap_mat[i, j] = numpy.real(op_to_trace.terms[()])
+            except:
+                ham_mat[i, j] = 0.0
+                overlap_mat[i, j] = 0.0
+
+    spectrum_qse = scipy.linalg.eigvalsh(ham_mat, overlap_mat)
+
+    return spectrum_qse

--- a/src/openfermion/measurements/_quantum_subspace_expansion_test.py
+++ b/src/openfermion/measurements/_quantum_subspace_expansion_test.py
@@ -190,6 +190,18 @@ class QSETest(unittest.TestCase):
             calculate_qse_spectrum(hamiltonian=ham, expansion_operators=[
                 stab1, stab2, stab3], expectation_values=expct_vals)
 
+    def test_qubitoperator_to_list(self):
+        """Test QubitOperators of expansion are set as list."""
+        stab_qop = (QubitOperator('Z0 Z2', -1.0) +
+                    QubitOperator('Z1 Z3', -1.0) +
+                    QubitOperator('Z0 Z1 Z2 Z3', 1.0))
+        ham = hubbard_ham()
+        (expct_vals, expct_vals_ext) = hubbard_ham_expect_vals()
+
+        get_additional_operators(hamiltonian=ham, expansion_operators=stab_qop)
+        calculate_qse_spectrum(hamiltonian=ham, expansion_operators=stab_qop,
+                               expectation_values=expct_vals_ext)
+
     def test_symmetry_qse(self):
         """Function to test SQSE."""
         stab1 = QubitOperator('Z0 Z2', -1.0)

--- a/src/openfermion/measurements/_quantum_subspace_expansion_test.py
+++ b/src/openfermion/measurements/_quantum_subspace_expansion_test.py
@@ -1,0 +1,240 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Test for quantum subspace expansion functions."""
+
+import unittest
+
+from openfermion.transforms import (jordan_wigner,
+                                    bravyi_kitaev, get_fermion_operator,
+                                    project_onto_sector)
+from openfermion.hamiltonians import MolecularData, fermi_hubbard
+from openfermion.ops import QubitOperator
+from openfermion.utils import eigenspectrum
+
+from openfermion.measurements import calculate_qse_spectrum
+from openfermion.measurements._quantum_subspace_expansion import (
+    get_additional_operators)
+
+
+def hubbard_ham():
+    """
+    Generate Hubbard model Hamiltonian to test functions.
+
+    Args:
+        None
+    Return:
+        hamiltonian: QubitOperator in Jordan-Wigner
+    """
+    # Set model.
+    x_dimension = 2
+    y_dimension = 1
+    tunneling = 1
+    coulomb = 2
+    magnetic_field = 0.
+    chemical_potential = 0.
+    periodic = 1
+    spinless = 0
+
+    # Get fermion operator.
+    hubbard_model = fermi_hubbard(
+        x_dimension, y_dimension, tunneling, coulomb, chemical_potential,
+        magnetic_field, periodic, spinless)
+
+    # Get qubit operator under Jordan-Wigner.
+    jw_hamiltonian = jordan_wigner(hubbard_model)
+    jw_hamiltonian.compress()
+
+    return jw_hamiltonian
+
+
+def h2_bravyi_kitaev():
+    """
+    Generate test Hamiltonian from H2.
+
+    Args:
+        None
+
+    Return:
+
+        hamiltonian: FermionicOperator
+        qop_ham: QubitOperator
+    """
+    geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 0.7414))]
+    molecule = MolecularData(geometry, 'sto-3g', 1,
+                             description="0.7414")
+    molecule.load()
+
+    molecular_hamiltonian = molecule.get_molecular_hamiltonian()
+
+    hamiltonian = get_fermion_operator(molecular_hamiltonian)
+    qop_ham = project_onto_sector(bravyi_kitaev(hamiltonian), [1, 3], [0, 0])
+
+    return hamiltonian, qop_ham
+
+
+def hubbard_ham_expect_vals():
+    """
+    Get expectation values.
+
+    Expectation values previously obtained in simulations.
+
+    Returns:
+            expct_vals (QubitOperator): Expectation values as QubitOperator.
+            expct_vals_ext (QubitOperator): Expectation values of the extended
+                Hamiltoinan.
+    """
+    expct_vals = QubitOperator()
+    expct_vals_ext = QubitOperator()
+
+    expct_vals.terms = {((0, 'Y'), (1, 'Z'), (2, 'Y')): 0.8743466545506314,
+                        ((0, 'X'), (1, 'Z'), (2, 'X')): 0.8751599153719161,
+                        ((1, 'Y'), (2, 'Z'), (3, 'Y')): 0.8728774175805551,
+                        ((1, 'X'), (2, 'Z'), (3, 'X')): 0.8732403041510814,
+                        (): 1.0,
+                        ((1, 'Z'),): 0.0038787944469396707,
+                        ((0, 'Z'),): -0.00032851220327859143,
+                        ((0, 'Z'), (1, 'Z')): -0.44347605363496034,
+                        ((3, 'Z'),): -0.0011170198007229848,
+                        ((2, 'Z'),): 0.0011778143202714753,
+                        ((2, 'Z'), (3, 'Z')): -0.4439960440736147
+                        }
+
+    expct_vals_ext.terms = {((0, 'Y'), (1, 'Z'), (2, 'Y')): 0.8743466545506314,
+                            ((0, 'X'), (1, 'Z'), (2, 'X')): 0.8751599153719161,
+                            ((1, 'Y'), (2, 'Z'), (3, 'Y')): 0.8728774175805551,
+                            ((1, 'X'), (2, 'Z'), (3, 'X')): 0.8732403041510814,
+                            (): 1.0,
+                            ((0, 'Z'), (1, 'Z')): -0.44347605363496034,
+                            ((2, 'Z'), (3, 'Z')): -0.4439960440736147,
+                            ((0, 'X'), (2, 'X'),
+                                (3, 'Z')): -0.8742992712768001,
+                            ((0, 'Y'), (2, 'Y'),
+                                (3, 'Z')): -0.874981704992061,
+                            ((0, 'Z'), (1, 'X'),
+                                (3, 'X')): -0.8769719627156427,
+                            ((0, 'Z'), (1, 'Y'),
+                                (3, 'Y')): -0.8749501758400109,
+                            ((0, 'Z'), (1, 'Z'),
+                                (2, 'Z'), (3, 'Z')): 0.97538832027736,
+                            ((1, 'Z'), (3, 'Z')): -0.9821867799949147,
+                            ((0, 'Z'), (3, 'Z')): 0.4412051987768667,
+                            ((1, 'Z'), (2, 'Z')): 0.44311225284211214,
+                            ((0, 'Z'), (2, 'Z')): -0.9812982051266501,
+                            ((1, 'Z'),): 0.0038787944469396707,
+                            ((0, 'Z'),): -0.00032851220327859143,
+                            ((3, 'Z'),): -0.0011170198007229848,
+                            ((2, 'Z'),): 0.0011778143202714753}
+
+    return expct_vals, expct_vals_ext
+
+
+def h2_expect_vals():
+    """Expectation values for H2 LR-QSE test."""
+    expct_vals = QubitOperator()
+    expct_vals.terms = {(): 1.0,
+                        ((0, 'Y'), (1, 'Y')): -0.21958330202868692,
+                        ((0, 'X'), (1, 'X')): -0.21992539710797498,
+                        ((0, 'Z'), (1, 'Z')): -0.9787248504287553,
+                        ((0, 'Y'), (1, 'X')): 0.0009958622913323499,
+                        ((0, 'X'), (1, 'Y')): 1.960326404420033e-05,
+                        ((0, 'Y'),): 0.005290597167661589,
+                        ((0, 'X'),): 0.0044508645519099055,
+                        ((0, 'Y'), (1, 'Z')): 0.005374734672752549,
+                        ((0, 'X'), (1, 'Z')): 0.002254414818511139,
+                        ((0, 'Z'), (1, 'Y')): -0.0018175385756145346,
+                        ((1, 'X'),): 0.003192646549690809,
+                        ((0, 'Z'), (1, 'X')): -0.0019412082018775102,
+                        ((1, 'Y'),): 0.0006835832299994119,
+                        ((0, 'Z'),): -0.9577234581517733,
+                        ((1, 'Z'),): 0.961162783855539}
+
+    return expct_vals
+
+
+class QSETest(unittest.TestCase):
+    """Quantum subspace expansion test class."""
+
+    def test_function_errors(self):
+        """Test error of main function."""
+        stab1 = QubitOperator('Z0 Z2', -1.0)
+        stab2 = QubitOperator('Z1 Z3', -1.0)
+        stab3 = QubitOperator('Z0 Z1 Z2 Z3', 1.0)
+        ham = hubbard_ham()
+        (expct_vals, expct_vals_ext) = hubbard_ham_expect_vals()
+
+        with self.assertRaises(TypeError):
+            get_additional_operators(hamiltonian=1.0, expansion_operators=[
+                stab1, stab2, stab3])
+        with self.assertRaises(TypeError):
+            get_additional_operators(hamiltonian=ham, expansion_operators=1.0)
+        with self.assertRaises(TypeError):
+            calculate_qse_spectrum(hamiltonian=1.0, expansion_operators=[
+                stab1, stab2, stab3], expectation_values=expct_vals_ext)
+        with self.assertRaises(TypeError):
+            calculate_qse_spectrum(hamiltonian=ham, expansion_operators=1.0,
+                                   expectation_values=expct_vals_ext)
+        with self.assertRaises(TypeError):
+            calculate_qse_spectrum(hamiltonian=ham, expansion_operators=[
+                stab1, stab2, stab3], expectation_values=2.0)
+        with self.assertRaises(ValueError):
+            calculate_qse_spectrum(hamiltonian=ham, expansion_operators=[
+                stab1, stab2, stab3], expectation_values=expct_vals)
+
+    def test_symmetry_qse(self):
+        """Function to test SQSE."""
+        stab1 = QubitOperator('Z0 Z2', -1.0)
+        stab2 = QubitOperator('Z1 Z3', -1.0)
+        stab3 = QubitOperator('Z0 Z1 Z2 Z3', 1.0)
+        ham = hubbard_ham()
+        (expct_vals, expct_vals_ext) = hubbard_ham_expect_vals()
+
+        # We will compare the noisy result with respect
+        # to the ground state energy of the Hubbard model.
+        hub_gs = eigenspectrum(ham)[0]
+        noisy_gs = (ham * expct_vals).terms[()]
+        sqse_gs = calculate_qse_spectrum(hamiltonian=ham, expansion_operators=[
+            stab1, stab2, stab3], expectation_values=expct_vals_ext)[0]
+
+        # Check that the greatest absolute value of the ground state is given
+        # by the eigenspectrum of the Hamiltonian.
+        self.assertGreater(abs(hub_gs), abs(noisy_gs))
+        self.assertGreater(abs(hub_gs), abs(sqse_gs))
+        # Check that the Symmetry-QSE ground state energy is greater than
+        # the noisy one in absolute value.
+        self.assertGreater(abs(sqse_gs), abs(noisy_gs))
+
+    def test_qse(self):
+        """Function to test LR-QSE."""
+        lr_expansion = [QubitOperator(p + str(q), 1.0) for q in range(2)
+                        for p in ['X', 'Y', 'Z']]
+        lr_expansion.append(QubitOperator(' ', 1.0))
+        ferop, qop_ham = h2_bravyi_kitaev()
+        expct_vals = h2_expect_vals()
+
+        spectrum = eigenspectrum(ferop)
+        noisy_gs = (expct_vals * qop_ham).terms[()]
+        qse_spectrum = calculate_qse_spectrum(
+            qop_ham, lr_expansion, expct_vals)
+
+        # The number of eigenvalues of the qse is equal to the number of
+        # expantion operators.
+        self.assertTrue(len(qse_spectrum) == len(lr_expansion))
+        # Check if the highest excited state is an approximation
+        # to true highest eigenstate.
+        self.assertGreater(abs(spectrum[-1]), abs(qse_spectrum[-1]))
+        self.assertAlmostEqual(abs(spectrum[-1]), abs(qse_spectrum[-1]),
+                               places=1)
+        # Check if it also mitigates.
+        self.assertGreater(abs(spectrum[0]), abs(noisy_gs))
+        self.assertGreater(abs(spectrum[0]), abs(qse_spectrum[0]))
+        self.assertGreater(abs(qse_spectrum[0]), abs(noisy_gs))


### PR DESCRIPTION
Hi all,

This PR contains two new modules added to measurements.

1. Hamiltonian split by stabilizers
- A Hamiltonian is split into subsets of Pauli operators that are affected when a stabilizer is measured detecting an error.
- This module allows one to find the subsets of Pauli operators unaffected after detecting an error using the stabilizers. Hopefully, this will allow to reduce the number of measurements to be performed while using symmetry verification/error detection.

2. Quantum subspace expansion
- I added a module that calculates QSE, including a function that returns a list of additional operators to measure to be able to perform the expansion.
- The test module of these functions requires estimated expectation values, hence I used calculations of my own to generate such estimated Hamiltonians. If a better way of doing the test exists I'll be happy to change it.

PS: I will not be able to work on improvements of the PR in the upcoming weeks, but as soon as I can I will make all the necessary changes. Sorry about it.
Best,
Xavi
