### PR TITLE
Fix cirq.google reference in docs.

### DIFF
--- a/docs/tutorials/circuits_1_basis_change.ipynb
+++ b/docs/tutorials/circuits_1_basis_change.ipynb
@@ -208,6 +208,7 @@
    "source": [
     "import openfermion\n",
     "import cirq\n",
+    "import cirq_google\n",
     "\n",
     "# Initialize the qubit register.\n",
     "qubits = cirq.LineQubit.range(n_qubits)\n",
@@ -282,7 +283,7 @@
    },
    "outputs": [],
    "source": [
-    "xmon_circuit = cirq.google.optimized_for_xmon(circuit)\n",
+    "xmon_circuit = cirq_google.optimized_for_xmon(circuit)\n",
     "print(xmon_circuit.to_qasm())"
    ]
   }


### PR DESCRIPTION
- One of the docs uses cirq.google and should be cirq_google.