### PR TITLE
Upgrade to cirq 0.11

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,5 +1,5 @@
 # For testing and analyzing code.
-mypy~=0.701.0
+mypy~=0.782.0
 pylint~=2.4.0
 pytest-cov~=2.5.0
 yapf~=0.27.0

--- a/dev_tools/prepared_env.py
+++ b/dev_tools/prepared_env.py
@@ -108,7 +108,7 @@ class PreparedEnv:
         response = requests.post(url, json=payload)
 
         if response.status_code != 201:
-            raise IOError('Request failed. Code: {}. Content: {}.'.format(
+            raise IOError('Request failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     def get_changed_files(self) -> List[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.10.0
+cirq==0.11.0
 deprecation
 h5py>=2.8
 networkx

--- a/src/openfermion/_compat_test.py
+++ b/src/openfermion/_compat_test.py
@@ -70,6 +70,7 @@ def test_wrap_module():
 
 
 def test_cirq_deprecations():
+
     @deprecated(deadline="v0.12", fix="use new_func")
     def old_func():
         pass

--- a/src/openfermion/_compat_test.py
+++ b/src/openfermion/_compat_test.py
@@ -19,6 +19,9 @@ import deprecation
 import openfermion
 from openfermion._compat import wrap_module
 
+from cirq._compat import deprecated
+from cirq.testing import assert_deprecated
+
 
 def deprecated_test(test: Callable) -> Callable:
     """Marks a test as using deprecated functionality.
@@ -64,3 +67,12 @@ def test_wrap_module():
                                       {'deprecated_attribute': ('', '')})
     with pytest.deprecated_call():
         _ = wrapped_openfermion.deprecated_attribute
+
+
+def test_cirq_deprecations():
+    @deprecated(deadline="v0.12", fix="use new_func")
+    def old_func():
+        pass
+
+    with assert_deprecated(deadline="v0.12"):
+        old_func()

--- a/src/openfermion/conftest.py
+++ b/src/openfermion/conftest.py
@@ -15,4 +15,3 @@ import os
 def pytest_configure(config):
     # fail tests when using deprecated cirq functionality
     os.environ['CIRQ_TESTING'] = "true"
-

--- a/src/openfermion/conftest.py
+++ b/src/openfermion/conftest.py
@@ -1,0 +1,18 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import os
+
+
+def pytest_configure(config):
+    # fail tests when using deprecated cirq functionality
+    os.environ['CIRQ_TESTING'] = "true"
+

--- a/src/openfermion/measurements/vpe_estimators.py
+++ b/src/openfermion/measurements/vpe_estimators.py
@@ -145,7 +145,7 @@ class PhaseFitEstimator(_VPEEstimator):
         return expectation_value
 
 
-def get_phase_function(results: Sequence[cirq.TrialResult],
+def get_phase_function(results: Sequence[cirq.Result],
                        qubits: Sequence[cirq.Qid],
                        target_qid: int,
                        rotation_set: Optional[Sequence] = None):
@@ -155,7 +155,7 @@ def get_phase_function(results: Sequence[cirq.TrialResult],
     that these measurements occur, we can estimate the phase function.
 
     Arguments:
-        measurements [Sequence[cirq.TrialResult]] -- A list of TrialResults
+        measurements [Sequence[cirq.Result]] -- A list of TrialResults
             from the different circuits to be run at each point. We assume that
             these circuits are correlated to the order of rotation_set, and the
             only difference should be the initial and final rotation (following)


### PR DESCRIPTION
Upgrades to cirq 0.11. `cirq.TrialResult` was removed after two releases worth of deprecation. I also added a new env var to pytest's conftest.py that will fail tests if a deprecated Cirq functionality is used. Also, mypy was failing to install on Mac + Python 3.8, so I bumped that too.