### PR TITLE
DropNegligible was used but is deprecated.

### DIFF
--- a/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
+++ b/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
@@ -201,7 +201,7 @@
     "        qubits, transformation_matrix, initial_state=occupied_orbitals))\n",
     "\n",
     "# Print circuit.\n",
-    "cirq.DropNegligible().optimize_circuit(state_preparation_circuit)\n",
+    "cirq.drop_negligible_operations(state_preparation_circuit)\n",
     "print(state_preparation_circuit)"
    ]
   },
@@ -251,7 +251,7 @@
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
     "\n",
     "# Print circuit.\n",
-    "cirq.DropNegligible().optimize_circuit(swap_network_trotter_step)\n",
+    "ccirq.drop_negligible_operations(swap_network_trotter_step)\n",
     "print(swap_network_trotter_step.to_text_diagram(transpose=True))"
    ]
   },
@@ -277,7 +277,7 @@
     "        qubits, hamiltonian, time, n_steps, order,\n",
     "        algorithm=trotter.SPLIT_OPERATOR),\n",
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
-    "cirq.DropNegligible().optimize_circuit(split_operator_trotter_step)\n",
+    "cirq.drop_negligible_operations(split_operator_trotter_step)\n",
     "print(split_operator_trotter_step.to_text_diagram(transpose=True))"
    ]
   },
@@ -352,7 +352,7 @@
     "        qubits, hamiltonian, time, n_steps, order,\n",
     "        algorithm=trotter.LINEAR_SWAP_NETWORK),\n",
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
-    "cirq.DropNegligible().optimize_circuit(swap_network_trotter_step)\n",
+    "cirq.drop_negligible_operations(swap_network_trotter_step)\n",
     "print(swap_network_trotter_step.to_text_diagram(transpose=True))"
    ]
   },
@@ -379,7 +379,7 @@
     "        algorithm=trotter.LINEAR_SWAP_NETWORK,\n",
     "        omit_final_swaps=True),\n",
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
-    "cirq.DropNegligible().optimize_circuit(swap_network_trotter_step)\n",
+    "cirq.drop_negligible_operations(swap_network_trotter_step)\n",
     "print(swap_network_trotter_step.to_text_diagram(transpose=True))"
    ]
   },
@@ -407,7 +407,7 @@
     "        qubits, hamiltonian, time, n_steps, order,\n",
     "        algorithm=trotter.LINEAR_SWAP_NETWORK),\n",
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
-    "cirq.DropNegligible().optimize_circuit(swap_network_trotter_step)\n",
+    "cirq.drop_negligible_operations(swap_network_trotter_step)\n",
     "print(swap_network_trotter_step.to_text_diagram(transpose=True))"
    ]
   },
@@ -469,7 +469,7 @@
     "        controlled_unitary))\n",
     "\n",
     "# Print the circuit.\n",
-    "cirq.DropNegligible().optimize_circuit(circuit)\n",
+    "cirq.drop_negligible_operations(circuit)\n",
     "print(circuit.to_text_diagram(transpose=True))"
    ]
   }


### PR DESCRIPTION
DeprecationWarning: DropNegligible was used but is deprecated. It will be removed in cirq v1.0. Use cirq.drop_negligible_operations instead.
cirq.DropNegligible().optimize_circuit
cirq.drop_empty_moments / cirq.drop_negligible_operations: Removes moments that are empty or operations that have very small effects, respectively.