### PR TITLE
Symm cons keywords

### DIFF
--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits.py
@@ -69,8 +69,11 @@ def symmetry_conserving_bravyi_kitaev(fermion_hamiltonian, active_orbitals,
         raise ValueError('Number of active fermions should be an integer.')
 
     # Arrange spins up then down, then BK map to qubit Hamiltonian.
-    fermion_hamiltonian_reorder = reorder(fermion_hamiltonian, up_then_down, num_modes=active_orbitals)
-    qubit_hamiltonian = bravyi_kitaev_tree(fermion_hamiltonian_reorder, n_qubits=active_orbitals)
+    fermion_hamiltonian_reorder = reorder(fermion_hamiltonian,
+                                          up_then_down,
+                                          num_modes=active_orbitals)
+    qubit_hamiltonian = bravyi_kitaev_tree(fermion_hamiltonian_reorder,
+                                           n_qubits=active_orbitals)
     qubit_hamiltonian.compress()
 
     # Allocates the parity factors for the orbitals as in arXiv:1704.05018.

--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits.py
@@ -69,8 +69,8 @@ def symmetry_conserving_bravyi_kitaev(fermion_hamiltonian, active_orbitals,
         raise ValueError('Number of active fermions should be an integer.')
 
     # Arrange spins up then down, then BK map to qubit Hamiltonian.
-    fermion_hamiltonian_reorder = reorder(fermion_hamiltonian, up_then_down)
-    qubit_hamiltonian = bravyi_kitaev_tree(fermion_hamiltonian_reorder)
+    fermion_hamiltonian_reorder = reorder(fermion_hamiltonian, up_then_down, num_modes=active_orbitals)
+    qubit_hamiltonian = bravyi_kitaev_tree(fermion_hamiltonian_reorder, n_qubits=active_orbitals)
     qubit_hamiltonian.compress()
 
     # Allocates the parity factors for the orbitals as in arXiv:1704.05018.

--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
@@ -142,7 +142,7 @@ class ReduceSymmetryQubitsTest(unittest.TestCase):
 
     # Check if single operator of a Hamiltonian is transformed consistently,
     # e.g. system with 2 particles, 4 spin-orbitals, and want to determine
-    # elements of 1- and 2-particle reduced density matrix
+    # elements of one- and two-particle reduced density matrix
     def test_single_operator(self):
         # Dummy operator acting only on 2 qubits of overall 4-qubit system
         op = FermionOperator("0^ 1^ 1 0") + FermionOperator("1^ 0^ 0 1")

--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
@@ -146,7 +146,9 @@ class ReduceSymmetryQubitsTest(unittest.TestCase):
     def test_single_operator(self):
         # Dummy operator acting only on 2 qubits of overall 4-qubit system
         op = FermionOperator("0^ 1^ 1 0") + FermionOperator("1^ 0^ 0 1")
-        trafo_op = symmetry_conserving_bravyi_kitaev(op, active_fermions=2, active_orbitals=4)
+        trafo_op = symmetry_conserving_bravyi_kitaev(op,
+                                                     active_fermions=2,
+                                                     active_orbitals=4)
         # Check via eigenspectrum -- needs to stay the same
         e_op = eigenspectrum(op)
         e_trafo = eigenspectrum(trafo_op)

--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
@@ -22,6 +22,7 @@ from openfermion.transforms.opconversions import get_fermion_operator
 from openfermion.linalg.sparse_tools import (
     get_sparse_operator, jw_get_ground_state_at_particle_number)
 from openfermion.linalg import eigenspectrum
+from openfermion.ops.operators import FermionOperator
 
 from openfermion.transforms.opconversions.remove_symmetry_qubits import (
     symmetry_conserving_bravyi_kitaev)
@@ -138,3 +139,16 @@ class ReduceSymmetryQubitsTest(unittest.TestCase):
                 sparse_op, n_ferm)
 
             self.assertAlmostEqual(eigenspectrum(hub_qbt)[0], ground_energy)
+
+    # Check if single operator of a Hamiltonian is transformed consistently,
+    # e.g. system with 2 particles, 4 spin-orbitals, and want to determine
+    # elements of 1- and 2-particle reduced density matrix
+    def test_single_operator(self):
+        # Dummy operator acting only on 2 qubits of overall 4-qubit system
+        op = FermionOperator("0^ 1^ 1 0") + FermionOperator("1^ 0^ 0 1")
+        trafo_op = symmetry_conserving_bravyi_kitaev(op, active_fermions=2, active_orbitals=4)
+        # Check via eigenspectrum -- needs to stay the same
+        e_op = eigenspectrum(op)
+        e_trafo = eigenspectrum(trafo_op)
+        # Check eigenvalues
+        self.assertSequenceEqual(e_op.tolist(), e_trafo.tolist())


### PR DESCRIPTION
Hi, hopefully this works now with the CLA...

This PR addresses an issue, that appears when using the symmetry_conserving_bravyi_kitaev transformation on operators acting only on a subset of qubits of the whole Hamiltonian (e.g. when one wants to determine the entries of the 2-RDM). This may not be very useful on certain systems (e.g. 2 fermions, 4 orbitals), as the transformation does not yield any benefit, but allows broader application.

Fixed by simple addition of 2 keywords in src/openfermion/transforms/opconversions/remove_symmetry_qubits.py + added a test with a dummy operator.

(A similar issue appears with the BKSF transformation, but would require deeper changes)