### PR TITLE
Adding mention of OpenFermion-FQE to the frontpage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,10 +87,10 @@ Follow the links below to learn more!
 High performance simulators
 ------------------------------------------
 * `OpenFermion-FQE <https://github.com/quantumlib/OpenFermion-FQE>`__ is
-  a high performance emulator of quantum circuit specified by a sequence of
-  fermion operators, which can exploit fermionic symmetries such as spin and
-  particle number. It is built as plugin because C++ backends for
-  OpenFermion-FQE must be compiled.
+  a high performance emulator of fermionic quantum evolutions specified 
+  by a sequence of fermion operators, which can exploit fermionic 
+  symmetries such as spin and particle number. It is built as a 
+  plugin because C++ backends for OpenFermion-FQE must be compiled.
 
 Circuit compilation plugins
 ------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,9 @@ Hamiltonians. For more information, see our
 .. image:: https://badge.fury.io/py/openfermion.svg
     :target: https://badge.fury.io/py/openfermion
 
+.. image:: https://img.shields.io/pypi/dm/openfermion
+   :target: https://img.shields.io/pypi/dm/openfermion
+
 
 Run the interactive Jupyter Notebooks in Colab_ or MyBinder_:
 

--- a/README.rst
+++ b/README.rst
@@ -55,9 +55,6 @@ You might also want to explore the alpha release of the
 `OpenFermion Cloud Library <https://github.com/quantumlib/OpenFermion/tree/master/cloud_library>`__
 where users can share and download precomputed molecular benchmark files.
 
-Check out other `projects and papers using OpenFermion <https://quantumai.google/openfermion/projects>`__ for inspiration,
-and let us know if you've been using OpenFermion!
-
 
 Developer install
 -----------------
@@ -92,8 +89,7 @@ High performance simulators
 * `OpenFermion-FQE <https://github.com/quantumlib/OpenFermion-FQE>`__ is
   a high performance emulator of fermionic quantum evolutions specified 
   by a sequence of fermion operators, which can exploit fermionic 
-  symmetries such as spin and particle number. It is built as a 
-  plugin because C++ backends for OpenFermion-FQE must be compiled.
+  symmetries such as spin and particle number. 
 
 Circuit compilation plugins
 ------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,16 @@ Specifically, plugins are used to simulate and compile quantum circuits and to p
 classical electronic structure calculations.
 Follow the links below to learn more!
 
-Circuit compilation and simulation plugins
+High performance simulators
+------------------------------------------
+* `OpenFermion-FQE <https://github.com/quantumlib/OpenFermion-FQE>`__ is
+  a high performance emulator of quantum circuit specified by a sequence of
+  fermion operators, which can exploit fermionic symmetries such as spin and
+  particle number. It is built as plugin because C++ backends for
+  OpenFermion-FQE must be compiled.
+
+
+Circuit compilation plugins
 ------------------------------------------
 * `Forest-OpenFermion <https://github.com/rigetticomputing/forestopenfermion>`__ to support integration with `Forest <https://www.rigetti.com/forest>`__.
 

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,6 @@ High performance simulators
   particle number. It is built as plugin because C++ backends for
   OpenFermion-FQE must be compiled.
 
-
 Circuit compilation plugins
 ------------------------------------------
 * `Forest-OpenFermion <https://github.com/rigetticomputing/forestopenfermion>`__ to support integration with `Forest <https://www.rigetti.com/forest>`__.


### PR DESCRIPTION
I noticed that we aren't advertising OpenFermion-FQE here. But we should be right? Feel free to edit aspects of the description.