### PR TITLE
Loosen Cirq version pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.11.0
+cirq~=0.11.0
 deprecation
 h5py>=2.8
 networkx


### PR DESCRIPTION
Use "compatible release" spec. This is important because
we use requirements.txt to set install_requires