### PR TITLE
Run Python checks for any change including deletion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,7 @@ jobs:
           # The outputs will be variables named "foo_files" for a filter "foo".
           filters: |
             python:
-              - added|modified:
-                  - '**/*.py'
+              - '**/*.py'
             yaml:
               - added|modified:
                   - '**/*.yaml'


### PR DESCRIPTION
The condition for running the Python checks needs to include deletion of Python files, not just addition or modification, because deletion can cause failures.