### PR TITLE
Remove doc source files from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,15 +34,6 @@ resource_requirements = open(
 resource_requirements = [r.strip() for r in resource_requirements]
 resource_requirements = [r for r in resource_requirements if not r.startswith('#')]
 
-docs_files_gen = os.walk('docs')
-docs_data_files_tuples = []
-for cwd, subdirs, files in list(docs_files_gen)[1:]:
-    if 'ipynb_checkpoints' in cwd:
-        continue
-    docs_data_files_tuples.append(
-        (os.path.join('openfermion', cwd), [os.path.join(cwd, file) for file in files])
-    )
-
 setup(
     name='openfermion',
     version=__version__,
@@ -66,7 +57,6 @@ setup(
             os.path.join('src', 'openfermion', 'testing', '*.hdf5'),
         ]
     },
-    data_files=docs_data_files_tuples,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This fixes issue https://github.com/quantumlib/OpenFermion/issues/887.  It removes the documentation source files from the installation.

Including the documentation `.md` and tutorial `.ipynb` files in the `pip` package installation seems unnecessary; the file end up in a very unusual location where users are unlikely to find them (which makes the value of their inclusion questionable), and the same content is available online (https://quantumai.google/openfermion).