### PR TITLE
DropNegligible was used but is deprecated.

### DIFF
--- a/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
+++ b/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
@@ -214,7 +214,7 @@
     "    strategy=cirq.InsertStrategy.EARLIEST)\n",
     "\n",
     "# Print circuit.\n",
-    "cirq.DropNegligible().optimize_circuit(circuit)\n",
+    "cirq.drop_negligible_operations(circuit)\n",
     "print(circuit.to_text_diagram(transpose=True))"
    ]
   },
@@ -269,7 +269,7 @@
     "print('Fidelity with exact result is {}.\\n'.format(fidelity))\n",
     "\n",
     "# Print circuit.\n",
-    "cirq.DropNegligible().optimize_circuit(circuit)\n",
+    "cirq.drop_negligible_operations(circuit)\n",
     "print(circuit.to_text_diagram(transpose=True))"
    ]
   }


### PR DESCRIPTION
DeprecationWarning: DropNegligible was used but is deprecated. It will be removed in cirq v1.0. Use cirq.drop_negligible_operations instead.
cirq.DropNegligible().optimize_circuit
cirq.drop_empty_moments / cirq.drop_negligible_operations: Removes moments that are empty or operations that have very small effects, respectively.