### PR TITLE
Change two_body.dtype comparison from numpy.float to numpy.float64 in DiagonalCoulombOperator

### DIFF
--- a/src/openfermion/ops/representations/diagonal_coulomb_hamiltonian.py
+++ b/src/openfermion/ops/representations/diagonal_coulomb_hamiltonian.py
@@ -37,9 +37,9 @@ class DiagonalCoulombHamiltonian:
     """
 
     def __init__(self, one_body, two_body, constant=0.):
-        if two_body.dtype != numpy.float:
+        if two_body.dtype != numpy.float64:
             raise ValueError('Two-body tensor has invalid dtype. Expected {} '
-                             'but was {}'.format(numpy.float, two_body.dtype))
+                             'but was {}'.format(numpy.float64, two_body.dtype))
         if not numpy.allclose(two_body, two_body.T):
             raise ValueError('Two-body tensor must be symmetric.')
         if not numpy.allclose(one_body, one_body.T.conj()):


### PR DESCRIPTION
numpy.float was deprecated in v1.24.0. Replace comparison with numpy.float64 instead. This is causing CI to fail in #813.