### PR TITLE
Remove extra comma at end of .zenodo.json file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -244,5 +244,5 @@
     "software development toolkit",
     "software"
   ],
-  "language": "eng",
+  "language": "eng"
 }


### PR DESCRIPTION
Somehow I missed the extra comma after the very last element in the JSON structure.

This is why there needs to be a JSON validator in the CI workflow.