### PR TITLE
Add .zenodo.json file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,248 @@
+{
+  "title": "OpenFermion",
+  "description": "The electronic structure package for quantum computers.",
+  "license": "Apache-2.0",
+  "access_right": "open",
+  "upload_type": "software",
+  "notes": "The full list of authors can be found on GitHub at the URL https://github.com/quantumlib/Cirq/graphs/contributors",
+  "creators": [
+    {
+      "name": "Ryan Babbush",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Jarrod R. McClean",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Nicholas Rubin",
+      "affiliation": "Rigetti Computing, Berkeley, California, US"
+    },
+    {
+      "name": "Kevin J. Sung",
+      "affiliation": "Department of Electrical Engineering and Computer Science, University of Michigan, Ann Arbor, Michigan, US"
+    },
+    {
+      "name": "Ian D. Kivlichan",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Dave Bacon",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Xavier Bonet-Monroig",
+      "affiliation": "Leiden University, Leiden, NL"
+    },
+    {
+      "name": "Yudong Cao",
+      "affiliation": "Department of Chemistry and Chemical Biology, Harvard University, Cambridge, Massachusetts, US"
+    },
+    {
+      "name": "Chengyu Dai",
+      "affiliation": "Department of Physics, University of Michigan, Ann Arbor, Michigan, US"
+    },
+    {
+      "name": "E. Schuyler Fried",
+      "affiliation": "Department of Chemistry and Chemical Biology, Harvard University, Cambridge, Massachusetts, US"
+    },
+    {
+      "name": "Craig Gidney",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Brendan Gimby",
+      "affiliation": "Department of Electrical Engineering and Computer Science, University of Michigan, Ann Arbor, Michigan, US"
+    },
+    {
+      "name": "Pranav Gokhale",
+      "affiliation": "Department of Computer Science, University of Chicago, Chicago, Illinois, US"
+    },
+    {
+      "name": "Thomas Häner",
+      "affiliation": "Theoretische Physik, ETH Zurich, Zurich, CH"
+    },
+    {
+      "name": "Tarini Hardikar",
+      "affiliation": "Department of Physics, Dartmouth College, Hanover, New Hampshire, US"
+    },
+    {
+      "name": "Vojtĕch Havlíček",
+      "affiliation": "Department of Computer Science, Oxford University, Oxford, UK"
+    },
+    {
+      "name": "Oscar Higgott",
+      "affiliation": "Department of Physics and Astronomy, University College London, Gower Street, London, UK"
+    },
+    {
+      "name": "Cupjin Huang",
+      "affiliation": "Department of Electrical Engineering and Computer Science, University of Michigan, Ann Arbor, Michigan, US"
+    },
+    {
+      "name": "Josh Izaac",
+      "affiliation": "Xanadu, Toronto, CA"
+    },
+    {
+      "name": "Zhang Jiang",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "William Kirby",
+      "affiliation": "Tufts University, Boston, Massachusetts, US"
+    },
+    {
+      "name": "Xinle Liu",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Sam McArdle",
+      "affiliation": "Department of Materials, University of Oxford, Oxford, UK"
+    },
+    {
+      "name": "Matthew Neeley",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Thomas O'Brien",
+      "affiliation": "Instituut-Lorentz, Universiteit Leiden, Leiden, NL"
+    },
+    {
+      "name": "Bryan O'Gorman",
+      "affiliation": "BQIC, University of California, Berkeley, Caliifornia, US"
+    },
+    {
+      "name": "Isil Ozfidan",
+      "affiliation": "D-Wave Systems Inc., Burnaby, British Columbia, CA"
+    },
+    {
+      "name": "Maxwell D. Radin",
+      "affiliation": "Materials Department, University of California Santa Barbara, Santa Barbara, California, US"
+    },
+    {
+      "name": "Jhonathan Romero",
+      "affiliation": "Department of Chemistry and Chemical Biology, Harvard University, Cambridge, Michigan, US"
+    },
+    {
+      "name": "Daniel Sank",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Nicolas P. D. Sawaya",
+      "affiliation": "Department of Chemistry and Chemical Biology, Harvard University, Cambridge, Michigan, US"
+    },
+    {
+      "name": "Bruno Senjean",
+      "affiliation": "Leiden University, Leiden, NL"
+    },
+    {
+      "name": "Kanav Setia",
+      "affiliation": "Department of Physics, Dartmouth College, Hanover, New Hampshire, US"
+    },
+    {
+      "name": "Hannah Sim",
+      "affiliation": "Department of Chemistry and Chemical Biology, Harvard University, Cambridge, Massachusetts, US"
+    },
+    {
+      "name": "Damian S. Steiger",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Mark Steudtner",
+      "affiliation": "Instituut-Lorentz, Universiteit Leiden, Leiden, NL"
+    },
+    {
+      "name": "Qiming Sun",
+      "affiliation": "Division of Chemistry and Chemical Engineering, California Institute of Technology, Pasadena, California, US"
+    },
+    {
+      "name": "Wei Sun",
+      "affiliation": "Google LLC"
+    },
+    {
+      "name": "Daochen Wang",
+      "affiliation": "Joint Center for Quantum Information and Computer Science, University of Maryland, College Park, Maryland, US"
+    },
+    {
+      "name": "Fang Zhang",
+      "affiliation": "Department of Electrical Engineering and Computer Science, University of Michigan, Ann Arbor, Michigan, US"
+    },
+    {
+      "name": "Emiel Koridon",
+      "affiliation": "Leiden University, Leiden, NL"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/quantumlib/OpenFermion",
+      "relation": "isDerivedFrom",
+      "scheme": "url"
+    },
+    {
+      "identifier": "10.1088/2058-9565/ab8ebc",
+      "resource_type": "publication-article",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.48550/arXiv.1710.07629",
+      "resource_type": "publication-preprint",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://quantumai.google/openfermion",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/quantumlib/OpenFermion/blob/main/README.md",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://pypi.org/project/openfermion",
+      "relation": "isSupplementedBy",
+      "scheme": "url"
+    }
+  ],
+  "keywords": [
+    "algorithms",
+    "API",
+    "application programming interface",
+    "chemistry",
+    "Cirq",
+    "electronic structure",
+    "fermion",
+    "fermionic systems",
+    "Hamiltonians",
+    "high performance",
+    "NISQ",
+    "noisy intermediate-scale quantum",
+    "open-source software",
+    "physics",
+    "Python",
+    "quantum algorithms",
+    "quantum chemistry",
+    "quantum circuit simulator",
+    "quantum circuit",
+    "quantum computer simulator",
+    "quantum computing",
+    "quantum information science",
+    "quantum information",
+    "quantum programming language",
+    "quantum programming",
+    "quantum simulation",
+    "quantum state",
+    "quantum system",
+    "quantum theory",
+    "quantum",
+    "qubit Hamiltonians",
+    "qubit",
+    "science",
+    "SDK",
+    "simulation",
+    "software development toolkit",
+    "software"
+  ],
+  "language": "eng",
+}


### PR DESCRIPTION
Zenodo is an open repository maintained by CERN for preserving research data and software. It assigns permanent unique identifiers to each repository so it can be identified and cited. Zenodo also provides an integration mechanism allowing GitHub repository owners to arrange for GitHub releases to be sent automatically to Zenodo when they are made.

In order to provide users with (i) a way to override the values obtained via the GitHub API and (ii) to set other metadata fields available in Zenodo but not in GitHub, the Zenodo-GitHub integration mechanism will also look for a `.zenodo.json` file at the top level of a repository.

This PR adds a `.zenodo.json` file for OpenFermion; separately, we will turn on the GitHub-Zenodo integration for this repository, so that OpenFermion releases are archived in Zenodo automatically.