### PR TITLE
Matrix exponential of sparse matrix is not allowed

### DIFF
--- a/docs/fqe/tutorials/diagonal_coulomb_evolution.ipynb
+++ b/docs/fqe/tutorials/diagonal_coulomb_evolution.ipynb
@@ -319,7 +319,7 @@
    "outputs": [],
    "source": [
     "cirq_wfn = fqe.to_cirq(fqe_wfn).reshape((-1, 1))\n",
-    "final_cirq_wfn = expm(-1j * of.get_sparse_operator(diagonal_coulomb)) @ cirq_wfn\n",
+    "final_cirq_wfn = expm(-1j * of.get_sparse_operator(diagonal_coulomb).todense()) @ cirq_wfn\n",
     "# recover a fqe wavefunction\n",
     "from_cirq_wfn = fqe.from_cirq(final_cirq_wfn.flatten(), 1.0E-8)\n"
    ]

--- a/docs/fqe/tutorials/fermi_hubbard.ipynb
+++ b/docs/fqe/tutorials/fermi_hubbard.ipynb
@@ -222,7 +222,7 @@
     "init_cirq_wfn = fqe.to_cirq(init_wfn)\n",
     "\n",
     "# Exponentiate the (sparse) Hamiltonian U = exp(-i H t).\n",
-    "unitary = expm(-1j * e_time * of.get_sparse_operator(hubbard))\n",
+    "unitary = expm(-1j * e_time * of.get_sparse_operator(hubbard).todense())\n",
     "\n",
     "# Do the time evolution |𝛹'⟩ = U |𝛹⟩.\n",
     "true_evolved_cirq = unitary @ init_cirq_wfn"

--- a/docs/fqe/tutorials/fqe_vs_openfermion_quadratic_hamiltonians.ipynb
+++ b/docs/fqe/tutorials/fqe_vs_openfermion_quadratic_hamiltonians.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "# full space unitary\n",
     "time = np.random.random()\n",
-    "hamiltonian_evolution = expm(-1j * ikappa_mat * time) "
+    "hamiltonian_evolution = expm(-1j * ikappa_mat.todense() * time) "
    ]
   },
   {


### PR DESCRIPTION
- The matrix exponential of these sparse matrices is causing errors in certain versions of scipy:
"loop of ufunc does not support argument 0 of type csc_matrix which has no callable exp method"

- Converting these to dense matrices to get docs working again.

Note:  this does have a performance impact on the code.  Is there a better way to do this?