### PR TITLE
Silence asyncio_default_fixture_loop_scope warnings

### DIFF
--- a/dev_tools/conf/pytest.ini
+++ b/dev_tools/conf/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+
+# Silence deprecation warnings about option "asyncio_default_fixture_loop_scope"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION

They're deprecation warnings that are harmless currently.