### PR TITLE
Revamp CI: matrix, multi-Cirq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,37 +43,32 @@ jobs:
       - name: Lint
         run: check/pylint
   pytest:
-    name: Pytest Ubuntu
-    runs-on: ubuntu-18.04
+    name: Pytest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # On each operating system, check latest version of python and cirq
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ '3.9' ]
+        cirq-version: [ '~=0.13.0', '>=0.14.0.dev' ]
+        # Also check least-supported versions (linux only)
+        include:
+          - os: ubuntu-latest
+            python-version: 3.8
+            cirq-version: '~=0.12.0'
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
-          architecture: 'x64'
+          python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: |
-          pip install -r requirements.txt
           pip install -r dev_tools/conf/pip-list-dev-tools.txt
-          git config --global user.name ${GITHUB_ACTOR}
+          pip install cirq-core${{matrix.cirq-version}} cirq-google${{matrix.cirq-version}} -r requirements.txt
       - name: Pytest check
-        run: check/pytest --actually-quiet
-  pytest37:
-    name: Pytest Ubuntu
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-      - name: Install requirements
-        run: |
-          pip install -r requirements.txt
-          pip install -r dev_tools/conf/pip-list-dev-tools.txt
-          git config --global user.name ${GITHUB_ACTOR}
-      - name: Pytest check
-        run: check/pytest --actually-quiet
+        run: check/pytest
+        shell: bash
   coverage:
     name: Coverage check
     runs-on: ubuntu-18.04
@@ -90,35 +85,3 @@ jobs:
           git config --global user.name ${GITHUB_ACTOR}
       - name: Coverage check
         run: check/pytest-and-incremental-coverage --actually-quiet
-  windows:
-    name: Pytest Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.6'
-          architecture: 'x64'
-      - name: Install requirements
-        run: |
-          pip install -r requirements.txt
-          pip install -r dev_tools/conf/pip-list-dev-tools.txt
-      - name: Pytest Windows
-        run: check/pytest
-        shell: bash
-  macos:
-    name: Pytest MacOS
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.6'
-          architecture: 'x64'
-      - name: Install requirements
-        run: |
-          pip install -r requirements.txt
-          pip install -r dev_tools/conf/pip-list-dev-tools.txt
-          git config --global user.name ${GITHUB_ACTOR}
-      - name: Pytest check
-        run: check/pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # On each operating system, check latest version of python and cirq
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ '3.9' ]
-        cirq-version: [ '~=0.13.0', '>=0.14.0.dev' ]
+        cirq-version: [ '~=0.13.0' ]
         # Also check least-supported versions (linux only)
         include:
           - os: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,28 @@
+name: Cirq Pre-release
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cirq-next:
+    name: Cirq Pre-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ '3.9' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install requirements
+        run: |
+          pip install -r dev_tools/conf/pip-list-dev-tools.txt
+          pip install -r requirements.txt
+          pip install -U cirq-core cirq-google --pre
+      - name: Pytest check
+        run: check/pytest
+        shell: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-cirq-core~=0.12.0
-cirq-google~=0.12.0
+cirq-core>=0.12.0
+cirq-google>=0.12.0
 deprecation
 h5py>=2.8
 networkx
 numpy>=1.11.0
 pubchempy
-requests~=2.18
+requests>=2.18
 scipy>=1.1.0
 sympy
-nbformat


### PR DESCRIPTION
- Use CI "matrix" to reduce duplication in testing infrastructure
- stop pinning cirq in `install_requires`. Lower bound only. More often than not, we are artificially restricting dependers from using the latest Cirq than preventing real problems. Testing against pre-release should prevent surprises.
- Test 1) lowest supported version of things 2) latest version of things 3) vs. cirq pre-release
- Clarify and bump supported python version: latest two versions
- Clarify and bump supported cirq version: latest two versions (unless this is difficult to maintain, then we'd just support the latest version and drop it from the matrix)