### PR TITLE
Type hints hamiltonians

### DIFF
--- a/src/openfermion/.vscode/settings.json
+++ b/src/openfermion/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.pylintEnabled": false,
+    "python.linting.pycodestyleEnabled": true,
+    "python.linting.enabled": true
+}

--- a/src/openfermion/.vscode/settings.json
+++ b/src/openfermion/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python.linting.pylintEnabled": false,
-    "python.linting.pycodestyleEnabled": true,
-    "python.linting.enabled": true
-}

--- a/src/openfermion/hamiltonians/jellium.py
+++ b/src/openfermion/hamiltonians/jellium.py
@@ -16,8 +16,11 @@ import numpy
 from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.utils.grid import Grid
 
+from typing import Optional
 
-def wigner_seitz_length_scale(wigner_seitz_radius, n_particles, dimension):
+
+def wigner_seitz_length_scale(wigner_seitz_radius: float,
+                                n_particles: int, dimension: int) -> float:
     """Function to give length_scale associated with Wigner-Seitz radius.
 
     Args:
@@ -51,7 +54,8 @@ def wigner_seitz_length_scale(wigner_seitz_radius, n_particles, dimension):
     return length_scale
 
 
-def plane_wave_kinetic(grid, spinless=False, e_cutoff=None):
+def plane_wave_kinetic(grid: Grid, spinless: bool = False,
+                        e_cutoff: Optional[float] = None) -> FermionOperator:
     """Return the kinetic energy operator in the plane wave basis.
 
     Args:
@@ -86,11 +90,11 @@ def plane_wave_kinetic(grid, spinless=False, e_cutoff=None):
     return operator
 
 
-def plane_wave_potential(grid,
-                         spinless=False,
-                         e_cutoff=None,
-                         non_periodic=False,
-                         period_cutoff=None):
+def plane_wave_potential(grid: Grid,
+                         spinless: bool = False,
+                         e_cutoff: float = None,
+                         non_periodic: bool = False,
+                         period_cutoff: Optional[float] = None) -> FermionOperator:
     """Return the e-e potential operator in the plane wave basis.
 
     Args:
@@ -184,13 +188,14 @@ def plane_wave_potential(grid,
     return operator
 
 
-def dual_basis_jellium_model(grid,
-                             spinless=False,
-                             kinetic=True,
-                             potential=True,
-                             include_constant=False,
-                             non_periodic=False,
-                             period_cutoff=None):
+def dual_basis_jellium_model(grid: Grid,
+                             spinless: bool = False,
+                             kinetic: bool = True,
+                             potential: bool = True,
+                             include_constant: bool = False,
+                             non_periodic: bool = False,
+                             period_cutoff: Optional[float] = None
+                             ) -> FermionOperator:
     """Return jellium Hamiltonian in the dual basis of arXiv:1706.00023
 
     Args:
