### PR TITLE
Don't use --include-git-root option with osv-scanner

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -88,7 +88,6 @@ jobs:
           scan-args: |-
             --format=json
             --output=old-results.json
-            --include-git-root
             --recursive
             ./
 
@@ -106,7 +105,6 @@ jobs:
           scan-args: |-
             --format=json
             --output=new-results.json
-            --include-git-root
             --recursive
             ./
 


### PR DESCRIPTION
The documentation wasn't clear on this; it makes it scan .git/, which seems unnecessary for us.