### PR TITLE
Run OSV scan on PRs if requirements files are changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,9 @@ jobs:
       docker: ${{steps.filter.outputs.docker || steps.filter.outputs.ci}}
       docker_files: ${{steps.filter.outputs.docker_files}}
 
+      requirements: ${{steps.filter.outputs.requirements || steps.filter.outputs.ci}}
+      requirements_files: ${{steps.filter.outputs.requirements_files}}
+
       shell: ${{steps.filter.outputs.shell || steps.filter.outputs.ci}}
       shell_files: ${{steps.filter.outputs.shell_files}}
     steps:
@@ -163,6 +166,10 @@ jobs:
             docker:
               - '**/dockerfile'
               - '**/Dockerfile'
+            requirements:
+              - 'dev_tools/requirements/deps/*.txt'
+              - 'docs/**/*-requirements.txt'
+              - 'docs/**/requirements.txt'
             shell:
               - '**/*.sh'
               - 'check/*'
@@ -563,3 +570,12 @@ jobs:
 
       - name: Run shellcheck on shell scripts that have been changed
         run: shellcheck ${{env.changed_files}}
+
+  vulnerability-checks:
+    if: needs.changes.outputs.requirements == 'true'
+    name: Vulnerability checks
+    needs: changes
+    uses: ./.github/workflows/osv-scanner.yaml
+    permissions: write-all
+    with:
+      reason: CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,25 +84,25 @@ jobs:
     outputs:
       gha: ${{steps.filter.outputs.gha}}
       gha_files: ${{steps.filter.outputs.gha_files}}
+
       # The following all test both the relevant file condition & the CI config
       # because a change in the CI workflows can affect the CI check results.
-      python: |-
-        ${{steps.filter.outputs.python}} || ${{steps.filter.outputs.ci}}
+      python: ${{steps.filter.outputs.python || steps.filter.outputs.ci}}
       python_files: ${{steps.filter.outputs.python_files}}
-      yaml: |-
-        ${{steps.filter.outputs.yaml}} || ${{steps.filter.outputs.ci}}
+
+      yaml: ${{steps.filter.outputs.yaml || steps.filter.outputs.ci}}
       yaml_files: ${{steps.filter.outputs.yaml_files}}
-      cff: |-
-        ${{steps.filter.outputs.cff}} || ${{steps.filter.outputs.ci}}
+
+      cff: ${{steps.filter.outputs.cff || steps.filter.outputs.ci}}
       cff_files: ${{steps.filter.outputs.cff_files}}
-      json: |-
-        ${{steps.filter.outputs.json}} || ${{steps.filter.outputs.ci}}
+
+      json: ${{steps.filter.outputs.json || steps.filter.outputs.ci}}
       json_files: ${{steps.filter.outputs.json_files}}
-      docker: |-
-        ${{steps.filter.outputs.docker}} || ${{steps.filter.outputs.ci}}
+
+      docker: ${{steps.filter.outputs.docker || steps.filter.outputs.ci}}
       docker_files: ${{steps.filter.outputs.docker_files}}
-      shell: |-
-        ${{steps.filter.outputs.shell}} || ${{steps.filter.outputs.ci}}
+
+      shell: ${{steps.filter.outputs.shell || steps.filter.outputs.ci}}
       shell_files: ${{steps.filter.outputs.shell_files}}
     steps:
       # When invoked manually, use the given SHA to figure out the change list.
@@ -223,7 +223,7 @@ jobs:
         run: echo '::add-matcher::.github/problem-matchers/black.json'
 
       - name: Run format checks
-        run: check/format-incremental ${{inputs.sha}}
+        run: check/format-incremental
 
   python-mypy:
     if: needs.changes.outputs.python == 'true'
@@ -385,7 +385,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: Python compatibility checks
     needs: [changes, setup]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - name: Check out a copy of the git repository

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,5 +1,13 @@
 # Summary: run Open Source Vulnerabilities (OSV) code scan.
 #
+# The OSV project provides a GA workflow that you can reference as a step with
+# "uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml".
+# Unfortunately, that workflow inexplicably doesn't use the latest version of
+# the scanner and reporter workflows, and also does other things like hard-code
+# the value of the osv-scanner "--gh-annotations" option to "false". Using the
+# separate actions directly allows us to adjust the options and use Dependabot
+# to update the workflow versions as new ones are introduced.
+#
 # For more examples and options, including how to ignore specific
 # vulnerabilities, see https://google.github.io/osv-scanner/github-action/.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run OSV analysis
+      - name: Run OSV scanner
         # yamllint disable rule:line-length
         uses: google/osv-scanner-action/osv-scanner-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
         continue-on-error: true
@@ -52,10 +60,9 @@ jobs:
             --format=json
             --output=osv-results.json
             --recursive
-            --skip-git
             ./
 
-      - name: Run osv-scanner-reporter
+      - name: Run OSV reporter
         # yamllint disable rule:line-length
         uses: google/osv-scanner-action/osv-reporter-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
         with:

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@
    :width: 75%
    :align: center
 
-.. |ci| image:: https://img.shields.io/github/actions/workflow/status/quantumlib/openfermion/ci.yml?style=flat-square&logo=GitHub&label=Continous%20integration
+.. |ci| image:: https://img.shields.io/github/actions/workflow/status/quantumlib/openfermion/ci.yaml?style=flat-square&logo=GitHub&label=CI
    :alt: Continuous integration status badge
-   :target: https://github.com/quantumlib/OpenFermion/workflows/Continuous%20Integration/badge.svg
+   :target: https://github.com/quantumlib/OpenFermion/actions/workflows/ci.yaml
 
 .. |python| image:: https://img.shields.io/badge/Python-3.10+-fcbc2c.svg?style=flat-square&logo=python&logoColor=white
    :alt: Compatible with Python versions 3.10 and higher


### PR DESCRIPTION
The sample workflows for the OSV scanner make it run on every PR, but
that doesn't make sense to me; better would be to run it only if a
requirements file is changed in a PR. So, that's what this does.