### PR TITLE
Fix pytest deprecation warnings.

### DIFF
--- a/src/openfermion/hamiltonians/jellium.py
+++ b/src/openfermion/hamiltonians/jellium.py
@@ -11,6 +11,7 @@
 #   limitations under the License.
 """This module constructs Hamiltonians for the uniform electron gas."""
 
+import math
 from typing import Optional
 
 import numpy
@@ -42,15 +43,15 @@ def wigner_seitz_length_scale(
     if dimension % 2:
         volume_per_particle = (
             2
-            * numpy.math.factorial(half_dimension)
+            * math.factorial(half_dimension)
             * (4 * numpy.pi) ** half_dimension
-            / numpy.math.factorial(dimension)
+            / math.factorial(dimension)
             * wigner_seitz_radius**dimension
         )
     else:
         volume_per_particle = (
             numpy.pi**half_dimension
-            / numpy.math.factorial(half_dimension)
+            / math.factorial(half_dimension)
             * wigner_seitz_radius**dimension
         )
 

--- a/src/openfermion/linalg/davidson_test.py
+++ b/src/openfermion/linalg/davidson_test.py
@@ -20,7 +20,6 @@ import scipy.linalg
 import scipy.sparse
 import scipy.sparse.linalg
 
-from openfermion.ops.operators import QubitOperator
 from openfermion.linalg.davidson import (
     Davidson,
     DavidsonOptions,
@@ -29,6 +28,7 @@ from openfermion.linalg.davidson import (
     append_random_vectors,
     orthonormalize,
 )
+from openfermion.ops.operators import QubitOperator
 
 
 def generate_matrix(dimension):

--- a/src/openfermion/linalg/davidson_test.py
+++ b/src/openfermion/linalg/davidson_test.py
@@ -117,7 +117,7 @@ class DavidsonOptionsTest(unittest.TestCase):
 
 
 class DavidsonTest(unittest.TestCase):
-    """ "Tests for Davidson class with a real matrix."""
+    """Tests for Davidson class with a real matrix."""
 
     def setUp(self):
         """Sets up all variables needed for Davidson class."""

--- a/src/openfermion/transforms/opconversions/bksf_test.py
+++ b/src/openfermion/transforms/opconversions/bksf_test.py
@@ -16,13 +16,13 @@ import unittest
 
 import numpy
 
-from openfermion.config import DATA_DIRECTORY
 from openfermion.chem import MolecularData
+from openfermion.config import DATA_DIRECTORY
+from openfermion.linalg import eigenspectrum, get_sparse_operator
 from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.ops.representations import InteractionOperator
 from openfermion.transforms.opconversions import bksf, get_fermion_operator, normal_ordered
 from openfermion.transforms.opconversions.jordan_wigner import jordan_wigner, jordan_wigner_one_body
-from openfermion.linalg import get_sparse_operator, eigenspectrum
 from openfermion.utils import count_qubits
 
 
@@ -173,8 +173,8 @@ class bravyi_kitaev_fastTransformTest(unittest.TestCase):
         tot_23_fermions = numpy.dot(
             two_fermion_state.conjugate().T, numpy.dot(number_operator_23_matrix, two_fermion_state)
         )
-        self.assertTrue(2.0 - float(tot_fermions.real) < 1e-13)
-        self.assertTrue(2.0 - float(tot_23_fermions.real) < 1e-13)
+        self.assertTrue(2.0 - float(tot_fermions[0, 0].real) < 1e-13)
+        self.assertTrue(2.0 - float(tot_23_fermions[0, 0].real) < 1e-13)
 
     def test_bravyi_kitaev_fast_excitation_terms(self):
         # Testing on-site and excitation terms in Hamiltonian

--- a/src/openfermion/utils/grid.py
+++ b/src/openfermion/utils/grid.py
@@ -11,6 +11,7 @@
 #   limitations under the License.
 
 import itertools
+
 import numpy
 import scipy
 import scipy.linalg
@@ -246,7 +247,7 @@ class Grid:
         for dimension, grid_coordinate in enumerate(grid_coordinates):
             # Make sure coordinate is an integer in the correct bounds.
             if isinstance(grid_coordinate, int) and grid_coordinate < self.length[dimension]:
-                tensor_factor += grid_coordinate * int(numpy.product(self.length[:dimension]))
+                tensor_factor += grid_coordinate * int(numpy.prod(self.length[:dimension]))
             else:
                 # Raise for invalid model.
                 raise OrbitalSpecificationError('Invalid orbital coordinates provided.')
@@ -270,7 +271,7 @@ class Grid:
             grid_indices (numpy.ndarray[int]):
                 The location of the qubit on the grid.
         """
-        if not (numpy.product(self.length) * (2 - spinless) > qubit_id >= 0):
+        if not (numpy.prod(self.length) * (2 - spinless) > qubit_id >= 0):
             raise OrbitalSpecificationError('Invalid qubit_id provided.')
 
         # Remove spin degree of freedom if it exists.
@@ -282,8 +283,8 @@ class Grid:
         # Get grid indices.
         grid_indices = []
         for dimension in range(self.dimensions):
-            remainder = orbital_id % int(numpy.product(self.length[: dimension + 1]))
-            grid_index = remainder // int(numpy.product(self.length[:dimension]))
+            remainder = orbital_id % int(numpy.prod(self.length[: dimension + 1]))
+            grid_index = remainder // int(numpy.prod(self.length[:dimension]))
             grid_indices += [grid_index]
         return grid_indices
 


### PR DESCRIPTION
The diff is huge because of reformatting. May be worth first merging #846.  But just fixed some deprecation warnings (numpy.product, numpy.math, converting size one array to scalar)  emitted by pytest. 