### PR TITLE
Erpa

### DIFF
--- a/src/openfermion/utils/__init__.py
+++ b/src/openfermion/utils/__init__.py
@@ -17,6 +17,8 @@ from ._channel_state import (amplitude_damping_channel, dephasing_channel,
 
 from ._commutators import anticommutator, commutator, double_commutator
 
+from ._erpa import singlet_erpa, erpa_eom_hamiltonian
+
 from ._grid import Grid
 
 from ._lattice import (HubbardSquareLattice, SpinPairs, Spin)

--- a/src/openfermion/utils/_erpa.py
+++ b/src/openfermion/utils/_erpa.py
@@ -3,9 +3,9 @@ from typing import Dict, Tuple, Union
 from itertools import product
 import numpy as np
 from numpy import einsum
+import scipy as sp
 from openfermion.utils._rdm_mapping_functions import kronecker_delta as kdelta
 from openfermion.utils._rdm_mapping_functions import map_two_pdm_to_one_pdm
-import scipy as sp
 
 
 def erpa_eom_hamiltonian(h_ijkl: np.ndarray, tpdm: np.ndarray, p: int, q: int,

--- a/src/openfermion/utils/_erpa.py
+++ b/src/openfermion/utils/_erpa.py
@@ -60,20 +60,18 @@ def erpa_eom_hamiltonian(h_ijkl: np.ndarray, tpdm: np.ndarray, p: int, q: int,
     #  (  -1.00000) h_ijkl(a,b,r,p) cre(a) cre(b) des(q) des(s)
     h_mat += -1.0 * einsum('ab,ab', h_ijkl[:, :, r, p], tpdm[:, :, q, s])
 
-    #  (   1.00000) h_ijkl(s,a,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
     if q == r:
+        #  (   1.00000) h_ijkl(s,a,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
         h_mat += 1.0 * einsum('abc,abc', h_ijkl[s, :, :, :], tpdm[p, :, :, :])
 
-    #  (  -1.00000) h_ijkl(a,s,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
-    if q == r:
+        #  (  -1.00000) h_ijkl(a,s,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
         h_mat += -1.0 * einsum('abc,abc', h_ijkl[:, s, :, :], tpdm[p, :, :, :])
 
-    #  (   1.00000) h_ijkl(a,b,r,c) kdelta(p,s) cre(a) cre(b) des(q) des(c)
     if p == s:
+        #  (   1.00000) h_ijkl(a,b,r,c) kdelta(p,s) cre(a) cre(b) des(q) des(c)
         h_mat += 1.0 * einsum('abc,abc', h_ijkl[:, :, r, :], tpdm[:, :, q, :])
 
-    #  (  -1.00000) h_ijkl(a,b,c,r) kdelta(p,s) cre(a) cre(b) des(q) des(c)
-    if p == s:
+        #  (  -1.00000) h_ijkl(a,b,c,r) kdelta(p,s) cre(a) cre(b) des(q) des(c)
         h_mat += -1.0 * einsum('abc,abc', h_ijkl[:, :, :, r], tpdm[:, :, q, :])
 
     return h_mat

--- a/src/openfermion/utils/_erpa.py
+++ b/src/openfermion/utils/_erpa.py
@@ -1,0 +1,146 @@
+"""Code to generate the eigenvalue problem for the ERPA equations"""
+from typing import Dict, Tuple, Union
+from itertools import product
+import numpy as np
+from numpy import einsum
+from openfermion.utils._rdm_mapping_functions import kronecker_delta as kdelta
+from openfermion.utils._rdm_mapping_functions import map_two_pdm_to_one_pdm
+import scipy as sp
+
+
+def erpa_eom_hamiltonian(h_ijkl: np.ndarray, tpdm: np.ndarray, p: int, q: int,
+                         r: int, s: int) -> Union[float, complex]:
+    """
+    Evaluate sum_{a,b,c,d}h_{a, b, d, c}<psi[p^ q, [a^ b^ c d, r^ s]]psi>
+
+    Args:
+        h_ijkl: two-body integral tensors of full reduced Hamiltonian
+        tpdm: two-RDM
+        p: left creation op index
+        q: left annihilation op index
+        r: right creation op index
+        s: right annihilation op index
+    Returns:
+        float or complex number
+    """
+    h_mat = 0
+    #  (   1.00000) h_ijkl(q,s,a,b) cre(p) cre(r) des(a) des(b)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[q, s, :, :], tpdm[p, r, :, :])
+
+    #  (  -1.00000) h_ijkl(q,a,r,b) cre(p) cre(a) des(s) des(b)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[q, :, r, :], tpdm[p, :, s, :])
+
+    #  (   1.00000) h_ijkl(q,a,b,r) cre(p) cre(a) des(s) des(b)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[q, :, :, r], tpdm[p, :, s, :])
+
+    #  (  -1.00000) h_ijkl(s,q,a,b) cre(p) cre(r) des(a) des(b)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[s, q, :, :], tpdm[p, r, :, :])
+
+    #  (  -1.00000) h_ijkl(s,a,p,b) cre(r) cre(a) des(q) des(b)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[s, :, p, :], tpdm[r, :, q, :])
+
+    #  (   1.00000) h_ijkl(s,a,b,p) cre(r) cre(a) des(q) des(b)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[s, :, :, p], tpdm[r, :, q, :])
+
+    #  (   1.00000) h_ijkl(a,q,r,b) cre(p) cre(a) des(s) des(b)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[:, q, r, :], tpdm[p, :, s, :])
+
+    #  (  -1.00000) h_ijkl(a,q,b,r) cre(p) cre(a) des(s) des(b)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[:, q, :, r], tpdm[p, :, s, :])
+
+    #  (   1.00000) h_ijkl(a,s,p,b) cre(r) cre(a) des(q) des(b)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[:, s, p, :], tpdm[r, :, q, :])
+
+    #  (  -1.00000) h_ijkl(a,s,b,p) cre(r) cre(a) des(q) des(b)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[:, s, :, p], tpdm[r, :, q, :])
+
+    #  (   1.00000) h_ijkl(a,b,p,r) cre(a) cre(b) des(q) des(s)
+    h_mat += 1.0 * einsum('ab,ab', h_ijkl[:, :, p, r], tpdm[:, :, q, s])
+
+    #  (  -1.00000) h_ijkl(a,b,r,p) cre(a) cre(b) des(q) des(s)
+    h_mat += -1.0 * einsum('ab,ab', h_ijkl[:, :, r, p], tpdm[:, :, q, s])
+
+    #  (   1.00000) h_ijkl(s,a,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
+    if q == r:
+        h_mat += 1.0 * einsum('abc,abc', h_ijkl[s, :, :, :], tpdm[p, :, :, :])
+
+    #  (  -1.00000) h_ijkl(a,s,b,c) kdelta(q,r) cre(p) cre(a) des(b) des(c)
+    if q == r:
+        h_mat += -1.0 * einsum('abc,abc', h_ijkl[:, s, :, :], tpdm[p, :, :, :])
+
+    #  (   1.00000) h_ijkl(a,b,r,c) kdelta(p,s) cre(a) cre(b) des(q) des(c)
+    if p == s:
+        h_mat += 1.0 * einsum('abc,abc', h_ijkl[:, :, r, :], tpdm[:, :, q, :])
+
+    #  (  -1.00000) h_ijkl(a,b,c,r) kdelta(p,s) cre(a) cre(b) des(q) des(c)
+    if p == s:
+        h_mat += -1.0 * einsum('abc,abc', h_ijkl[:, :, :, r], tpdm[:, :, q, :])
+
+    return h_mat
+
+
+def singlet_erpa(tpdm: np.ndarray, h_ijkl: np.ndarray) \
+        -> Tuple[np.ndarray, np.ndarray, Dict]:
+    """
+    Generate the singlet ERPA equations
+
+    [ea + eb, [H, sa, sb]] = [ea, [H, sa]]
+
+    The erpa equations are solved with scipy.linalg.eig which calls
+    lapack's geev
+
+    Args:
+        tpdm: 2-RDM tensor normal OpenFermion format
+        h_ijkl: reduced Hamiltonian tensor
+    Returns:
+        Tuple of the erpa system.
+    """
+    permuted_hijkl = np.einsum('ijlk', h_ijkl)
+    roots = np.array(np.roots([1, -1, -einsum('ijji', tpdm)]))
+    n_electrons = roots[np.where(roots > 0)[0]].real
+    opdm = map_two_pdm_to_one_pdm(tpdm, n_electrons)
+    dim = tpdm.shape[0] // 2  # dim = num spatial orbitals
+    full_basis = {}  # erpa basis.  A, B basis in RPA language
+    cnt = 0
+    for p, q in product(range(dim), repeat=2):
+        if p < q:
+            full_basis[(p, q)] = cnt
+            full_basis[(q, p)] = cnt + dim * (dim - 1) // 2
+            cnt += 1
+
+    erpa_mat = np.zeros((len(full_basis), len(full_basis)))
+    metric_mat = np.zeros((len(full_basis), len(full_basis)))
+    for rkey, ridx in full_basis.items():
+        p, q = rkey
+        for ckey, cidx in full_basis.items():
+            r, s = ckey
+            for sigma, tau in product([0, 1], repeat=2):
+                erpa_mat[ridx, cidx] += 0.5 * erpa_eom_hamiltonian(
+                    permuted_hijkl, tpdm, 2 * q + sigma, 2 * p + sigma,
+                    2 * r + tau, 2 * s + tau).real
+                metric_mat[ridx, cidx] += 0.5 * (
+                    opdm[2 * q + sigma, 2 * s + tau] *
+                    kdelta(2 * r + tau, 2 * p + sigma) -
+                    opdm[2 * p + sigma, 2 * r + tau] *
+                    kdelta(2 * q + sigma, 2 * s + tau)).real
+
+    # The metric is hermetian and can be diagonalized
+    # this allows us to project into the non-zero eigenvalue space
+    ws, vs = np.linalg.eigh(metric_mat)
+    non_zero_idx = np.where(np.abs(ws) > 1.0E-8)[0]
+    left_mat = vs[:, non_zero_idx].T @ erpa_mat @ vs[:, non_zero_idx]
+    right_mat = vs[:, non_zero_idx].T @ metric_mat @ vs[:, non_zero_idx]
+
+    # solve the matrix pencil using ddgev in lapack
+    w, v = sp.linalg.eig(left_mat, right_mat)
+
+    # the spectrum is symmetric (-w, w)
+    # find the positive spectrum eigensystem and return
+    real_eig_idx = np.where(np.abs(w.imag) < 1.0E-8)[0]
+    real_eigs = w[real_eig_idx]
+    real_eig_vecs = v[:, real_eig_idx]
+    reverse_projected_eig_vecs = vs[:, non_zero_idx] @ real_eig_vecs
+    pos_indices = np.where(real_eigs > 0)[0]
+    pos_indices = pos_indices[np.argsort(real_eigs[pos_indices])]
+    return real_eigs[pos_indices], reverse_projected_eig_vecs[:, pos_indices], \
+           full_basis

--- a/src/openfermion/utils/_erpa_test.py
+++ b/src/openfermion/utils/_erpa_test.py
@@ -4,11 +4,11 @@ import numpy as np
 import openfermion as of
 from openfermion.config import DATA_DIRECTORY
 from openfermion.hamiltonians import MolecularData
-from openfermion.utils._reduced_hamiltonian import make_reduced_hamiltonian
-from openfermion.utils._erpa import singlet_erpa, erpa_eom_hamiltonian
+from openfermion.utils import make_reduced_hamiltonian
+from openfermion.utils import singlet_erpa, erpa_eom_hamiltonian
 
 
-def h2_rpa_test():
+def test_h2_rpa():
     filename = os.path.join(DATA_DIRECTORY, "H2_sto-3g_singlet_0.7414.hdf5")
     molecule = MolecularData(filename=filename)
     reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),
@@ -24,7 +24,7 @@ def h2_rpa_test():
     assert isinstance(basis, dict)
 
 
-def erpa_eom_ham_h2():
+def test_erpa_eom_ham_h2():
     filename = os.path.join(DATA_DIRECTORY, "H2_sto-3g_singlet_0.7414.hdf5")
     molecule = MolecularData(filename=filename)
     reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),
@@ -60,7 +60,7 @@ def erpa_eom_ham_h2():
                 assert np.isclose(true, test)
 
 
-def erpa_eom_ham_lih():
+def test_erpa_eom_ham_lih():
     filename = os.path.join(DATA_DIRECTORY, "H1-Li1_sto-3g_singlet_1.45.hdf5")
     molecule = MolecularData(filename=filename)
     reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),

