### PR TITLE
Lookup dictionary for JW transformation of a FermionOperator

### DIFF
--- a/src/openfermion/transforms/opconversions/jordan_wigner.py
+++ b/src/openfermion/transforms/opconversions/jordan_wigner.py
@@ -57,22 +57,27 @@ def jordan_wigner(operator):
 
 def _jordan_wigner_fermion_operator(operator):
     transformed_operator = QubitOperator()
+    # Purpose is storing ladder terms already transformed.
+    lookup_ladder_terms = dict()
     for term in operator.terms:
         # Initialize identity matrix.
         transformed_term = QubitOperator((), operator.terms[term])
         # Loop through operators, transform and multiply.
         for ladder_operator in term:
-            z_factors = tuple(
-                (index, 'Z') for index in range(ladder_operator[0]))
-            pauli_x_component = QubitOperator(
-                z_factors + ((ladder_operator[0], 'X'),), 0.5)
-            if ladder_operator[1]:
-                pauli_y_component = QubitOperator(
-                    z_factors + ((ladder_operator[0], 'Y'),), -0.5j)
-            else:
-                pauli_y_component = QubitOperator(
-                    z_factors + ((ladder_operator[0], 'Y'),), 0.5j)
-            transformed_term *= pauli_x_component + pauli_y_component
+            if ladder_operator not in lookup_ladder_terms:
+                z_factors = tuple(
+                    (index, 'Z') for index in range(ladder_operator[0]))
+                pauli_x_component = QubitOperator(
+                    z_factors + ((ladder_operator[0], 'X'),), 0.5)
+                if ladder_operator[1]:
+                    pauli_y_component = QubitOperator(
+                        z_factors + ((ladder_operator[0], 'Y'),), -0.5j)
+                else:
+                    pauli_y_component = QubitOperator(
+                        z_factors + ((ladder_operator[0], 'Y'),), 0.5j)
+                lookup_ladder_terms[ladder_operator] = (pauli_x_component +
+                                                        pauli_y_component)
+            transformed_term *= lookup_ladder_terms[ladder_operator]
         transformed_operator += transformed_term
     return transformed_operator
 


### PR DESCRIPTION
Low-hanging fruit for a simple speedup when working on `FermionOperator` -> `QubitOperator` conversions. The problem has been raised in #587. This is not an optimal solution to this issue (neither parallelization nor cython), but there is a significant speed improvement when working with a `FermionOperator` with redundant terms.

Here is a simple script I used to test:
```
import time

import openfermion as of
from openfermionpyscf import run_pyscf

mol = of.chem.MolecularData(geometry=[["H", (0., 0., 0.)], ["H", (0., 0., 0.75)]], multiplicity=1, charge=0, basis="ccpvtz")
mol = run_pyscf(mol, verbose=True)
mol_op = mol.get_molecular_hamiltonian()

ferm_op = of.transforms.get_fermion_operator(mol_op)

start_time = time.time()
qubit_op = of.transforms.jordan_wigner(ferm_op)
final_time = time.time() - start_time

print(f"{final_time}s")
```

On my machine (Arch Linux 5.17.3-arch1-1, python 3.8.5): 
Before = 10min27s
After = 5min14s

Other tests:
O2_6-31g_triplet | 81s | 42 s
NaCl_sto-3g_singlet | 2min34s | 1min20s 