### PR TITLE
Make Dependabot not look at requirements/env

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: "pip"
     # OpenFermion has requirements.txt files in multiple places.
     directories:
-      - "/dev_tools/requirements/"
+      - "/dev_tools/requirements/deps"
       - "/docs/tutorials/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
It's generating PRs due to version changes in transitive dependencies. It seems to make more sense to make it pay attention only to requirements/deps/, and not also requirements/envs/.