### PR TITLE
Fix doc generation

### DIFF
--- a/docs/fqe/tutorials/fermi_hubbard.ipynb
+++ b/docs/fqe/tutorials/fermi_hubbard.ipynb
@@ -196,7 +196,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "e_time = 1.0\n",
+    "e_time = 0.9\n",
     "true_evolved_fqe = init_wfn.time_evolve(e_time, hubbard)"
    ]
   },


### PR DESCRIPTION
This document errors out with the following error:

"RuntimeError: maximum taylor expansion limit reached"

Changing the time to 0.9 eliminates the error.  Better solutions or ideas welcome, but this at least allows the python notebooks to be generated.