### PR TITLE
Correct Nick Rubin's affiliation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "Nicholas Rubin",
-      "affiliation": "Rigetti Computing, Berkeley, California, US"
+      "affiliation": "Google LLC"
     },
     {
       "name": "Kevin J. Sung",


### PR DESCRIPTION
Looking at the publications again, I see Google listed first, so I changed it to match.