### PR TITLE
Added build_api_docs.py script

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -1,0 +1,63 @@
+# Copyright 2020 The OpenFermion Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tool to generate external api_docs for OF (Shameless copy from TFQ)."""
+
+import os
+
+from absl import app
+from absl import flags
+from tensorflow_docs.api_generator import doc_controls
+from tensorflow_docs.api_generator import generate_lib
+from tensorflow_docs.api_generator import public_api
+
+import openfermion as of
+
+flags.DEFINE_string("output_dir", "/tmp/of_api", "Where to output the docs")
+
+flags.DEFINE_string("code_url_prefix",
+                    ("https://github.com/quantumlib/openfermion/tree/master/src"
+                     "openfermion"), "The url prefix for links to code.")
+
+flags.DEFINE_bool("search_hints", True,
+                  "Include metadata search hints in the generated files")
+
+flags.DEFINE_string("site_path", "quark/openfermion/api_docs/python",
+                    "Path prefix in the _toc.yaml")
+
+FLAGS = flags.FLAGS
+
+
+def main(unused_argv):
+
+    doc_generator = generate_lib.DocGenerator(
+        root_title="OpenFermion",
+        py_modules=[("of", of)],
+        base_dir=os.path.dirname(of.__file__),
+        code_url_prefix=FLAGS.code_url_prefix,
+        search_hints=FLAGS.search_hints,
+        site_path=FLAGS.site_path,
+        callbacks=[public_api.local_definitions_filter],
+        private_map={
+            # Module paths to skip when crawling source code.
+            # Example:
+            # "cirq.google.engine.client.quantum.QuantumEngineServiceClient":
+            # ["enums"]
+        })
+
+    doc_generator.build(output_dir=FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -27,7 +27,7 @@ import openfermion as of
 flags.DEFINE_string("output_dir", "/tmp/of_api", "Where to output the docs")
 
 flags.DEFINE_string("code_url_prefix",
-                    ("https://github.com/quantumlib/openfermion/tree/master/src"
+                    ("https://github.com/quantumlib/OpenFermion/tree/master/src"
                      "openfermion"), "The url prefix for links to code.")
 
 flags.DEFINE_bool("search_hints", True,


### PR DESCRIPTION
Puts `api_docs` build script similar to the ones in Cirq, copied from TFQ. @lamberta I've tested this locally and it should be good to go to be iterated on.