### PR TITLE
Fix scipy sqrtm precision issue

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -1,4 +1,4 @@
-cirq-core~=1.0
+cirq-core~=1.0,<1.3.0
 deprecation
 h5py>=2.8
 networkx

--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -6,7 +6,6 @@ numpy>=1.11.0
 pubchempy
 requests>=2.18
 
-# https://github.com/scipy/scipy/issues/18250
-scipy>=1.1.0,<1.10.0
+scipy>=1.1.0
 
 sympy

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -20,7 +20,7 @@ certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
     # via requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via -r deps/runtime.txt
 click==8.1.7
     # via

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -8,7 +8,7 @@ ase==3.22.1
     # via -r deps/resource_estimates_runtime.txt
 astroid==2.13.5
     # via pylint
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -16,11 +16,11 @@ black==23.3.0
     # via -r deps/format.txt
 build==1.0.3
     # via pip-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
     # via requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via -r deps/runtime.txt
 click==8.1.7
     # via
@@ -28,7 +28,7 @@ click==8.1.7
     #   pip-tools
 contourpy==1.2.0
     # via matplotlib
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -38,45 +38,45 @@ dill==0.3.7
     # via pylint
 duet==0.2.9
     # via cirq-core
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-fastjsonschema==2.18.1
+fastjsonschema==2.19.1
     # via nbformat
-fonttools==4.43.0
+fonttools==4.47.2
     # via matplotlib
 h5py==3.10.0
     # via
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.4
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.2
     # via pylint
-jax==0.4.20
+jax==0.4.23
     # via -r deps/resource_estimates_runtime.txt
-jaxlib==0.4.20
+jaxlib==0.4.23
     # via -r deps/resource_estimates_runtime.txt
-jsonschema==4.19.2
+jsonschema==4.21.0
     # via nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via nbformat
 kiwisolver==1.4.5
     # via matplotlib
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via astroid
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   ase
     #   cirq-core
 mccabe==0.7.0
     # via pylint
-ml-dtypes==0.3.1
+ml-dtypes==0.3.2
     # via
     #   jax
     #   jaxlib
@@ -94,7 +94,7 @@ networkx==3.2.1
     # via
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -118,15 +118,15 @@ packaging==23.2
     #   deprecation
     #   matplotlib
     #   pytest
-pandas==2.1.2
+pandas==2.1.4
     # via cirq-core
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pillow==10.1.0
+pillow==10.2.0
     # via matplotlib
 pip-tools==7.3.0
     # via -r deps/pip-tools.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   jupyter-core
@@ -143,17 +143,17 @@ pyproject-hooks==1.0.0
     # via build
 pyscf==2.4.0
     # via -r deps/resource_estimates_runtime.txt
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via -r deps/pytest.txt
 pytest-cov==4.1.0
     # via -r deps/pytest.txt
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r deps/pytest.txt
 python-dateutil==2.8.2
     # via
@@ -161,17 +161,17 @@ python-dateutil==2.8.2
     #   pandas
 pytz==2023.3.post1
     # via pandas
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via -r deps/runtime.txt
-rpds-py==0.10.6
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -196,28 +196,28 @@ tomli==2.0.1
     #   pylint
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 tqdm==4.66.1
     # via cirq-core
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   jupyter-core
     #   nbformat
 typed-ast==1.4.3
     # via mypy
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   astroid
     #   cirq-core
     #   mypy
-tzdata==2023.3
+tzdata==2023.4
     # via pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -8,7 +8,7 @@ black==23.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -40,7 +40,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -48,7 +48,7 @@ h5py==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -56,7 +56,7 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -73,7 +73,7 @@ networkx==3.2.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -89,19 +89,19 @@ packaging==23.2
     #   black
     #   deprecation
     #   matplotlib
-pandas==2.1.2
+pandas==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pathspec==0.11.2
+pathspec==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -126,7 +126,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -152,15 +152,15 @@ tqdm==4.66.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/mypy.env.txt deps/mypy.txt deps/runtime.txt
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -12,7 +12,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -32,7 +32,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -40,7 +40,7 @@ h5py==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -48,7 +48,7 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -69,7 +69,7 @@ networkx==3.2.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -84,11 +84,11 @@ packaging==23.2
     #   -c envs/dev.env.txt
     #   deprecation
     #   matplotlib
-pandas==2.1.2
+pandas==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -113,7 +113,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -139,16 +139,16 @@ typed-ast==1.4.3
     # via
     #   -c envs/dev.env.txt
     #   mypy
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   mypy
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -12,7 +12,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -30,7 +30,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -8,7 +8,7 @@ astroid==2.13.5
     # via
     #   -c envs/dev.env.txt
     #   pylint
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -40,7 +40,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -48,11 +48,11 @@ h5py==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
-isort==5.12.0
+isort==5.13.2
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -60,11 +60,11 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -81,7 +81,7 @@ networkx==3.2.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -96,15 +96,15 @@ packaging==23.2
     #   -c envs/dev.env.txt
     #   deprecation
     #   matplotlib
