### PR TITLE
Fix another expm doc error

### DIFF
--- a/docs/fqe/tutorials/fermi_hubbard.ipynb
+++ b/docs/fqe/tutorials/fermi_hubbard.ipynb
@@ -337,7 +337,7 @@
     "sparse_hopping_matrix = of.get_sparse_operator(sum(one_body_terms))\n",
     "\n",
     "# Exponentiate the matrix.\n",
-    "unitary = expm(-1j * e_time * sparse_hopping_matrix)\n",
+    "unitary = expm(-1j * e_time * sparse_hopping_matrix.todense())\n",
     "\n",
     "# Time-evolve the initial state.\n",
     "evolved_cirq_wfn = unitary @ init_cirq_wfn"


### PR DESCRIPTION
- Taking exponential of a sparse matrix is no longer allowed.
- Convert this to dense matrix to fix doc generation.