### PR TITLE
Adds a link to the Q-Chem plugin in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,8 @@ Electronic structure package plugins
 
 * `OpenFermion-Dirac <https://github.com/bsenjean/Openfermion-Dirac>`__ to support integration with `DIRAC <http://diracprogram.org/doku.php>`__.
 
+* `OpenFermion-QChem <https://github.com/qchemsoftware/OpenFermion-QChem>`__ to support integration with `Q-Chem <https://www.q-chem.com>`__.
+
 How to contribute
 =================
 


### PR DESCRIPTION
The OpenFermion/Q-Chem plugin was developed by Yongbin Kim and Anna Krylov (University of Southern California)