@@ -293,7 +298,7 @@ def dual_basis_jellium_model(grid,
     return operator
 
 
-def dual_basis_kinetic(grid, spinless=False):
+def dual_basis_kinetic(grid: Grid, spinless: bool = False) -> FermionOperator:
     """Return the kinetic operator in the dual basis of arXiv:1706.00023.
 
     Args:
@@ -306,10 +311,11 @@ def dual_basis_kinetic(grid, spinless=False):
     return dual_basis_jellium_model(grid, spinless, True, False)
 
 
-def dual_basis_potential(grid,
-                         spinless=False,
-                         non_periodic=False,
-                         period_cutoff=None):
+def dual_basis_potential(grid: Grid,
+                         spinless: bool = False,
+                         non_periodic: bool = False,
+                         period_cutoff: Optional[float] = None
+                         ) -> FermionOperator:
     """Return the potential operator in the dual basis of arXiv:1706.00023
 
     Args:
@@ -326,13 +332,13 @@ def dual_basis_potential(grid,
                                     non_periodic, period_cutoff)
 
 
-def jellium_model(grid,
-                  spinless=False,
-                  plane_wave=True,
-                  include_constant=False,
-                  e_cutoff=None,
-                  non_periodic=False,
-                  period_cutoff=None):
+def jellium_model(grid: Grid,
+                  spinless: bool = False,
+                  plane_wave: bool = True,
+                  include_constant: bool = False,
+                  e_cutoff: float = None,
+                  non_periodic: bool = False,
+                  period_cutoff: Optional[float] = None) -> FermionOperator:
     """Return jellium Hamiltonian as FermionOperator class.
 
     Args:
@@ -367,9 +373,10 @@ def jellium_model(grid,
     return hamiltonian
 
 
-def jordan_wigner_dual_basis_jellium(grid,
-                                     spinless=False,
-                                     include_constant=False):
+def jordan_wigner_dual_basis_jellium(grid: Grid,
+                                     spinless: bool = False,
+                                     include_constant: bool = False
+                                     ) -> QubitOperator:
     """Return the jellium Hamiltonian as QubitOperator in the dual basis.
 
     Args:
@@ -482,11 +489,11 @@ def jordan_wigner_dual_basis_jellium(grid,
 
 
 def hypercube_grid_with_given_wigner_seitz_radius_and_filling(
-        dimension,
-        grid_length,
-        wigner_seitz_radius,
-        filling_fraction=0.5,
-        spinless=True):
+        dimension: int,
+        grid_length: int,
+        wigner_seitz_radius: float,
+        filling_fraction: float = 0.5,
+        spinless: bool = True) -> Grid:
     """Return a Grid with the same number of orbitals along each dimension
     with the specified Wigner-Seitz radius.
 

--- a/src/openfermion/hamiltonians/jellium.py
+++ b/src/openfermion/hamiltonians/jellium.py
@@ -11,12 +11,12 @@
 #   limitations under the License.
 """This module constructs Hamiltonians for the uniform electron gas."""
 
+from typing import Optional
+
 import numpy
 
 from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.utils.grid import Grid
-
-from typing import Optional
 
 
 def wigner_seitz_length_scale(wigner_seitz_radius: float,
@@ -94,7 +94,8 @@ def plane_wave_potential(grid: Grid,
                          spinless: bool = False,
                          e_cutoff: float = None,
                          non_periodic: bool = False,
-                         period_cutoff: Optional[float] = None) -> FermionOperator:
+                         period_cutoff: Optional[float] = None
+                         ) -> FermionOperator:
     """Return the e-e potential operator in the plane wave basis.
 
     Args:

--- a/src/openfermion/hamiltonians/jellium.py
+++ b/src/openfermion/hamiltonians/jellium.py
@@ -19,8 +19,8 @@ from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.utils.grid import Grid
 
 
-def wigner_seitz_length_scale(wigner_seitz_radius: float,
-                                n_particles: int, dimension: int) -> float:
+def wigner_seitz_length_scale(wigner_seitz_radius: float, n_particles: int,
+                              dimension: int) -> float:
     """Function to give length_scale associated with Wigner-Seitz radius.
 
     Args:
@@ -54,8 +54,9 @@ def wigner_seitz_length_scale(wigner_seitz_radius: float,
     return length_scale
 
 
-def plane_wave_kinetic(grid: Grid, spinless: bool = False,
-                        e_cutoff: Optional[float] = None) -> FermionOperator:
+def plane_wave_kinetic(grid: Grid,
+                       spinless: bool = False,
+                       e_cutoff: Optional[float] = None) -> FermionOperator:
     """Return the kinetic energy operator in the plane wave basis.
 
     Args:
@@ -95,7 +96,7 @@ def plane_wave_potential(grid: Grid,
                          e_cutoff: float = None,
                          non_periodic: bool = False,
                          period_cutoff: Optional[float] = None
-                         ) -> FermionOperator:
+                        ) -> FermionOperator:
     """Return the e-e potential operator in the plane wave basis.
 
     Args:
@@ -196,7 +197,7 @@ def dual_basis_jellium_model(grid: Grid,
                              include_constant: bool = False,
                              non_periodic: bool = False,
                              period_cutoff: Optional[float] = None
-                             ) -> FermionOperator:
+                            ) -> FermionOperator:
     """Return jellium Hamiltonian in the dual basis of arXiv:1706.00023
 
     Args:
