### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         '': [os.path.join('src', 'openfermion', 'data', '*.hdf5'),
              os.path.join('src', 'openfermion', 'data', '*.npy')]
     },
-    data_files=[('openfermion/examples', [
+    data_files=[('share/openfermion/examples', [
                  'examples/binary_code_transforms_demo.ipynb',
                  'examples/bosonic_operator_tutorial.ipynb',
                  'examples/jordan_wigner_and_bravyi_kitaev_transforms.ipynb',


### PR DESCRIPTION
The current openfermion installation with 'sudo pip install openfermion' will put the example file in usr/local/openfermion which is not normally the example file go to.

I propose this change will put the example files under /usr/share/openfermion/examples on a linux installation with a package manager.
The /usr/share hierarchy is for all read-only architecture independent data files.


https://github.com/quantumlib/OpenFermion/issues/590