### PR TITLE
Update cirq pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.8.2
+cirq==0.9.1
 deprecation
 h5py>=2.8
 networkx

--- a/src/openfermion/circuits/gates/fermionic_simulation_test.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation_test.py
@@ -427,7 +427,7 @@ def test_quartic_fermionic_simulation_on_simulator(gate, exponent,
 
     a, b, c, d = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(gate(a, b, c, d)**exponent)
-    result = circuit.final_wavefunction(initial_state)
+    result = circuit.final_state_vector(initial_state=initial_state)
     cirq.testing.assert_allclose_up_to_global_phase(result,
                                                     correct_state,
                                                     atol=atol)

--- a/src/openfermion/circuits/gates/four_qubit_gates_test.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates_test.py
@@ -109,7 +109,7 @@ def test_four_qubit_rotation_gates_on_simulator(gate, exponent, initial_state,
 
     a, b, c, d = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(gate(a, b, c, d)**exponent)
-    result = circuit.final_wavefunction(initial_state)
+    result = circuit.final_state_vector(initial_state=initial_state)
     cirq.testing.assert_allclose_up_to_global_phase(result,
                                                     correct_state,
                                                     atol=atol)

--- a/src/openfermion/circuits/primitives/bogoliubov_transform_test.py
+++ b/src/openfermion/circuits/primitives/bogoliubov_transform_test.py
@@ -55,8 +55,7 @@ def test_bogoliubov_transform_fourier_transform(transformation_matrix,
         bogoliubov_transform(qubits,
                              transformation_matrix,
                              initial_state=initial_state))
-    state = circuit.final_wavefunction(initial_state)
-
+    state = circuit.final_state_vector(initial_state=initial_state)
     cirq.testing.assert_allclose_up_to_global_phase(state,
                                                     correct_state,
                                                     atol=atol)
@@ -106,7 +105,7 @@ def test_spin_symmetric_bogoliubov_transform(n_spatial_orbitals,
         bogoliubov_transform(qubits,
                              transformation_matrix,
                              initial_state=initial_state))
-    state = circuit.final_wavefunction(initial_state)
+    state = circuit.final_state_vector(initial_state=initial_state)
 
     # Check that the result is an eigenstate with the correct eigenvalue
     numpy.testing.assert_allclose(quad_ham_sparse.dot(state),
@@ -155,14 +154,14 @@ def test_bogoliubov_transform_quadratic_hamiltonian(n_qubits,
             2**(n_qubits - 1 - int(i)) for i in occupied_orbitals)
 
         # Get the state using a circuit simulation
-        state1 = circuit.final_wavefunction(initial_state)
+        state1 = circuit.final_state_vector(initial_state=initial_state)
 
         # Also test the option to start with a computational basis state
         special_circuit = cirq.Circuit(
             bogoliubov_transform(qubits,
                                  transformation_matrix,
                                  initial_state=initial_state))
-        state2 = special_circuit.final_wavefunction(
+        state2 = special_circuit.final_state_vector(
             initial_state, qubits_that_should_be_present=qubits)
 
         # Check that the result is an eigenstate with the correct eigenvalue

--- a/src/openfermion/circuits/primitives/ffft_test.py
+++ b/src/openfermion/circuits/primitives/ffft_test.py
@@ -150,7 +150,7 @@ def test_F0Gate_transform(amplitudes):
         _fourier_transform_single_fermionic_modes(amplitudes))
 
     circuit = cirq.Circuit(_F0Gate().on(*qubits))
-    state = circuit.final_wavefunction(initial_state)
+    state = circuit.final_state_vector(initial_state=initial_state)
 
     assert np.allclose(state, expected_state, rtol=0.0)
 
@@ -189,7 +189,7 @@ def test_TwiddleGate_transform(k, n, qubit, initial, expected):
     expected_state = _single_fermionic_modes_state(expected)
 
     circuit = cirq.Circuit(_TwiddleGate(k, n).on(qubits[qubit]))
-    state = circuit.final_wavefunction(initial_state,
+    state = circuit.final_state_vector(initial_state=initial_state,
                                        qubits_that_should_be_present=qubits)
 
     assert np.allclose(state, expected_state, rtol=0.0)
@@ -228,7 +228,7 @@ def test_ffft_single_fermionic_modes(amplitudes):
     qubits = LineQubit.range(len(amplitudes))
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_wavefunction(initial_state,
+    state = circuit.final_state_vector(initial_state=initial_state,
                                        qubits_that_should_be_present=qubits)
 
     assert np.allclose(state, expected_state, rtol=0.0)
@@ -256,7 +256,7 @@ def test_ffft_single_fermionic_modes_non_power_of_2(amplitudes):
     qubits = LineQubit.range(len(amplitudes))
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_wavefunction(initial_state,
+    state = circuit.final_state_vector(initial_state=initial_state,
                                        qubits_that_should_be_present=qubits)
 
     cirq.testing.assert_allclose_up_to_global_phase(state,
@@ -286,7 +286,7 @@ def test_ffft_multi_fermionic_mode(n, initial):
     qubits = LineQubit.range(n)
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_wavefunction(initial_state,
+    state = circuit.final_state_vector(initial_state=initial_state,
                                        qubits_that_should_be_present=qubits)
 
     assert np.allclose(state, expected_state, rtol=0.0)
@@ -306,7 +306,7 @@ def test_ffft_multi_fermionic_mode_non_power_of_2(n, initial):
     qubits = LineQubit.range(n)
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_wavefunction(initial_state,
+    state = circuit.final_state_vector(initial_state=initial_state,
                                        qubits_that_should_be_present=qubits)
 
     cirq.testing.assert_allclose_up_to_global_phase(state,

--- a/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
+++ b/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
@@ -241,5 +241,6 @@ def test_circuit_generation_state():
     test_unitary = scipy.linalg.expm(
         get_sparse_operator(fermion_generator, 4).toarray())
     test_final_state = test_unitary.dot(wavefunction)
-    cirq_wf = simulator.simulate(circuit).final_state
+    cirq_wf = simulator.simulate(circuit).final_state_vector
+
     assert numpy.allclose(cirq_wf, test_final_state.flatten())

--- a/src/openfermion/circuits/primitives/state_preparation_test.py
+++ b/src/openfermion/circuits/primitives/state_preparation_test.py
@@ -57,7 +57,7 @@ def test_prepare_gaussian_state(n_qubits,
                                initial_state=initial_state))
     if isinstance(initial_state, list):
         initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
-    state = circuit.final_wavefunction(initial_state)
+    state = circuit.final_state_vector(initial_state=initial_state)
 
     # Check that the result is an eigenstate with the correct eigenvalue
     numpy.testing.assert_allclose(quad_ham_sparse.dot(state),
@@ -110,7 +110,7 @@ def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
 
     if isinstance(initial_state, list):
         initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
-    state = circuit.final_wavefunction(initial_state)
+    state = circuit.final_state_vector(initial_state=initial_state)
 
     # Check that the result is an eigenstate with the correct eigenvalue
     numpy.testing.assert_allclose(quad_ham_sparse.dot(state),
@@ -157,6 +157,6 @@ def test_prepare_slater_determinant(slater_determinant_matrix,
                                    initial_state=initial_state))
     if isinstance(initial_state, list):
         initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
-    state = circuit.final_wavefunction(initial_state)
+    state = circuit.final_state_vector(initial_state=initial_state)
 
     assert cirq.allclose_up_to_global_phase(state, correct_state, atol=atol)

--- a/src/openfermion/circuits/trotter/simulate_trotter_test.py
+++ b/src/openfermion/circuits/trotter/simulate_trotter_test.py
@@ -151,7 +151,7 @@ def test_simulate_trotter_simulate(hamiltonian, time, initial_state,
     circuit = cirq.Circuit(
         simulate_trotter(qubits, hamiltonian, time, n_steps, order, algorithm))
 
-    final_state = circuit.final_wavefunction(start_state)
+    final_state = circuit.final_state_vector(initial_state=start_state)
     correct_state = exact_state
     assert fidelity(final_state, correct_state) > result_fidelity
     # Make sure the time wasn't too small
@@ -203,7 +203,7 @@ def test_simulate_trotter_simulate_controlled(hamiltonian, time, initial_state,
         simulate_trotter(qubits, hamiltonian, time, n_steps, order, algorithm,
                          control))
 
-    final_state = circuit.final_wavefunction(start_state)
+    final_state = circuit.final_state_vector(initial_state=start_state)
     correct_state = (numpy.kron(zero, initial_state) +
                      numpy.kron(one, exact_state)) / numpy.sqrt(2)
     assert fidelity(final_state, correct_state) > result_fidelity

--- a/src/openfermion/transforms/opconversions/qubitoperator_to_paulisum_test.py
+++ b/src/openfermion/transforms/opconversions/qubitoperator_to_paulisum_test.py
@@ -11,8 +11,8 @@
 #   limitations under the License.
 import pytest
 import numpy
-import openfermion
 import cirq
+import openfermion
 from openfermion.ops.operators import QubitOperator
 
 from openfermion.transforms.opconversions import (qubit_operator_to_pauli_sum)

--- a/src/openfermion/transforms/opconversions/qubitoperator_to_paulisum_test.py
+++ b/src/openfermion/transforms/opconversions/qubitoperator_to_paulisum_test.py
@@ -64,7 +64,7 @@ def test_expectation_values(qubitop, state_binary):
     op_mat = openfermion.get_sparse_operator(qubitop, n_qubits)
 
     expct_qop = openfermion.expectation(op_mat, state)
-    expct_pauli = pauli_str.expectation_from_wavefunction(state, qubit_map)
+    expct_pauli = pauli_str.expectation_from_state_vector(state, qubit_map)
 
     numpy.testing.assert_allclose(expct_qop, expct_pauli)
 
@@ -85,6 +85,6 @@ def test_expectation_values_paulisum(qubitop, state_binary):
     op_mat = openfermion.get_sparse_operator(qubitop, n_qubits)
 
     expct_qop = openfermion.expectation(op_mat, state)
-    expct_pauli = pauli_str.expectation_from_wavefunction(state, qubit_map)
+    expct_pauli = pauli_str.expectation_from_state_vector(state, qubit_map)
 
     numpy.testing.assert_allclose(expct_qop, expct_pauli)

--- a/src/openfermion/utils/bch_expansion_test.py
+++ b/src/openfermion/utils/bch_expansion_test.py
@@ -91,14 +91,14 @@ class BCHTest(unittest.TestCase):
 
             test = bch_expand(x, y, order=self.test_order)
             baseline = bch_expand_baseline(x, y, order=self.test_order)
-            self.assertAlmostEquals(norm(test - baseline), 0.0)
+            self.assertAlmostEqual(norm(test - baseline), 0.0)
 
             test = bch_expand(x, y, z, order=self.test_order)
             baseline = bch_expand_baseline(x,
                                            bch_expand_baseline(
                                                y, z, order=self.test_order),
                                            order=self.test_order)
-            self.assertAlmostEquals(norm(test - baseline), 0.0)
+            self.assertAlmostEqual(norm(test - baseline), 0.0)
 
     def test_verification(self):
         """Verify basic sanity checking on inputs"""

--- a/src/openfermion/utils/channel_state_test.py
+++ b/src/openfermion/utils/channel_state_test.py
@@ -41,14 +41,14 @@ class ChannelTest(unittest.TestCase):
         test_density_matrix = (amplitude_damping_channel(
             self.density_matrix, 0, 1))
         self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
-                                0.0)
+                               0.0)
 
         test_density_matrix = (amplitude_damping_channel(self.density_matrix,
                                                          0,
                                                          1,
                                                          transpose=True))
         self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
-                                0.0)
+                               0.0)
 
         # With probability 1
         correct_density_matrix = np.zeros((4, 4), dtype=complex)
@@ -66,7 +66,7 @@ class ChannelTest(unittest.TestCase):
         # Check for identity on |11> state
         test_density_matrix = (dephasing_channel(self.density_matrix, 1, 1))
         self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
-                                0.0)
+                               0.0)
 
         test_density_matrix = (dephasing_channel(self.density_matrix,
                                                  1,
@@ -80,8 +80,7 @@ class ChannelTest(unittest.TestCase):
         # Check for correct action on cat state
         # With probability = 0
         test_density_matrix = (dephasing_channel(self.cat_matrix, 0, 1))
-        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
-                                0.0)
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix), 0.0)
         # With probability = 1
 
         correct_matrix = np.array([[0.50, 0.25, 0.00, 0.00],
@@ -96,15 +95,13 @@ class ChannelTest(unittest.TestCase):
 
         # With probability = 0
         test_density_matrix = (depolarizing_channel(self.cat_matrix, 0, 1))
-        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
-                                0.0)
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix), 0.0)
 
         test_density_matrix = (depolarizing_channel(self.cat_matrix,
                                                     0,
                                                     1,
                                                     transpose=True))
-        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
-                                0.0)
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix), 0.0)
 
         # With probability 1 on both qubits
         correct_density_matrix = (np.array(
@@ -117,9 +114,9 @@ class ChannelTest(unittest.TestCase):
         test_density_matrix = (depolarizing_channel(test_density_matrix, 1, 1))
 
         self.assertAlmostEqual(norm(correct_density_matrix -
-                                     test_density_matrix),
-                                0.0,
-                                places=6)
+                                    test_density_matrix),
+                               0.0,
+                               places=6)
 
         # Depolarizing channel should be self-adjoint
         test_density_matrix = (depolarizing_channel(self.cat_matrix,
@@ -132,17 +129,17 @@ class ChannelTest(unittest.TestCase):
                                                     transpose=True))
 
         self.assertAlmostEqual(norm(correct_density_matrix -
-                                     test_density_matrix),
-                                0.0,
-                                places=6)
+                                    test_density_matrix),
+                               0.0,
+                               places=6)
 
         # With probability 1 for total depolarization
         correct_density_matrix = np.eye(4) / 4.0
         test_density_matrix = (depolarizing_channel(self.cat_matrix, 1, 'All'))
         self.assertAlmostEqual(norm(correct_density_matrix -
-                                     test_density_matrix),
-                                0.0,
-                                places=6)
+                                    test_density_matrix),
+                               0.0,
+                               places=6)
 
     def test_verification(self):
         """Verify basic sanity checking on inputs"""