-pandas==2.1.2
+pandas==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -133,7 +133,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -155,7 +155,7 @@ tomli==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   pylint
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -163,20 +163,20 @@ tqdm==4.66.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -c envs/dev.env.txt
     #   astroid

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -8,12 +8,12 @@ ase==3.22.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -29,7 +29,7 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -45,7 +45,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -53,11 +53,11 @@ execnet==2.0.2
     # via
     #   -c envs/dev.env.txt
     #   pytest-xdist
-fastjsonschema==2.18.1
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -66,7 +66,7 @@ h5py==3.10.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -74,23 +74,23 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-jax==0.4.20
+jax==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-jaxlib==0.4.20
+jaxlib==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-jsonschema==4.19.2
+jsonschema==4.21.0
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -98,12 +98,12 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   -c envs/dev.env.txt
     #   ase
     #   cirq-core
-ml-dtypes==0.3.1
+ml-dtypes==0.3.2
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -121,7 +121,7 @@ networkx==3.2.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -147,15 +147,15 @@ packaging==23.2
     #   deprecation
     #   matplotlib
     #   pytest
-pandas==2.1.2
+pandas==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -175,14 +175,14 @@ pyscf==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -190,7 +190,7 @@ pytest-cov==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -203,7 +203,7 @@ pytz==2023.3.post1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -212,12 +212,12 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.10.6
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -248,20 +248,20 @@ tqdm==4.66.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -17,7 +17,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.2.0
+cirq-core==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -25,7 +25,7 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -41,7 +41,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -49,11 +49,11 @@ execnet==2.0.2
     # via
     #   -c envs/dev.env.txt
     #   pytest-xdist
-fastjsonschema==2.18.1
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -61,7 +61,7 @@ h5py==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -69,15 +69,15 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-jsonschema==4.19.2
+jsonschema==4.21.0
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -85,7 +85,7 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.2
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -102,7 +102,7 @@ networkx==3.2.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.25.2
+numpy==1.26.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -118,15 +118,15 @@ packaging==23.2
     #   deprecation
     #   matplotlib
     #   pytest
-pandas==2.1.2
+pandas==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -142,14 +142,14 @@ pyparsing==3.1.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -157,7 +157,7 @@ pytest-cov==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -170,7 +170,7 @@ pytz==2023.3.post1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -179,12 +179,12 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.10.6
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.9.3
+scipy==1.11.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -211,20 +211,20 @@ tqdm==4.66.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0
+cirq-core==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/max_compat/dev.env.txt
+++ b/dev_tools/requirements/max_compat/dev.env.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --constraint=deps/oldest-versions.txt --output-file=max_compat/dev.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -18,7 +18,7 @@ cirq-core==1.0.0
     #   -r deps/runtime.txt
 contourpy==1.1.1
     # via matplotlib
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,34 +26,34 @@ deprecation==2.1.0
     # via -r deps/runtime.txt
 duet==0.2.8
     # via cirq-core
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-fastjsonschema==2.18.1
+fastjsonschema==2.19.1
     # via nbformat
-fonttools==4.43.0
+fonttools==4.47.2
     # via matplotlib
 h5py==3.10.0
     # via -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via requests
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   jsonschema
     #   jsonschema-specifications
     #   matplotlib
 iniconfig==2.0.0
     # via pytest
-jsonschema==4.19.2
+jsonschema==4.21.0
     # via nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via nbformat
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.7.3
+matplotlib==3.7.4
     # via cirq-core
 mpmath==1.3.0
     # via sympy
@@ -79,11 +79,11 @@ packaging==23.2
     #   pytest
 pandas==2.0.3
     # via cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via matplotlib
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via jupyter-core
 pluggy==1.3.0
     # via pytest
@@ -91,17 +91,17 @@ pubchempy==1.0.4
     # via -r deps/runtime.txt
 pyparsing==3.1.1
     # via matplotlib
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via -r deps/pytest.txt
 pytest-cov==4.1.0
     # via -r deps/pytest.txt
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r deps/pytest.txt
 python-dateutil==2.8.2
     # via
@@ -109,17 +109,17 @@ python-dateutil==2.8.2
     #   pandas
 pytz==2023.3.post1
     # via pandas
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via -r deps/runtime.txt
-rpds-py==0.10.6
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.9.3
+scipy==1.10.1
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -137,15 +137,15 @@ tomli==2.0.1
     #   pytest
 tqdm==4.66.1
     # via cirq-core
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   jupyter-core
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 zipp==3.17.0
     # via importlib-resources

--- a/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
+++ b/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --constraint=deps/oldest-versions.txt --constraint=max_compat/dev.env.txt --output-file=max_compat/pytest-max-compat.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
     #   referencing
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c max_compat/dev.env.txt
     #   requests
@@ -26,7 +26,7 @@ contourpy==1.1.1
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest-cov
@@ -42,7 +42,7 @@ duet==0.2.8
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest
@@ -50,11 +50,11 @@ execnet==2.0.2
     # via
     #   -c max_compat/dev.env.txt
     #   pytest-xdist
