### PR TITLE
Update setup.py data_files to point to docs/tutorials/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ setup(
         ]
     },
     data_files=[('openfermion/examples', [
-        'docs/tutorials/binary_code_transforms_demo.ipynb',
-        'docs/tutorials/bosonic_operator_tutorial.ipynb',
+        'docs/tutorials/binary_code_transforms.ipynb',
+        'docs/tutorials/bosonic_operators.ipynb',
+        'docs/tutorials/intro_to_openfermion.ipynb',
         'docs/tutorials/jordan_wigner_and_bravyi_kitaev_transforms.ipynb',
-        'docs/tutorials/openfermion_tutorial.ipynb',
-        'docs/tutorials/performance_benchmarks.py'
+        'examples/performance_benchmarks.py'
     ])],
 )


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/OpenFermion/issues/644

Tested in Colab:

```
!pip install -U git+https://github.com/lamberta/OpenFermion.git@setup-docs#egg=openfermion
...

from openfermion.ops import FermionOperator

my_term = FermionOperator(((3, 1), (1, 0)))
print(my_term)

my_term = FermionOperator('3^ 1')
print(my_term)
```