### PR TITLE
Fix cirq coverage test

### DIFF
--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -59,7 +59,7 @@ def assert_implements_consistent_protocols(
             local_vals=local_vals)
     except TypeError:
         # Cirq 0.12
-        cirq.testing.assert_implements_consistent_protocols( # coverage: ignore
+        cirq.testing.assert_implements_consistent_protocols(  # coverage: ignore
             val,
             exponents=exponents,
             qubit_count=qubit_count,

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -52,6 +52,7 @@ def assert_implements_consistent_protocols(
         exponents=exponents,
         qubit_count=qubit_count,
         ignoring_global_phase=ignoring_global_phase,
+        ignore_decompose_to_default_gateset=True,
         setup_code=setup_code,
         global_vals=global_vals,
         local_vals=local_vals)

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -67,5 +67,5 @@ def assert_implements_consistent_protocols(
             ignoring_global_phase=ignoring_global_phase,  # coverage: ignore
             setup_code=setup_code,  # coverage: ignore
             global_vals=global_vals,  # coverage: ignore
-            local_vals=local_vals, # coverage: ignore
+            local_vals=local_vals,  # coverage: ignore
         )  # coverage: ignore

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -46,13 +46,25 @@ def assert_implements_consistent_protocols(
         global_vals: Optional[Dict[str, Any]] = None,
         local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
+    try:
+        # Cirq 0.14
+        cirq.testing.assert_implements_consistent_protocols(
+            val,
+            exponents=exponents,
+            qubit_count=qubit_count,
+            ignoring_global_phase=ignoring_global_phase,
+            ignore_decompose_to_default_gateset=True,
+            setup_code=setup_code,
+            global_vals=global_vals,
+            local_vals=local_vals)
+    except TypeError:
+        # Cirq 0.12
+        cirq.testing.assert_implements_consistent_protocols(
+            val,
+            exponents=exponents,
+            qubit_count=qubit_count,
+            ignoring_global_phase=ignoring_global_phase,
+            setup_code=setup_code,
+            global_vals=global_vals,
+            local_vals=local_vals)
 
-    cirq.testing.assert_implements_consistent_protocols(
-        val,
-        exponents=exponents,
-        qubit_count=qubit_count,
-        ignoring_global_phase=ignoring_global_phase,
-        ignore_decompose_to_default_gateset=True,
-        setup_code=setup_code,
-        global_vals=global_vals,
-        local_vals=local_vals)

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -16,12 +16,15 @@ import sympy
 
 import cirq
 
-_setup_code = (
-    "import cirq\n" "import numpy as np\n" "import sympy\n" "import openfermion\n"
-)
+_setup_code = ("import cirq\n"
+               "import numpy as np\n"
+               "import sympy\n"
+               "import openfermion\n")
 
 
-def assert_equivalent_repr(value: Any, *, setup_code: str = _setup_code) -> None:
+def assert_equivalent_repr(value: Any,
+                           *,
+                           setup_code: str = _setup_code) -> None:
     """Checks that eval(repr(v)) == v.
 
     Args:
@@ -34,15 +37,15 @@ def assert_equivalent_repr(value: Any, *, setup_code: str = _setup_code) -> None
 
 
 def assert_implements_consistent_protocols(
-    val: Any,
-    *,
-    exponents: Sequence[Any] = (0, 1, -1, 0.5, 0.25, -0.5, 0.1, sympy.Symbol("s")),
-    qubit_count: Optional[int] = None,
-    ignoring_global_phase: bool = False,
-    setup_code: str = _setup_code,
-    global_vals: Optional[Dict[str, Any]] = None,
-    local_vals: Optional[Dict[str, Any]] = None
-) -> None:
+        val: Any,
+        *,
+        exponents: Sequence[Any] = (0, 1, -1, 0.5, 0.25, -0.5, 0.1,
+                                    sympy.Symbol("s")),
+        qubit_count: Optional[int] = None,
+        ignoring_global_phase: bool = False,
+        setup_code: str = _setup_code,
+        global_vals: Optional[Dict[str, Any]] = None,
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
     try:
         # Cirq 0.14

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -22,8 +22,7 @@ _setup_code = ("import cirq\n"
                "import openfermion\n")
 
 
-def assert_equivalent_repr(value: Any,
-                           *,
+def assert_equivalent_repr(value: Any, *,
                            setup_code: str = _setup_code) -> None:
     """Checks that eval(repr(v)) == v.
 

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -67,5 +67,5 @@ def assert_implements_consistent_protocols(
             ignoring_global_phase=ignoring_global_phase,  # coverage: ignore
             setup_code=setup_code,  # coverage: ignore
             global_vals=global_vals,  # coverage: ignore
-            local_vals=local_vals,
+            local_vals=local_vals, # coverage: ignore
         )  # coverage: ignore

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -16,14 +16,12 @@ import sympy
 
 import cirq
 
-_setup_code = ('import cirq\n'
-               'import numpy as np\n'
-               'import sympy\n'
-               'import openfermion\n')
+_setup_code = (
+    "import cirq\n" "import numpy as np\n" "import sympy\n" "import openfermion\n"
+)
 
 
-def assert_equivalent_repr(value: Any, *,
-                           setup_code: str = _setup_code) -> None:
+def assert_equivalent_repr(value: Any, *, setup_code: str = _setup_code) -> None:
     """Checks that eval(repr(v)) == v.
 
     Args:
@@ -36,15 +34,15 @@ def assert_equivalent_repr(value: Any, *,
 
 
 def assert_implements_consistent_protocols(
-        val: Any,
-        *,
-        exponents: Sequence[Any] = (0, 1, -1, 0.5, 0.25, -0.5, 0.1,
-                                    sympy.Symbol('s')),
-        qubit_count: Optional[int] = None,
-        ignoring_global_phase: bool = False,
-        setup_code: str = _setup_code,
-        global_vals: Optional[Dict[str, Any]] = None,
-        local_vals: Optional[Dict[str, Any]] = None) -> None:
+    val: Any,
+    *,
+    exponents: Sequence[Any] = (0, 1, -1, 0.5, 0.25, -0.5, 0.1, sympy.Symbol("s")),
+    qubit_count: Optional[int] = None,
+    ignoring_global_phase: bool = False,
+    setup_code: str = _setup_code,
+    global_vals: Optional[Dict[str, Any]] = None,
+    local_vals: Optional[Dict[str, Any]] = None
+) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
     try:
         # Cirq 0.14
@@ -56,14 +54,16 @@ def assert_implements_consistent_protocols(
             ignore_decompose_to_default_gateset=True,
             setup_code=setup_code,
             global_vals=global_vals,
-            local_vals=local_vals)
-    except TypeError:
+            local_vals=local_vals,
+        )
+    except TypeError:  # coverage: ignore
         # Cirq 0.12
         cirq.testing.assert_implements_consistent_protocols(  # coverage: ignore
-            val,
-            exponents=exponents,
-            qubit_count=qubit_count,
-            ignoring_global_phase=ignoring_global_phase,
-            setup_code=setup_code,
-            global_vals=global_vals,
-            local_vals=local_vals)
+            val,  # coverage: ignore
+            exponents=exponents,  # coverage: ignore
+            qubit_count=qubit_count,  # coverage: ignore
+            ignoring_global_phase=ignoring_global_phase,  # coverage: ignore
+            setup_code=setup_code,  # coverage: ignore
+            global_vals=global_vals,  # coverage: ignore
+            local_vals=local_vals,
+        )  # coverage: ignore

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -59,7 +59,7 @@ def assert_implements_consistent_protocols(
             local_vals=local_vals)
     except TypeError:
         # Cirq 0.12
-        cirq.testing.assert_implements_consistent_protocols(
+        cirq.testing.assert_implements_consistent_protocols( # coverage: ignore
             val,
             exponents=exponents,
             qubit_count=qubit_count,

--- a/src/openfermion/testing/wrapped.py
+++ b/src/openfermion/testing/wrapped.py
@@ -67,4 +67,3 @@ def assert_implements_consistent_protocols(
             setup_code=setup_code,
             global_vals=global_vals,
             local_vals=local_vals)
-


### PR DESCRIPTION
- Add additional parameter to ignore gates that do not decompose
into cirq native gates (such as fermionic quartic gates).