### PR TITLE
Oligoacene addition to cloud library

### DIFF
--- a/cloud_library/k-acene.txt
+++ b/cloud_library/k-acene.txt
@@ -1,0 +1,17 @@
+# Linear k-acenes k = 2-12 in 6-31g* basis
+# Geometries taken from J. Chem. Theory Comput. 2019, 15, 1, 276–289
+# The MolecularData integrals are for the active space
+# of size [4k + 2o, 4k + 2e]. The core energy is the
+# nuclear repulsion + the active space adjustment
+# The MO coefficients are computed with pyscf and included in the "general_calculation"
+# attribute field. H10-C14_6-31g*_singlet.hdf5
+H12-C18_6-31g*_singlet.hdf5
+H14-C22_6-31g*_singlet.hdf5
+H16-C26_6-31g*_singlet.hdf5
+H18-C30_6-31g*_singlet.hdf5
+H20-C34_6-31g*_singlet.hdf5
+H22-C38_6-31g*_singlet.hdf5
+H24-C42_6-31g*_singlet.hdf5
+H26-C46_6-31g*_singlet.hdf5
+H28-C50_6-31g*_singlet.hdf5
+H8-C10_6-31g*_singlet.hdf5


### PR DESCRIPTION
Adding k-acenes to the cloud library.  pi active spaces are 4k + 2o, 4k + 2e in size.
Integrals for the active space are stored in the integral fields of MolecularData.

The MO-coefficients from pyscf are stored in the general_calculations field.

Email: rubinnc0@gmail.com