### PR TITLE
Delete trigger on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ on:
     types:
       - checks_requested
 
-  push:
-    branches:
-      - master
-
   # Allow manual invocation.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
When a pull request is merged, it causes a push event on the main branch, which ends up causing this workflow to be executed twice when the merge occurs.