### PR TITLE
Upgrade to cirq 0.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-cirq~=0.11.0
+cirq-core~=0.12.0
+cirq-google~=0.12.0
 deprecation
 h5py>=2.8
 networkx

--- a/src/openfermion/_compat_test.py
+++ b/src/openfermion/_compat_test.py
@@ -75,5 +75,5 @@ def test_cirq_deprecations():
     def old_func():
         pass
 
-    with pytest.raises(ValueError, match="should not use deprecated"):
+    with pytest.raises(ValueError, match="deprecated .* not allowed"):
         old_func()

--- a/src/openfermion/circuits/gates/common_gates.py
+++ b/src/openfermion/circuits/gates/common_gates.py
@@ -18,8 +18,7 @@ import sympy
 import cirq
 
 
-class FSwapPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate,
-                   cirq.TwoQubitGate):
+class FSwapPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
     """The FSWAP gate, possibly raised to a power.
 
     FSwapPowGate()**t = FSwapPowGate(exponent=t) and acts on two qubits in the

--- a/src/openfermion/circuits/gates/fermionic_simulation.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation.py
@@ -398,7 +398,7 @@ class InteractionOperatorFermionicGate(ParityPreservingFermionicGate):
 
 class QuadraticFermionicSimulationGate(InteractionOperatorFermionicGate,
                                        cirq.InterchangeableQubitsGate,
-                                       cirq.TwoQubitGate, cirq.EigenGate):
+                                       cirq.EigenGate):
     r"""``(w0 |10⟩⟨01| + h.c.) + w1 |11⟩⟨11|`` interaction.
 
     With weights $(w_0, w_1)$ and exponent $t$, this gate's matrix
@@ -433,6 +433,9 @@ class QuadraticFermionicSimulationGate(InteractionOperatorFermionicGate,
 
     @classmethod
     def num_weights(cls):
+        return 2
+
+    def _num_qubits_(self) -> int:
         return 2
 
     def _decompose_(self, qubits):
@@ -532,7 +535,7 @@ class QuadraticFermionicSimulationGate(InteractionOperatorFermionicGate,
 
 
 class CubicFermionicSimulationGate(InteractionOperatorFermionicGate,
-                                   cirq.ThreeQubitGate, cirq.EigenGate):
+                                   cirq.EigenGate):
     r"""``w0|110⟩⟨101| + w1|110⟩⟨011| + w2|101⟩⟨011|`` + h.c. interaction.
 
     With weights $(w_0, w_1, w_2)$ and exponent $t$, this gate's
@@ -574,6 +577,9 @@ class CubicFermionicSimulationGate(InteractionOperatorFermionicGate,
 
     @classmethod
     def num_weights(cls):
+        return 3
+
+    def _num_qubits_(self) -> int:
         return 3
 
     @classmethod


### PR DESCRIPTION
Upgrades Cirq to v0.12. 
- Openfermion now depends explicitly on cirq-core and cirq-google instead of the cirq metapackage. 
- `cirq.TwoQubitGate` and `cirq.ThreeQubitGate` were deprecated and their usages have been replaced by an explicit `_num_qubits_` method definition. 

Fixes #743