--- a/src/openfermion/utils/_erpa_test.py
+++ b/src/openfermion/utils/_erpa_test.py
@@ -1,0 +1,97 @@
+from itertools import product
+import os
+import numpy as np
+import openfermion as of
+from openfermion.config import DATA_DIRECTORY
+from openfermion.hamiltonians import MolecularData
+from openfermion.utils._reduced_hamiltonian import make_reduced_hamiltonian
+from openfermion.utils._erpa import singlet_erpa, erpa_eom_hamiltonian
+
+
+def h2_rpa_test():
+    filename = os.path.join(DATA_DIRECTORY, "H2_sto-3g_singlet_0.7414.hdf5")
+    molecule = MolecularData(filename=filename)
+    reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),
+                                           molecule.n_electrons)
+    hf_opdm = np.diag([1] * molecule.n_electrons + [0] *
+                      (molecule.n_qubits - molecule.n_electrons))
+    hf_tpdm = 2 * of.wedge(hf_opdm, hf_opdm, (1, 1), (1, 1))
+
+    pos_spectrum, xy_eigvects, basis = singlet_erpa(hf_tpdm,
+                                                    reduced_ham.two_body_tensor)
+    assert np.isclose(pos_spectrum, 0.92926444)  # pyscf-rpa value
+    assert isinstance(xy_eigvects, np.ndarray)
+    assert isinstance(basis, dict)
+
+
+def erpa_eom_ham_h2():
+    filename = os.path.join(DATA_DIRECTORY, "H2_sto-3g_singlet_0.7414.hdf5")
+    molecule = MolecularData(filename=filename)
+    reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),
+                                           molecule.n_electrons)
+    rha_fermion = of.get_fermion_operator(reduced_ham)
+    permuted_hijkl = np.einsum('ijlk', reduced_ham.two_body_tensor)
+    opdm = np.diag([1] * molecule.n_electrons + [0] *
+                   (molecule.n_qubits - molecule.n_electrons))
+    tpdm = 2 * of.wedge(opdm, opdm, (1, 1), (1, 1))
+    rdms = of.InteractionRDM(opdm, tpdm)
+    dim = reduced_ham.one_body_tensor.shape[0] // 2
+    full_basis = {}  # erpa basis.  A, B basis in RPA language
+    cnt = 0
+    for p, q in product(range(dim), repeat=2):
+        if p < q:
+            full_basis[(p, q)] = cnt
+            full_basis[(q, p)] = cnt + dim * (dim - 1) // 2
+            cnt += 1
+    for rkey in full_basis.keys():
+        p, q = rkey
+        for ckey in full_basis.keys():
+            r, s = ckey
+            for sigma, tau in product([0, 1], repeat=2):
+                test = erpa_eom_hamiltonian(permuted_hijkl, tpdm, 2 * q + sigma,
+                                            2 * p + sigma, 2 * r + tau,
+                                            2 * s + tau).real
+                qp_op = of.FermionOperator(
+                    ((2 * q + sigma, 1), (2 * p + sigma, 0)))
+                rs_op = of.FermionOperator(((2 * r + tau, 1), (2 * s + tau, 0)))
+                erpa_op = of.normal_ordered(
+                    of.commutator(qp_op, of.commutator(rha_fermion, rs_op)))
+                true = rdms.expectation(of.get_interaction_operator(erpa_op))
+                assert np.isclose(true, test)
+
+
+def erpa_eom_ham_lih():
+    filename = os.path.join(DATA_DIRECTORY, "H1-Li1_sto-3g_singlet_1.45.hdf5")
+    molecule = MolecularData(filename=filename)
+    reduced_ham = make_reduced_hamiltonian(molecule.get_molecular_hamiltonian(),
+                                           molecule.n_electrons)
+    rha_fermion = of.get_fermion_operator(reduced_ham)
+    permuted_hijkl = np.einsum('ijlk', reduced_ham.two_body_tensor)
+    opdm = np.diag([1] * molecule.n_electrons + [0] *
+                   (molecule.n_qubits - molecule.n_electrons))
+    tpdm = 2 * of.wedge(opdm, opdm, (1, 1), (1, 1))
+    rdms = of.InteractionRDM(opdm, tpdm)
+    dim = 3  # so we don't do the full basis.  This would make the test long
+    full_basis = {}  # erpa basis.  A, B basis in RPA language
+    cnt = 0
+    # start from 1 to make test shorter
+    for p, q in product(range(1, dim), repeat=2):
+        if p < q:
+            full_basis[(p, q)] = cnt
+            full_basis[(q, p)] = cnt + dim * (dim - 1) // 2
+            cnt += 1
+    for rkey in full_basis.keys():
+        p, q = rkey
+        for ckey in full_basis.keys():
+            r, s = ckey
+            for sigma, tau in product([0, 1], repeat=2):
+                test = erpa_eom_hamiltonian(permuted_hijkl, tpdm, 2 * q + sigma,
+                                            2 * p + sigma, 2 * r + tau,
+                                            2 * s + tau).real
+                qp_op = of.FermionOperator(
+                    ((2 * q + sigma, 1), (2 * p + sigma, 0)))
+                rs_op = of.FermionOperator(((2 * r + tau, 1), (2 * s + tau, 0)))
+                erpa_op = of.normal_ordered(
+                    of.commutator(qp_op, of.commutator(rha_fermion, rs_op)))
+                true = rdms.expectation(of.get_interaction_operator(erpa_op))
+                assert np.isclose(true, test)


### PR DESCRIPTION
Implements the ERPA equations.  Generates the non-symmetric eigenvalue problem and uses geev from scipy.lapack to solve the matrix pencil.

Here's the erpa equations with a 2-RDM generated from a Hartree-Fock 1-RDM.  We recover the results from the RPA implementation in pyscf. 


<img width="551" alt="Screen Shot 2020-05-27 at 10 12 53 PM" src="https://user-images.githubusercontent.com/7128746/83101461-40f38c00-a067-11ea-8cae-3b31df520fbc.png">
