### PR TITLE
Use specific versions of GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: (Set up Python)
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the git repository
@@ -160,7 +160,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: Python format checks
     needs: [changes, setup]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the git repository
@@ -186,7 +186,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: Python type checks
     needs: [changes, setup]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the git repository
@@ -210,7 +210,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: Python lint checks
     needs: [changes, setup]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the git repository
@@ -249,7 +249,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-14, windows-2022 ]
         cirq-version: [ 1.4.1 ]
       fail-fast: false
     steps:
@@ -275,7 +275,7 @@ jobs:
     if: needs.changes.outputs.python == 'true' && (success() || failure())
     name: Python pytest checks
     needs: [changes, pytest-matrix]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           result="${{needs.pytest-matrix.result}}"
@@ -293,7 +293,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-14]
         cirq-version: [ 1.4.1 ]
       fail-fast: false
     steps:
@@ -319,7 +319,7 @@ jobs:
     if: needs.changes.outputs.python == 'true' && (success() || failure())
     name: Python extra pytest checks
     needs: [changes, pytest-extra-matrix]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           result="${{needs.pytest-extra-matrix.result}}"
@@ -357,7 +357,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: Python code coverage checks
     needs: [changes, setup]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out a copy of the git repository

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -26,7 +26,7 @@ jobs:
         # making all necessary Python dependencies available on those combos.
         # TODO: add "3.13.1" once Cirq 1.5 is released.
         python-version: ["3.10.11", "3.11.9", "3.12.7", "3.13.1"]
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
         arch: [x64, arm64]
         exclude:
           # MacOS 14 is only available for arm64.
@@ -34,7 +34,7 @@ jobs:
             arch: x64
 
           # Windows is only available for x64.
-          - os: windows-latest
+          - os: windows-2022
             arch: arm64
 
           # GitHub provides separate Ubuntu runners for ARM and x64.


### PR DESCRIPTION
Google security best practices mandate the use of specific runner versions instead of "-latest".