### PR TITLE
Pin Requirements to working cirq versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core>=0.12.0
-cirq-google>=0.12.0
+cirq-core>=0.12.0,<=0.14.0
+cirq-google>=0.12.0,<=0.14.0
 deprecation
 h5py>=2.8
 networkx


### PR DESCRIPTION
Cirq has had a lot of movement in preparation for the 1.0 release.

OpenFermion now only works with versions of cirq <=0.14.0.  This
PR enforces python package management into the allowable cirq range.

This PR should be followed by a permenant fix for cirq 1.0
compatability.