### PR TITLE
Use local reference to workflow path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   cirq-stable:
     name: Using stable Cirq release
-    uses: mhucka/openfermion/.github/workflows/nightly-pytest.yml@master
+    uses: ./.github/workflows/nightly-pytest.yml
     with:
       args: ""
 
   cirq-pre:
     name: Using Cirq pre-release
-    uses: mhucka/openfermion/.github/workflows/nightly-pytest.yml@master
+    uses: ./.github/workflows/nightly-pytest.yml
     with:
       args: "--pre"


### PR DESCRIPTION
This is safer, and doesn't need a version either.