### PR TITLE
Version bump to 1.7.0

### DIFF
--- a/src/openfermion/_version.py
+++ b/src/openfermion/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "1.7.0.dev0"
+__version__ = "1.7.0"


### PR DESCRIPTION
This updates `src/openfermion/_version.py` to record the version number 1.7.0 for the release.