### PR TITLE
Fix CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on: [pull_request]
 jobs:
   format:
     name: Format check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: 'x64'
       - name: Install yapf
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep yapf | xargs pip install
@@ -18,12 +20,12 @@ jobs:
         run: check/format-incremental
   mypy:
     name: Type check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: 'x64'
       - name: Install mypy
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep mypy | xargs pip install
@@ -31,12 +33,12 @@ jobs:
         run: check/mypy
   lint:
     name: Lint check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: 'x64'
       - name: Install pylint
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep "pylint\|astroid" | grep -v "#" | xargs pip install
@@ -71,9 +73,11 @@ jobs:
         shell: bash
   coverage:
     name: Coverage check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
           python-version: '3.8'
@@ -85,4 +89,4 @@ jobs:
           pip install -r dev_tools/conf/pip-list-dev-tools.txt
           git config --global user.name ${GITHUB_ACTOR}
       - name: Coverage check
-        run: check/pytest-and-incremental-coverage --actually-quiet
+        run: check/pytest-and-incremental-coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ networkx
 numpy>=1.11.0
 pubchempy
 requests>=2.18
-scipy>=1.1.0
+scipy>=1.1.0,<1.10.0
 sympy

--- a/src/openfermion/ops/representations/diagonal_coulomb_hamiltonian.py
+++ b/src/openfermion/ops/representations/diagonal_coulomb_hamiltonian.py
@@ -37,9 +37,9 @@ class DiagonalCoulombHamiltonian:
     """
 
     def __init__(self, one_body, two_body, constant=0.):
-        if two_body.dtype != numpy.float:
+        if two_body.dtype != numpy.float64:
             raise ValueError('Two-body tensor has invalid dtype. Expected {} '
-                             'but was {}'.format(numpy.float, two_body.dtype))
+                             'but was {}'.format(numpy.float64, two_body.dtype))
         if not numpy.allclose(two_body, two_body.T):
             raise ValueError('Two-body tensor must be symmetric.')
         if not numpy.allclose(one_body, one_body.T.conj()):


### PR DESCRIPTION
Some fixes for failing CI:

- v1.10.0 of scipy introduces a bug in the linalg.sqrtm function for complex valued matrices. Restrict maximum scipy version until this is resolved. See #815.
- Fix deprecated float comprison for numpy1.24.0 which now throws an error 
- Ubuntu 18.04 is no longer supported. Updated ci.yml to ubuntu-latest.