-fastjsonschema==2.18.1
+fastjsonschema==2.19.1
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
-fonttools==4.43.0
+fonttools==4.47.2
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
@@ -62,11 +62,11 @@ h5py==3.10.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.4
+idna==3.6
     # via
     #   -c max_compat/dev.env.txt
     #   requests
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
@@ -76,15 +76,15 @@ iniconfig==2.0.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest
-jsonschema==4.19.2
+jsonschema==4.21.0
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
@@ -92,7 +92,7 @@ kiwisolver==1.4.5
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-matplotlib==3.7.3
+matplotlib==3.7.4
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
@@ -129,7 +129,7 @@ pandas==2.0.3
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
@@ -137,7 +137,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c max_compat/dev.env.txt
     #   jupyter-core
@@ -153,14 +153,14 @@ pyparsing==3.1.1
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
@@ -168,7 +168,7 @@ pytest-cov==4.1.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
@@ -181,7 +181,7 @@ pytz==2023.3.post1
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
@@ -190,12 +190,12 @@ requests==2.31.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.10.6
+rpds-py==0.17.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.9.3
+scipy==1.10.1
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -222,20 +222,20 @@ tqdm==4.66.1
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c max_compat/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -c max_compat/dev.env.txt
     #   requests

--- a/src/openfermion/circuits/gates/fermionic_simulation.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation.py
@@ -809,8 +809,7 @@ class QuarticFermionicSimulationGate(InteractionOperatorFermionicGate, cirq.Eige
         combined_rotations = {}
         # See: https://github.com/quantumlib/OpenFermion/issues/815
         # for scipy >= v0.10.0 there is a bug in la.sqrtm leading to a loss in
-        # precision, meaning this following code breaks causes unit tests to
-        # fail.
+        # precision, meaning this following code causes the unit tests to fail.
         # combined_rotations[0] = la.sqrtm(
         #     np.linalg.multi_dot(
         #         [
@@ -827,7 +826,7 @@ class QuarticFermionicSimulationGate(InteractionOperatorFermionicGate, cirq.Eige
             )
         )
         eig_vec_inv = la.inv(eig_vec)
-        # A^{1/2} = V D V^{-1}, where D is the matrix of eigenvalues and V is the
+        # A^{1/2} = V D^{1/2} V^{-1}, where D is the matrix of eigenvalues and V is the
         # matrix of eigenvectors.
         combined_rotations[0] = np.linalg.multi_dot([eig_vec, np.diag(eig_val**0.5), eig_vec_inv])
         combined_rotations[1] = la.inv(combined_rotations[0])

--- a/src/openfermion/circuits/gates/fermionic_simulation.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation.py
@@ -12,16 +12,16 @@
 
 import abc
 import itertools
-from typing import cast, Dict, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Union, cast
 
+import cirq
 import numpy as np
 import scipy.linalg as la
 import sympy
-import cirq
 
 import openfermion.ops as ops
-from openfermion.transforms import get_interaction_operator
 from openfermion.linalg import jordan_wigner_sparse
+from openfermion.transforms import get_interaction_operator
 from openfermion.utils import hermitian_conjugated
 
 if TYPE_CHECKING:
@@ -807,11 +807,29 @@ class QuarticFermionicSimulationGate(InteractionOperatorFermionicGate, cirq.Eige
         ]
 
         combined_rotations = {}
-        combined_rotations[0] = la.sqrtm(
+        # See: https://github.com/quantumlib/OpenFermion/issues/815
+        # for scipy >= v0.10.0 there is a bug in la.sqrtm leading to a loss in
+        # precision, meaning this following code breaks causes unit tests to
+        # fail.
+        # combined_rotations[0] = la.sqrtm(
+        #     np.linalg.multi_dot(
+        #         [
+        #           la.inv(individual_rotations[1]),
+        #           individual_rotations[0],
+        #           individual_rotations[2]
+        #         ]
+        #     )
+        # )
+        # Compute the square root through eigendecomposition instead until the issue is resolved.
+        eig_val, eig_vec = np.linalg.eig(
             np.linalg.multi_dot(
                 [la.inv(individual_rotations[1]), individual_rotations[0], individual_rotations[2]]
             )
         )
+        eig_vec_inv = la.inv(eig_vec)
+        # A^{1/2} = V D V^{-1}, where D is the matrix of eigenvalues and V is the
+        # matrix of eigenvectors.
+        combined_rotations[0] = np.linalg.multi_dot([eig_vec, np.diag(eig_val**0.5), eig_vec_inv])
         combined_rotations[1] = la.inv(combined_rotations[0])
         combined_rotations[2] = np.linalg.multi_dot(
             [la.inv(individual_rotations[0]), individual_rotations[1], combined_rotations[0]]


### PR DESCRIPTION
Addresses #815 by replacing la.sqrtm with the square root computed via eigendecomposition. Just bumping the input array's precision to 256 didn't solve the problem.