### PR TITLE
Add timeouts to jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 name: Continuous integration checks
-run-name: Continuous integration checks triggered by ${{github.event_name}}
+run-name: CI checks for ${{github.event_name}} by ${{github.actor}}
 
 on:
   pull_request:
@@ -60,6 +60,7 @@ env:
 jobs:
   Setup:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out a copy of the OpenFermion git repository
         uses: actions/checkout@v4
@@ -89,6 +90,7 @@ jobs:
     name: Format check
     needs: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,6 +113,7 @@ jobs:
     name: Type check
     needs: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -131,6 +134,7 @@ jobs:
     name: Lint check
     needs: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -150,6 +154,7 @@ jobs:
   pytest-max-compat:
     name: Pytest max compat
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -171,6 +176,7 @@ jobs:
     name: Pytest matrix
     needs: Setup
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -212,6 +218,7 @@ jobs:
     name: Pytest extra matrix
     needs: Setup
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -17,6 +17,7 @@ jobs:
     # Try to fit as much info as possible into the GHA sidebar at run-time.
     name: Py ${{matrix.python-version}} + ${{matrix.os}}/${{matrix.arch}}
     runs-on: ${{matrix.os}}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Google best practices for GitHub Actions recommend setting timeouts on jobs, to guard against unexpected problems causing jobs to take the full 60 minute GitHub default (go/github-actions#set-a-job-timeout).