### PR TITLE
Add Dockerfile linting to CI checks

### DIFF
--- a/.github/problem-matchers/README.md
+++ b/.github/problem-matchers/README.md
@@ -23,3 +23,9 @@ The following problem matcher JSON file came from the
 documentation (copied on 2025-02-12, version 1.7.7):
 
 - [`actionlint.json`](https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json)
+
+The following problem matcher JSON file came from the
+[hadolint-action](https://github.com/hadolint/hadolint-action) repository
+(copied on 2025-02-17, version 3.1.0):
+
+- [`problem-matcher.json`](https://github.com/hadolint/hadolint-action/blob/master/problem-matcher.json)

--- a/.github/problem-matchers/hadolint.json
+++ b/.github/problem-matchers/hadolint.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "brpaz/hadolint-action",
+      "pattern": [
+        {
+          "regexp": "(.*)\\:(\\d+)\\s(.*)",
+          "file": 1,
+          "line": 2,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
 
   json-lint:
     if: needs.changes.outputs.json == 'true'
-    name: Validate JSON files
+    name: JSON file lint checks
     needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -445,7 +445,7 @@ jobs:
 
   cff-validation:
     if: needs.changes.outputs.cff == 'true'
-    name: Validate CITATION.cff file(s)
+    name: CITATION.cff validation
     needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -465,7 +465,7 @@ jobs:
 
   docker-lint:
     if: needs.changes.outputs.docker == 'true'
-    name: Validate Docker files
+    name: Dockerfile lint checks
     needs: changes
     # This uses a Mac runner because hadolint isn't available via Linux apt.
     runs-on: macos-14
@@ -491,7 +491,7 @@ jobs:
 
   workflow-validation:
     if: needs.changes.outputs.gha == 'true'
-    name: Validate GitHub Actions file(s)
+    name: GitHub Actions file validation
     needs: [changes, yaml-lint]
     # This uses a Mac runner because actionlint isn't available via Linux apt.
     runs-on: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
       gha_files: ${{steps.filter.outputs.gha_files}}
       json: ${{steps.filter.outputs.json}}
       json_files: ${{steps.filter.outputs.json_files}}
+      docker: ${{steps.filter.outputs.docker}}
+      docker_files: ${{steps.filter.outputs.docker_files}}
     steps:
       # When invoked manually, use the given SHA to figure out the change list.
       - if: github.event_name == 'workflow_dispatch'
@@ -141,6 +143,9 @@ jobs:
             json:
               - added|modified:
                   - '**/*.json'
+            docker:
+              - '**/dockerfile'
+              - '**/Dockerfile'
 
   setup:
     if: needs.changes.outputs.python == 'true'
@@ -457,6 +462,32 @@ jobs:
       - name: Run cffconvert in validation mode
         run: |
           cffconvert --validate
+
+  docker-lint:
+    if: needs.changes.outputs.docker == 'true'
+    name: Validate Docker files
+    needs: changes
+    # This uses a Mac runner because hadolint isn't available via Linux apt.
+    runs-on: macos-14
+    timeout-minutes: 5
+    env:
+      changed_files: ${{needs.changes.outputs.docker_files}}
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      # Note: there is a hadolint GitHub Actions available, but it only accepts
+      # one Dockerfile to check. We have > 1 file to check, so we need the CLI.
+      - name: Install hadolint
+        run: |
+          brew install hadolint
+
+      - name: Set up hadolint output problem matcher
+        run: echo '::add-matcher::.github/problem-matchers/hadolint.json'
+
+      - name: Run hadolint on Dockerfiles that have been changed
+        run: |
+          hadolint ${{env.changed_files}}
 
   workflow-validation:
     if: needs.changes.outputs.gha == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
 
   json-lint:
     if: needs.changes.outputs.json == 'true'
-    name: JSON file lint checks
+    name: JSON lint checks
     needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -491,7 +491,7 @@ jobs:
 
   workflow-validation:
     if: needs.changes.outputs.gha == 'true'
-    name: GitHub Actions file validation
+    name: GitHub Actions validation
     needs: [changes, yaml-lint]
     # This uses a Mac runner because actionlint isn't available via Linux apt.
     runs-on: macos-14

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,11 @@
+# Summary: configuration for hadolint used in CI checks.
+# Info about options can be found at https://github.com/hadolint/hadolint/.
+
+format: tty
+no-color: false
+no-fail: false
+failure-threshold: error
+ignored:
+  - DL3025
+  - DL3047
+  - DL3059


### PR DESCRIPTION
This performs static checking on the (currently) two Dockerfiles in the OpenFermion repository for syntax validity and common best practices.