### PR TITLE
make deprecation test meaningful

### DIFF
--- a/src/openfermion/_compat_test.py
+++ b/src/openfermion/_compat_test.py
@@ -75,5 +75,5 @@ def test_cirq_deprecations():
     def old_func():
         pass
 
-    with assert_deprecated(deadline="v0.12"):
+    with pytest.raises(ValueError, match="should not use deprecated"):
         old_func()


### PR DESCRIPTION
I noticed that I made a mistake - the deprecation test was always passing. Now it's only passing if the `CIRQ_TESTING` env var is defined - which is what we want.