### PR TITLE
Remove cirq_google

### DIFF
--- a/docs/tutorials/circuits_1_basis_change.ipynb
+++ b/docs/tutorials/circuits_1_basis_change.ipynb
@@ -208,7 +208,6 @@
    "source": [
     "import openfermion\n",
     "import cirq\n",
-    "import cirq_google\n",
     "\n",
     "# Initialize the qubit register.\n",
     "qubits = cirq.LineQubit.range(n_qubits)\n",


### PR DESCRIPTION
cirq_google is not used in this tutorial.  It is also no longer imported by the requirements file.  Just remove this import.