@@ -316,7 +317,7 @@ def dual_basis_potential(grid: Grid,
                          spinless: bool = False,
                          non_periodic: bool = False,
                          period_cutoff: Optional[float] = None
-                         ) -> FermionOperator:
+                        ) -> FermionOperator:
     """Return the potential operator in the dual basis of arXiv:1706.00023
 
     Args:
@@ -377,7 +378,7 @@ def jellium_model(grid: Grid,
 def jordan_wigner_dual_basis_jellium(grid: Grid,
                                      spinless: bool = False,
                                      include_constant: bool = False
-                                     ) -> QubitOperator:
+                                    ) -> QubitOperator:
     """Return the jellium Hamiltonian as QubitOperator in the dual basis.
 
     Args:

--- a/src/openfermion/hamiltonians/mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/mean_field_dwave.py
@@ -18,13 +18,15 @@ from openfermion.hamiltonians.special_operators import number_operator
 # Preventing cyclical imports
 import openfermion.utils as op_utils
 
+from typing import Optional
 
-def mean_field_dwave(x_dimension,
-                     y_dimension,
-                     tunneling,
-                     sc_gap,
-                     chemical_potential=0.,
-                     periodic=True):
+
+def mean_field_dwave(x_dimension: int,
+                     y_dimension: int,
+                     tunneling: float,
+                     sc_gap: float,
+                     chemical_potential: Optional[float] = 0.,
+                     periodic: bool = True) -> FermionOperator:
     r"""Return symbolic representation of a BCS mean-field d-wave Hamiltonian.
 
     The Hamiltonians of this model live on a grid of dimensions

--- a/src/openfermion/hamiltonians/mean_field_dwave.py
+++ b/src/openfermion/hamiltonians/mean_field_dwave.py
@@ -10,6 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """This module constructs Hamiltonians for the BCS mean-field d-wave model."""
+from typing import Optional
 
 from openfermion.ops.operators import FermionOperator
 from openfermion.utils.indexing import down_index, up_index
@@ -17,8 +18,6 @@ from openfermion.hamiltonians.special_operators import number_operator
 
 # Preventing cyclical imports
 import openfermion.utils as op_utils
-
-from typing import Optional
 
 
 def mean_field_dwave(x_dimension: int,

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -90,8 +90,7 @@ def plane_wave_external_potential(
         spinless: bool,
         e_cutoff: Optional[float] = None,
         non_periodic: bool = False,
-        period_cutoff: Optional[float] = None
-        ) -> FermionOperator:
+        period_cutoff: Optional[float] = None) -> FermionOperator:
     """Return the external potential operator in plane wave basis.
 
     The external potential resulting from electrons interacting with nuclei.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -23,12 +23,12 @@ from openfermion.utils.grid import Grid
 import openfermion.chem.molecular_data as md
 
 
-def dual_basis_external_potential(grid: Grid,
-                                  geometry: List[Tuple[str, Tuple[int, int, int]]],
-                                  spinless: bool,
-                                  non_periodic: bool = False,
-                                  period_cutoff: Optional[float] = None
-                                  ) -> FermionOperator:
+def dual_basis_external_potential(
+        grid: Grid,
+        geometry: List[Tuple[str, Tuple[int, int, int]]],
+        spinless: bool,
+        non_periodic: bool = False,
+        period_cutoff: Optional[float] = None) -> FermionOperator:
     """Return the external potential in the dual basis of arXiv:1706.00023.
 
     The external potential resulting from electrons interacting with nuclei
@@ -84,13 +84,14 @@ def dual_basis_external_potential(grid: Grid,
     return operator
 
 
-def plane_wave_external_potential(grid: Grid,
-                                  geometry: List[Tuple[str, Tuple[int, int, int]]],
-                                  spinless: bool,
-                                  e_cutoff: Optional[float] = None,
-                                  non_periodic: bool = False,
-                                  period_cutoff: Optional[float] = None
-                                  ) -> FermionOperator:
+def plane_wave_external_potential(
+         grid: Grid,
+         geometry: List[Tuple[str, Tuple[int, int, int]]],
+         spinless: bool,
+         e_cutoff: Optional[float] = None,
+         non_periodic: bool = False,
+         period_cutoff: Optional[float] = None
+        ) -> FermionOperator:
     """Return the external potential operator in plane wave basis.
 
     The external potential resulting from electrons interacting with nuclei.
