### PR TITLE
Making OF work with cirq>=0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,12 @@ jobs:
         # On each operating system, check latest version of python and cirq
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ '3.9' ]
-        cirq-version: [ '~=0.13.0' ]
+        cirq-version: [ '~=1.0.0' ]
         # Also check least-supported versions (linux only)
         include:
           - os: ubuntu-latest
             python-version: 3.8
-            cirq-version: '~=0.12.0'
+            cirq-version: '~=0.15.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*cover
 .hypothesis/
 
 # Sphinx documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core>=0.12.0,<=0.14.0
-cirq-google>=0.12.0,<=0.14.0
+cirq-core>=0.15.0
+cirq-google>=0.15.0
 deprecation
 h5py>=2.8
 networkx

--- a/src/openfermion/circuits/primitives/bogoliubov_transform_test.py
+++ b/src/openfermion/circuits/primitives/bogoliubov_transform_test.py
@@ -101,11 +101,13 @@ def test_spin_symmetric_bogoliubov_transform(n_spatial_orbitals,
         2**(n_qubits - 1 - int(i + n_spatial_orbitals)) for i in down_orbitals))
 
     # Apply the circuit
+    sim = cirq.Simulator(dtype=numpy.complex128)
     circuit = cirq.Circuit(
         bogoliubov_transform(qubits,
                              transformation_matrix,
                              initial_state=initial_state))
-    state = circuit.final_state_vector(initial_state=initial_state)
+    sim_result = sim.simulate(circuit, initial_state=initial_state)
+    state = sim_result.final_state_vector
 
     # Check that the result is an eigenstate with the correct eigenvalue
     numpy.testing.assert_allclose(quad_ham_sparse.dot(state),
@@ -121,6 +123,7 @@ def test_bogoliubov_transform_quadratic_hamiltonian(n_qubits,
                                                     conserves_particle_number,
                                                     atol=5e-5):
     qubits = LineQubit.range(n_qubits)
+    sim = cirq.Simulator(dtype=numpy.complex128)
 
     # Initialize a random quadratic Hamiltonian
     quad_ham = random_quadratic_hamiltonian(n_qubits,
@@ -154,15 +157,18 @@ def test_bogoliubov_transform_quadratic_hamiltonian(n_qubits,
             2**(n_qubits - 1 - int(i)) for i in occupied_orbitals)
 
         # Get the state using a circuit simulation
-        state1 = circuit.final_state_vector(initial_state=initial_state)
+        state1 = sim.simulate(circuit,
+                              initial_state=initial_state).final_state_vector
 
         # Also test the option to start with a computational basis state
         special_circuit = cirq.Circuit(
             bogoliubov_transform(qubits,
                                  transformation_matrix,
                                  initial_state=initial_state))
-        state2 = special_circuit.final_state_vector(
-            initial_state, qubits_that_should_be_present=qubits)
+
+        state2 = sim.simulate(special_circuit,
+                              initial_state=initial_state,
+                              qubit_order=qubits).final_state_vector
 
         # Check that the result is an eigenstate with the correct eigenvalue
         numpy.testing.assert_allclose(quad_ham_sparse.dot(state1),

--- a/src/openfermion/circuits/primitives/ffft.py
+++ b/src/openfermion/circuits/primitives/ffft.py
@@ -83,7 +83,7 @@ class _F0Gate(cirq.MatrixGate):
         return cirq.CircuitDiagramInfo(wire_symbols=symbols)
 
 
-class _TwiddleGate(cirq.SingleQubitGate):
+class _TwiddleGate(cirq.ZPowGate):
     r"""Gate that introduces arbitrary FFT twiddle factors.
 
     Realizes unitary gate $\omega^{k\dagger}_n$ that phases creation
@@ -99,6 +99,7 @@ class _TwiddleGate(cirq.SingleQubitGate):
     """
 
     def __init__(self, k, n):
+
         """Initializes Twiddle gate.
 
         Args:
@@ -107,6 +108,8 @@ class _TwiddleGate(cirq.SingleQubitGate):
         """
         self.k = k
         self.n = n
+        exponent = -2 * self.k / self.n
+        super().__init__(exponent=exponent, global_shift=0)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs
                               ) -> cirq.CircuitDiagramInfo:

--- a/src/openfermion/circuits/primitives/ffft_test.py
+++ b/src/openfermion/circuits/primitives/ffft_test.py
@@ -145,12 +145,14 @@ def _multi_fermionic_mode_base_state(n: int, amplitude: complex,
                          [[1, 0], [1j, 0], [0, 1], [0, -1j], [1, 1]])
 def test_F0Gate_transform(amplitudes):
     qubits = LineQubit.range(2)
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _single_fermionic_modes_state(amplitudes)
     expected_state = _single_fermionic_modes_state(
         _fourier_transform_single_fermionic_modes(amplitudes))
 
     circuit = cirq.Circuit(_F0Gate().on(*qubits))
-    state = circuit.final_state_vector(initial_state=initial_state)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state).final_state_vector
 
     assert np.allclose(state, expected_state, rtol=0.0)
 
@@ -185,12 +187,14 @@ def test_F0Gate_text_diagram():
 ])
 def test_TwiddleGate_transform(k, n, qubit, initial, expected):
     qubits = LineQubit.range(2)
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _single_fermionic_modes_state(initial)
     expected_state = _single_fermionic_modes_state(expected)
 
     circuit = cirq.Circuit(_TwiddleGate(k, n).on(qubits[qubit]))
