### PR TITLE
Add workflow to trim Dependabot PR message bodies

### DIFF
--- a/.github/workflows/dependabot-pr-trimmer.yaml
+++ b/.github/workflows/dependabot-pr-trimmer.yaml
@@ -17,7 +17,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 name: Dependabot PR trimmer
-run-name: Filter message body of PR #
+run-name: Filter message body of PR ${{github.event.pull_request.number}}
 
 on:
   pull_request:
@@ -29,10 +29,15 @@ on:
         type: string
         required: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
-  setup:
+  filter-message:
+    name: Filter PR message body
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions: write-all
     steps:
       - if: >-
           github.event.pull_request.user.login == 'dependabot[bot]' ||

--- a/.github/workflows/dependabot-pr-trimmer.yaml
+++ b/.github/workflows/dependabot-pr-trimmer.yaml
@@ -1,0 +1,45 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Remove bloat from Dependabot's PR messages
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Dependabot PR trimmer
+run-name: Filter message body of PR #
+
+on:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'The PR number of the PR to edit:'
+        type: string
+        required: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event_name == 'workflow_dispatch'
+        env:
+          pr-number: ${{inputs.pr-number || github.event.pull_request.number}}
+        run: |
+          gh pr view ${{env.pr-number}} --json body --jq .body |\
+            sed '/(dependabot-automerge-end)/,/<\/details>/d' |\
+            gh pr edit ${{env.pr-number}} --body-file -


### PR DESCRIPTION

Remove the command summary, because when using merge queues the
resulting commit messages are overly bloated.