### PR TITLE
Only run Scorecard 1/day, not on every push

### DIFF
--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -5,12 +5,6 @@ name: Scorecard supply-chain security
 run-name: Analyze code for Scorecard
 
 on:
-  push:
-    branches:
-      - master
-
-  # To guarantee the Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '19 20 * * 6'
 


### PR DESCRIPTION
Let's reduce the frequency of this. We don't have enough untrusted contributors to warrant running this on every push.