### PR TITLE
Use a variable to get the correct repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   cirq-stable:
     name: Using stable Cirq release
-    uses: mhucka/openfermion/.github/workflows/nightly-pytest.yml@master
+    uses: ${{github.repository}}/.github/workflows/nightly-pytest.yml@master
     with:
       args: ""
 
   cirq-pre:
     name: Using Cirq pre-release
-    uses: mhucka/openfermion/.github/workflows/nightly-pytest.yml@master
+    uses: ${{github.repository}}/.github/workflows/nightly-pytest.yml@master
     with:
       args: "--pre"


### PR DESCRIPTION
We don't need to hard-code the repository org/name combo.