--- a/src/openfermion/utils/channel_state_test.py
+++ b/src/openfermion/utils/channel_state_test.py
@@ -40,14 +40,14 @@ class ChannelTest(unittest.TestCase):
         # With probability 0
         test_density_matrix = (amplitude_damping_channel(
             self.density_matrix, 0, 1))
-        self.assertAlmostEquals(norm(self.density_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
                                 0.0)
 
         test_density_matrix = (amplitude_damping_channel(self.density_matrix,
                                                          0,
                                                          1,
                                                          transpose=True))
-        self.assertAlmostEquals(norm(self.density_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
                                 0.0)
 
         # With probability 1
@@ -57,7 +57,7 @@ class ChannelTest(unittest.TestCase):
         test_density_matrix = (amplitude_damping_channel(
             self.density_matrix, 1, 1))
 
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             norm(correct_density_matrix - test_density_matrix), 0.0)
 
     def test_dephasing(self):
@@ -65,7 +65,7 @@ class ChannelTest(unittest.TestCase):
 
         # Check for identity on |11> state
         test_density_matrix = (dephasing_channel(self.density_matrix, 1, 1))
-        self.assertAlmostEquals(norm(self.density_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.density_matrix - test_density_matrix),
                                 0.0)
 
         test_density_matrix = (dephasing_channel(self.density_matrix,
@@ -75,12 +75,12 @@ class ChannelTest(unittest.TestCase):
 
         correct_matrix = np.array([[0., 0., 0., 0.], [0., 0., 0., 0.],
                                    [0., 0., 0.5, -0.5], [0., 0., -0.5, 1.]])
-        self.assertAlmostEquals(norm(correct_matrix - test_density_matrix), 0.0)
+        self.assertAlmostEqual(norm(correct_matrix - test_density_matrix), 0.0)
 
         # Check for correct action on cat state
         # With probability = 0
         test_density_matrix = (dephasing_channel(self.cat_matrix, 0, 1))
-        self.assertAlmostEquals(norm(self.cat_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
                                 0.0)
         # With probability = 1
 
@@ -89,21 +89,21 @@ class ChannelTest(unittest.TestCase):
                                    [0.00, 0.00, 0.00, 0.00],
                                    [0.00, -0.25, 0.00, 0.50]])
         test_density_matrix = (dephasing_channel(self.cat_matrix, 1, 1))
-        self.assertAlmostEquals(norm(correct_matrix - test_density_matrix), 0.0)
+        self.assertAlmostEqual(norm(correct_matrix - test_density_matrix), 0.0)
 
     def test_depolarizing(self):
         """Test depolarizing on a simple qubit state"""
 
         # With probability = 0
         test_density_matrix = (depolarizing_channel(self.cat_matrix, 0, 1))
-        self.assertAlmostEquals(norm(self.cat_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
                                 0.0)
 
         test_density_matrix = (depolarizing_channel(self.cat_matrix,
                                                     0,
                                                     1,
                                                     transpose=True))
-        self.assertAlmostEquals(norm(self.cat_matrix - test_density_matrix),
+        self.assertAlmostEqual(norm(self.cat_matrix - test_density_matrix),
                                 0.0)
 
         # With probability 1 on both qubits
@@ -116,7 +116,7 @@ class ChannelTest(unittest.TestCase):
         test_density_matrix = (depolarizing_channel(self.cat_matrix, 1, 0))
         test_density_matrix = (depolarizing_channel(test_density_matrix, 1, 1))
 
-        self.assertAlmostEquals(norm(correct_density_matrix -
+        self.assertAlmostEqual(norm(correct_density_matrix -
                                      test_density_matrix),
                                 0.0,
                                 places=6)
@@ -131,7 +131,7 @@ class ChannelTest(unittest.TestCase):
                                                     1,
                                                     transpose=True))
 
-        self.assertAlmostEquals(norm(correct_density_matrix -
+        self.assertAlmostEqual(norm(correct_density_matrix -
                                      test_density_matrix),
                                 0.0,
                                 places=6)
@@ -139,7 +139,7 @@ class ChannelTest(unittest.TestCase):
         # With probability 1 for total depolarization
         correct_density_matrix = np.eye(4) / 4.0
         test_density_matrix = (depolarizing_channel(self.cat_matrix, 1, 'All'))
-        self.assertAlmostEquals(norm(correct_density_matrix -
+        self.assertAlmostEqual(norm(correct_density_matrix -
                                      test_density_matrix),
                                 0.0,
                                 places=6)


### PR DESCRIPTION
Updated test files now use `final_state_vector`.  Old function call
will be depricated in cirq  v0.10.