### PR TITLE
Resolves failing cirq pre-release

### DIFF
--- a/src/openfermion/_version.py
+++ b/src/openfermion/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "1.6.0dev0"
+__version__ = "1.5.1"

--- a/src/openfermion/circuits/gates/four_qubit_gates_test.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates_test.py
@@ -263,7 +263,8 @@ def test_double_excitation_matches_fermionic_evolution(exponent):
     op += openfermion.hermitian_conjugated(op)
     matrix_op = openfermion.get_sparse_operator(op)
 
-    time_evol_op = scipy.linalg.expm(-1j * matrix_op * exponent * numpy.pi)
+    time_evol_op = scipy.sparse.linalg.expm(-1j * matrix_op * exponent *
+                                            numpy.pi)
     time_evol_op = time_evol_op.todense()
 
     cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(gate),

--- a/src/openfermion/testing/circuit_validation.py
+++ b/src/openfermion/testing/circuit_validation.py
@@ -14,7 +14,7 @@
 from typing import List
 
 import numpy
-from scipy import linalg
+import scipy
 import cirq
 import openfermion
 from openfermion.config import EQ_TOLERANCE
@@ -46,10 +46,10 @@ def validate_trotterized_evolution(circuit: cirq.Circuit,
     hs_dim = 2**n_qubits
     qubit_op = ops[0]
     op_matrix = openfermion.get_sparse_operator(qubit_op, n_qubits=n_qubits)
-    target_unitary = linalg.expm(1j * op_matrix)
+    target_unitary = scipy.sparse.linalg.expm(1j * op_matrix)
     for qubit_op in ops[1:]:
         op_matrix = openfermion.get_sparse_operator(qubit_op, n_qubits=n_qubits)
-        op_unitary = linalg.expm(1j * op_matrix)
+        op_unitary = scipy.sparse.linalg.expm(1j * op_matrix)
         target_unitary = op_unitary.dot(target_unitary)
 
     actual_unitary = circuit.unitary(qubit_order=qubits)


### PR DESCRIPTION
Apparently prior releases of openfermion were attempting to
use scipy.linalg.expm to exponentiate sparse matrices.  Until recently
the scipy API seem to resolve the issue of using scipy.linalg.expm
instead of scipy.sparse.linalg.expm.

This issue was not surfaced until the 1.0.0dev release so some
combination of numpy/scipy pinning or depinning has revealed this
bug in openfermion.  This commit fixes the issue by converting
scipy.linalg.expm to scipy.sparse.linalg.expm where appropriate.