### PR TITLE
Update & enhance packaging scripts

### DIFF
--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -32,38 +32,63 @@
 ################################################################################
 
 PROJECT_NAME=openfermion
+RED=$'\033[31m'
+RESET=$'\033[0m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
 
-set -ex
+set -e
 
-if [ -z "${1}" ]; then
-  echo -e "\e[31mNo output directory given.\e[0m"
+if [ -z "$1" ]; then
+  echo -e "${RED}No output directory given.${RESET}"
   exit 1
 fi
-out_dir=$(realpath "${1}")
 
-SPECIFIED_VERSION="${2}"
+mkdir -p "$1"
+out_dir=$(realpath "$1")
+
+SPECIFIED_VERSION="$2"
+if [ -n "$SPECIFIED_VERSION" ]; then
+    echo "Will set version to $SPECIFIED_VERSION"
+fi
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd "$(dirname "${BASH_SOURCE[0]}")"
 repo_dir=$(git rev-parse --show-toplevel)
-cd ${repo_dir}
+cd "$repo_dir"
 
-# Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).
-if [ ! -z "$(git status --short)" ]; then
-    echo -e "\e[31mWARNING: You have uncommitted changes. They won't be included in the package.\e[0m"
+function confirm() {
+    local question="$1"
+    read -r -p "$question (y/n) " answer
+    [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+# Make a clean copy of HEAD, without files ignored by git (but potentially kept
+# by setup.py).
+if [ -n "$(git status --short)" ]; then
+    echo -e "${RED}WARNING: There are uncommitted git changes."
+    echo -e "They won't be included in the package.${RESET}"
+    if ! confirm "${YELLOW}Proceed anyway?${RESET}"; then
+        echo "Stopping."
+        exit 1
+    fi
 fi
+
 tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
-trap "{ rm -rf ${tmp_git_dir}; }" EXIT
-cd "${tmp_git_dir}"
+trap "{ rm -rf $tmp_git_dir; }" EXIT
+
+cd "$tmp_git_dir"
 git init --quiet
-git fetch ${repo_dir} HEAD --quiet --depth=1
+git fetch "$repo_dir" HEAD --quiet --depth=1
 git checkout FETCH_HEAD -b work --quiet
-if [ ! -z "${SPECIFIED_VERSION}" ]; then
-    echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/src/${PROJECT_NAME}/_version.py"
+
+if [ -n "$SPECIFIED_VERSION" ]; then
+    echo '__version__ = "'"$SPECIFIED_VERSION"'"' \
+         > "$tmp_git_dir/src/$PROJECT_NAME/_version.py"
 fi
 
 # Python wheel.
-echo "Producing python package files..."
-python -m build --outdir "${out_dir}"
+echo -e "${GREEN}Producing Python package files...${RESET}"
+python -m build --outdir "$out_dir"
 
-ls "${out_dir}"
+echo -e "${GREEN}Finished – output is in $out_dir${RESET}"

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -23,11 +23,17 @@
 #
 # Usage:
 #     dev_tools/packaging/produce-package.sh output_dir [version]
+#
+# Note: since around 2021, the use of setup.py to build distributions has been
+# deprecated and replaced with using the Python 'build' package, and along with
+# this, stricter requirements for versioning were introduced. This means that
+# the "version" argument to this script must conform to patterns described at
+# https://packaging.python.org/en/latest/discussions/versioning/.
 ################################################################################
 
 PROJECT_NAME=openfermion
 
-set -e
+set -ex
 
 if [ -z "${1}" ]; then
   echo -e "\e[31mNo output directory given.\e[0m"
@@ -58,6 +64,6 @@ fi
 
 # Python wheel.
 echo "Producing python package files..."
-python3 setup.py -q sdist -d "${out_dir}"
+python -m build --outdir "${out_dir}"
 
 ls "${out_dir}"

--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -2,6 +2,7 @@
 virtualenv
 
 # for creating packages
+build
 setuptools
 wheel
 


### PR DESCRIPTION
This fixes a few small problems with the packaging scripts, replaces the deprecated `python3 -m setup.py bdist` command with the `build` equivalent, and slightly enhances and cleans up `produce-package.sh`.