@@ -121,15 +122,15 @@ def plane_wave_external_potential(grid: Grid,
     return operator
 
 
-def plane_wave_hamiltonian(grid: Grid,
-                           geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
-                           spinless: bool = False,
-                           plane_wave: bool = True,
-                           include_constant: bool = False,
-                           e_cutoff: Optional[float] = None,
-                           non_periodic: bool = False,
-                           period_cutoff: Optional[float] = None
-                           ) -> FermionOperator:
+def plane_wave_hamiltonian(
+        grid: Grid,
+        geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+        spinless: bool = False,
+        plane_wave: bool = True,
+        include_constant: bool = False,
+        e_cutoff: Optional[float] = None,
+        non_periodic: bool = False,
+        period_cutoff: Optional[float] = None) -> FermionOperator:
     """Returns Hamiltonian as FermionOperator class.
 
     Args:
@@ -174,11 +175,11 @@ def plane_wave_hamiltonian(grid: Grid,
     return jellium_op + external_potential
 
 
-def jordan_wigner_dual_basis_hamiltonian(grid: Grid,
-                                         geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
-                                         spinless: bool = False,
-                                         include_constant: bool = False
-                                         ) -> QubitOperator:
+def jordan_wigner_dual_basis_hamiltonian(
+        grid: Grid,
+        geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+        spinless: bool = False,
+        include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.
 
     Args:

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -85,12 +85,12 @@ def dual_basis_external_potential(
 
 
 def plane_wave_external_potential(
-         grid: Grid,
-         geometry: List[Tuple[str, Tuple[int, int, int]]],
-         spinless: bool,
-         e_cutoff: Optional[float] = None,
-         non_periodic: bool = False,
-         period_cutoff: Optional[float] = None
+        grid: Grid,
+        geometry: List[Tuple[str, Tuple[int, int, int]]],
+        spinless: bool,
+        e_cutoff: Optional[float] = None,
+        non_periodic: bool = False,
+        period_cutoff: Optional[float] = None
         ) -> FermionOperator:
     """Return the external potential operator in plane wave basis.
 

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -16,15 +16,19 @@ from openfermion.hamiltonians.jellium import (jellium_model,
                                               jordan_wigner_dual_basis_jellium)
 from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.transforms.repconversions import inverse_fourier_transform
+from openfermion.utils.grid import Grid
 
 import openfermion.chem.molecular_data as md
 
+from typing import List, Tuple, Optional
 
-def dual_basis_external_potential(grid,
-                                  geometry,
-                                  spinless,
-                                  non_periodic=False,
-                                  period_cutoff=None):
+
+def dual_basis_external_potential(grid: Grid,
+                                  geometry: List[Tuple[str, Tuple[int, int, int]]],
+                                  spinless: bool,
+                                  non_periodic: bool = False,
+                                  period_cutoff: Optional[float] = None
+                                  ) -> FermionOperator:
     """Return the external potential in the dual basis of arXiv:1706.00023.
 
     The external potential resulting from electrons interacting with nuclei
@@ -80,12 +84,13 @@ def dual_basis_external_potential(grid,
     return operator
 
 
-def plane_wave_external_potential(grid,
-                                  geometry,
-                                  spinless,
-                                  e_cutoff=None,
-                                  non_periodic=False,
-                                  period_cutoff=None):
+def plane_wave_external_potential(grid: Grid,
+                                  geometry: List[Tuple[str, Tuple[int, int, int]]],
+                                  spinless: bool,
+                                  e_cutoff: Optional[float] = None,
+                                  non_periodic: bool = False,
+                                  period_cutoff: Optional[float] = None
+                                  ) -> FermionOperator:
     """Return the external potential operator in plane wave basis.
 
     The external potential resulting from electrons interacting with nuclei.
@@ -116,14 +121,15 @@ def plane_wave_external_potential(grid,
     return operator
 
 
-def plane_wave_hamiltonian(grid,
-                           geometry=None,
-                           spinless=False,
-                           plane_wave=True,
-                           include_constant=False,
-                           e_cutoff=None,
-                           non_periodic=False,
-                           period_cutoff=None):
+def plane_wave_hamiltonian(grid: Grid,
+                           geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+                           spinless: bool = False,
+                           plane_wave: bool = True,
+                           include_constant: bool = False,
+                           e_cutoff: Optional[float] = None,
+                           non_periodic: bool = False,
+                           period_cutoff: Optional[float] = None
+                           ) -> FermionOperator:
     """Returns Hamiltonian as FermionOperator class.
 
     Args:
@@ -168,10 +174,11 @@ def plane_wave_hamiltonian(grid,
     return jellium_op + external_potential
 
 
-def jordan_wigner_dual_basis_hamiltonian(grid,
-                                         geometry=None,
-                                         spinless=False,
-                                         include_constant=False):
+def jordan_wigner_dual_basis_hamiltonian(grid: Grid,
+                                         geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+                                         spinless: bool = False,
+                                         include_constant: bool = False
+                                         ) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.
 
     Args:

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -25,8 +25,7 @@ import openfermion.chem.molecular_data as md
 
 def dual_basis_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
-                                        Union[int, float]]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]],
         spinless: bool,
         non_periodic: bool = False,
         period_cutoff: Optional[float] = None) -> FermionOperator:
@@ -87,8 +86,7 @@ def dual_basis_external_potential(
 
 def plane_wave_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
-                                        Union[int, float]]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]],
         spinless: bool,
         e_cutoff: Optional[float] = None,
         non_periodic: bool = False,
@@ -125,8 +123,7 @@ def plane_wave_external_potential(
 
 def plane_wave_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[
-            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         plane_wave: bool = True,
         include_constant: bool = False,
@@ -179,8 +176,7 @@ def plane_wave_hamiltonian(
 
 def jordan_wigner_dual_basis_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[
-            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -25,7 +25,8 @@ import openfermion.chem.molecular_data as md
 
 def dual_basis_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[int, int, int]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
+                       Union[int, float]]]],
         spinless: bool,
         non_periodic: bool = False,
         period_cutoff: Optional[float] = None) -> FermionOperator:
@@ -86,7 +87,8 @@ def dual_basis_external_potential(
 
 def plane_wave_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[int, int, int]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
+                       Union[int, float]]]],
         spinless: bool,
         e_cutoff: Optional[float] = None,
         non_periodic: bool = False,
@@ -123,7 +125,8 @@ def plane_wave_external_potential(
 
 def plane_wave_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
+                           Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         plane_wave: bool = True,
         include_constant: bool = False,
@@ -176,7 +179,8 @@ def plane_wave_hamiltonian(
 
 def jordan_wigner_dual_basis_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[int, int, int]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
+                           Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -26,7 +26,7 @@ import openfermion.chem.molecular_data as md
 def dual_basis_external_potential(
         grid: Grid,
         geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
-                       Union[int, float]]]],
+                                        Union[int, float]]]],
         spinless: bool,
         non_periodic: bool = False,
         period_cutoff: Optional[float] = None) -> FermionOperator:
@@ -88,7 +88,7 @@ def dual_basis_external_potential(
 def plane_wave_external_potential(
         grid: Grid,
         geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
-                       Union[int, float]]]],
+                                        Union[int, float]]]],
         spinless: bool,
         e_cutoff: Optional[float] = None,
         non_periodic: bool = False,
@@ -126,7 +126,7 @@ def plane_wave_external_potential(
 def plane_wave_hamiltonian(
         grid: Grid,
         geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
-                           Union[int, float], Union[int, float]]]]] = None,
+            Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         plane_wave: bool = True,
         include_constant: bool = False,
@@ -180,7 +180,7 @@ def plane_wave_hamiltonian(
 def jordan_wigner_dual_basis_hamiltonian(
         grid: Grid,
         geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
-                           Union[int, float], Union[int, float]]]]] = None,
+            Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -25,7 +25,8 @@ import openfermion.chem.molecular_data as md
 
 def dual_basis_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
+                                        Union[int, float]]]],
         spinless: bool,
         non_periodic: bool = False,
         period_cutoff: Optional[float] = None) -> FermionOperator:
@@ -86,7 +87,8 @@ def dual_basis_external_potential(
 
 def plane_wave_external_potential(
         grid: Grid,
-        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]],
+        geometry: List[Tuple[str, Tuple[Union[int, float], Union[int, float],
+                                        Union[int, float]]]],
         spinless: bool,
         e_cutoff: Optional[float] = None,
         non_periodic: bool = False,
@@ -123,7 +125,8 @@ def plane_wave_external_potential(
 
 def plane_wave_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[
+            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         plane_wave: bool = True,
         include_constant: bool = False,
@@ -176,7 +179,8 @@ def plane_wave_hamiltonian(
 
 def jordan_wigner_dual_basis_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[Union[int, float], Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[
+            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -125,8 +125,8 @@ def plane_wave_external_potential(
 
 def plane_wave_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
-            Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[
+            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         plane_wave: bool = True,
         include_constant: bool = False,
@@ -179,8 +179,8 @@ def plane_wave_hamiltonian(
 
 def jordan_wigner_dual_basis_hamiltonian(
         grid: Grid,
-        geometry: Optional[List[Tuple[str, Tuple[Union[int, float],
-            Union[int, float], Union[int, float]]]]] = None,
+        geometry: Optional[List[Tuple[str, Tuple[
+            Union[int, float], Union[int, float], Union[int, float]]]]] = None,
         spinless: bool = False,
         include_constant: bool = False) -> QubitOperator:
     """Return the dual basis Hamiltonian as QubitOperator.

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -10,6 +10,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Construct Hamiltonians in plan wave basis and its dual in 3D."""
+from typing import List, Tuple, Optional
+
 import numpy as np
 
 from openfermion.hamiltonians.jellium import (jellium_model,
@@ -19,8 +21,6 @@ from openfermion.transforms.repconversions import inverse_fourier_transform
 from openfermion.utils.grid import Grid
 
 import openfermion.chem.molecular_data as md
-
-from typing import List, Tuple, Optional
 
 
 def dual_basis_external_potential(grid: Grid,

--- a/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
+++ b/src/openfermion/hamiltonians/plane_wave_hamiltonian.py
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Construct Hamiltonians in plan wave basis and its dual in 3D."""
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 
 import numpy as np
 

--- a/src/openfermion/hamiltonians/special_operators.py
+++ b/src/openfermion/hamiltonians/special_operators.py
@@ -206,7 +206,7 @@ def s_squared_operator(n_spatial_orbitals: int) -> FermionOperator:
 
 
 def majorana_operator(term: Optional[Union[Tuple[int, int], str]] = None,
-                        coefficient=1.) -> FermionOperator:
+                      coefficient=1.) -> FermionOperator:
     r"""Initialize a Majorana operator.
 
     Args:
@@ -276,8 +276,7 @@ def majorana_operator(term: Optional[Union[Tuple[int, int], str]] = None,
 def number_operator(n_modes: int,
                     mode: Optional[int] = None,
                     coefficient=1.,
-                    parity: int = -1
-                    ) -> Union[BosonOperator, FermionOperator]:
+                    parity: int = -1) -> Union[BosonOperator, FermionOperator]:
     """Return a fermionic or bosonic number operator.
 
     Args:

--- a/src/openfermion/hamiltonians/special_operators.py
+++ b/src/openfermion/hamiltonians/special_operators.py
@@ -13,8 +13,10 @@
 from openfermion.ops.operators import BosonOperator, FermionOperator
 from openfermion.utils.indexing import down_index, up_index
 
+from typing import Optional, Union, Tuple
 
-def s_plus_operator(n_spatial_orbitals):
+
+def s_plus_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the s+ operator.
 
     .. math::
@@ -44,7 +46,7 @@ def s_plus_operator(n_spatial_orbitals):
     return operator
 
 
-def s_minus_operator(n_spatial_orbitals):
+def s_minus_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the s+ operator.
 
     .. math::
@@ -74,7 +76,7 @@ def s_minus_operator(n_spatial_orbitals):
     return operator
 
 
-def sx_operator(n_spatial_orbitals):
+def sx_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the sx operator.
 
     .. math::
@@ -107,7 +109,7 @@ def sx_operator(n_spatial_orbitals):
     return operator
 
 
-def sy_operator(n_spatial_orbitals):
+def sy_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the sy operator.
 
     .. math::
@@ -140,7 +142,7 @@ def sy_operator(n_spatial_orbitals):
     return operator
 
 
-def sz_operator(n_spatial_orbitals):
+def sz_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the sz operator.
 
     .. math::
@@ -172,7 +174,7 @@ def sz_operator(n_spatial_orbitals):
     return operator
 
 
-def s_squared_operator(n_spatial_orbitals):
+def s_squared_operator(n_spatial_orbitals: int) -> FermionOperator:
     r"""Return the s^{2} operator.
 
     .. math::
@@ -203,7 +205,8 @@ def s_squared_operator(n_spatial_orbitals):
     return operator
 
 
-def majorana_operator(term=None, coefficient=1.):
+def majorana_operator(term: Optional[Tuple[int, int], str] = None,
+                        coefficient=1.) -> FermionOperator:
     r"""Initialize a Majorana operator.
 
     Args:
@@ -270,7 +273,11 @@ def majorana_operator(term=None, coefficient=1.):
         raise ValueError('Operator specified incorrectly.')
 
 
-def number_operator(n_modes, mode=None, coefficient=1., parity=-1):
+def number_operator(n_modes: int,
+                    mode: Optional[int] = None,
+                    coefficient=1.,
+                    parity: int = -1
+                    ) -> Union[BosonOperator, FermionOperator]:
     """Return a fermionic or bosonic number operator.
 
     Args:
@@ -285,10 +292,13 @@ def number_operator(n_modes, mode=None, coefficient=1., parity=-1):
     Returns:
         operator (BosonOperator or FermionOperator)
     """
+
     if parity == -1:
         Op = FermionOperator
     elif parity == 1:
         Op = BosonOperator
+    else:
+        raise ValueError('Invalid parity value: {}'.format(parity))
 
     if mode is None:
         operator = Op()

--- a/src/openfermion/hamiltonians/special_operators.py
+++ b/src/openfermion/hamiltonians/special_operators.py
@@ -205,7 +205,7 @@ def s_squared_operator(n_spatial_orbitals: int) -> FermionOperator:
     return operator
 
 
-def majorana_operator(term: Optional[Tuple[int, int], str] = None,
+def majorana_operator(term: Optional[Union[Tuple[int, int], str]] = None,
                         coefficient=1.) -> FermionOperator:
     r"""Initialize a Majorana operator.
 

--- a/src/openfermion/hamiltonians/special_operators.py
+++ b/src/openfermion/hamiltonians/special_operators.py
@@ -10,10 +10,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Commonly used operators (mainly instances of SymbolicOperator)."""
+from typing import Optional, Union, Tuple
+
 from openfermion.ops.operators import BosonOperator, FermionOperator
 from openfermion.utils.indexing import down_index, up_index
-
-from typing import Optional, Union, Tuple
 
 
 def s_plus_operator(n_spatial_orbitals: int) -> FermionOperator:

--- a/src/openfermion/hamiltonians/special_operators_test.py
+++ b/src/openfermion/hamiltonians/special_operators_test.py
@@ -150,7 +150,6 @@ class NumberOperatorTest(unittest.TestCase):
             number_operator(4, parity=2)
 
 
-
 class MajoranaOperatorTest(unittest.TestCase):
 
     def test_init(self):

--- a/src/openfermion/hamiltonians/special_operators_test.py
+++ b/src/openfermion/hamiltonians/special_operators_test.py
@@ -145,6 +145,11 @@ class NumberOperatorTest(unittest.TestCase):
                 ((3, 1), (3, 0))))
         self.assertTrue(op == expected)
 
+    def test_bad_parity(self):
+        with self.assertRaises(ValueError):
+            number_operator(4, parity=2)
+
+
 
 class MajoranaOperatorTest(unittest.TestCase):
 


### PR DESCRIPTION
I added type hints to the function parameters and for the function return for some files in Hamiltonians.
I also noticed that the parity parameter is expected to take a value of -1 or 1. It doesn't check whether the actual value is either one of those. It will now throw a ValueError for other values.