### PR TITLE
Fix nightly ci workflow failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10.12", "3.11.9", "3.12.8"]
+        os: [ubuntu-22.04, macos-14, windows-latest]
+        python-version: ["3.10.11", "3.11.9", "3.12.8"]
         arch: [x64, arm64]
         exclude:
           - os: windows-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   cirq-stable:
-    name: Test current stable Cirq release
+    name: Stable Cirq release
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -65,7 +65,7 @@ jobs:
           check/pytest
 
   cirq-dev:
-    name: Test latest Cirq pre-release
+    name: Cirq pre-release
     runs-on: ${{matrix.os}}
     strategy:
       matrix:


### PR DESCRIPTION
More combinations of {OS, Python, architecture} are missing than I thought. This adjusts some requested versions to try to find a working combination for the matrix of combinations.