-    state = circuit.final_state_vector(initial_state=initial_state,
-                                       qubits_that_should_be_present=qubits)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state,
+                         qubit_order=qubits).final_state_vector
 
     assert np.allclose(state, expected_state, rtol=0.0)
 
@@ -222,14 +226,16 @@ def test_TwiddleGate_text_diagram():
                           [0, 0, 0, 0, 0, 0, 0, 1],
                           [0, 0, -1j / np.sqrt(2), 0, 0, 1 / np.sqrt(2), 0, 0]])
 def test_ffft_single_fermionic_modes(amplitudes):
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _single_fermionic_modes_state(amplitudes)
     expected_state = _single_fermionic_modes_state(
         _fourier_transform_single_fermionic_modes(amplitudes))
     qubits = LineQubit.range(len(amplitudes))
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_state_vector(initial_state=initial_state,
-                                       qubits_that_should_be_present=qubits)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state,
+                         qubit_order=qubits).final_state_vector
 
     assert np.allclose(state, expected_state, rtol=0.0)
 
@@ -250,14 +256,16 @@ def test_ffft_single_fermionic_modes(amplitudes):
     [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
 ])
 def test_ffft_single_fermionic_modes_non_power_of_2(amplitudes):
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _single_fermionic_modes_state(amplitudes)
     expected_state = _single_fermionic_modes_state(
         _fourier_transform_single_fermionic_modes(amplitudes))
     qubits = LineQubit.range(len(amplitudes))
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_state_vector(initial_state=initial_state,
-                                       qubits_that_should_be_present=qubits)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state,
+                         qubit_order=qubits).final_state_vector
 
     cirq.testing.assert_allclose_up_to_global_phase(state,
                                                     expected_state,
@@ -281,13 +289,15 @@ def test_ffft_single_fermionic_modes_non_power_of_2(amplitudes):
     (8, (1, [0, 1, 2, 3, 4, 5, 6, 7])),
 ])
 def test_ffft_multi_fermionic_mode(n, initial):
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _multi_fermionic_mode_base_state(n, *initial)
     expected_state = _fourier_transform_multi_fermionic_mode(n, *initial)
     qubits = LineQubit.range(n)
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_state_vector(initial_state=initial_state,
-                                       qubits_that_should_be_present=qubits)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state,
+                         qubit_order=qubits).final_state_vector
 
     assert np.allclose(state, expected_state, rtol=0.0)
 
@@ -301,13 +311,15 @@ def test_ffft_multi_fermionic_mode(n, initial):
     (9, (1, [2, 4, 6])),
 ])
 def test_ffft_multi_fermionic_mode_non_power_of_2(n, initial):
+    sim = cirq.Simulator(dtype=np.complex128)
     initial_state = _multi_fermionic_mode_base_state(n, *initial)
     expected_state = _fourier_transform_multi_fermionic_mode(n, *initial)
     qubits = LineQubit.range(n)
 
     circuit = cirq.Circuit(ffft(qubits), strategy=cirq.InsertStrategy.EARLIEST)
-    state = circuit.final_state_vector(initial_state=initial_state,
-                                       qubits_that_should_be_present=qubits)
+    state = sim.simulate(circuit,
+                         initial_state=initial_state,
+                         qubit_order=qubits).final_state_vector
 
     cirq.testing.assert_allclose_up_to_global_phase(state,
                                                     expected_state,


### PR DESCRIPTION
With the removal of .final_state_vector from the Circuit object
and SingleQubitGate from cirq we can now upgrade our cirq compatability.

This version of OF will work with cirq 1.0