### PR TITLE
Use pull_request type enqueued for pr trimmer workflow

### DIFF
--- a/.github/workflows/dependabot-pr-trimmer.yaml
+++ b/.github/workflows/dependabot-pr-trimmer.yaml
@@ -20,9 +20,9 @@ name: Dependabot PR trimmer
 run-name: Filter message body of PR ${{github.event.pull_request.number}}
 
 on:
-  merge_group:
+  pull_request:
     types:
-      - checks_requested
+      - enqueued
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION

This should be better than using the merge_queue trigger. In the latter
case, the environment isn't the same; e.g., the pull request number does
not have a value (because it's not actually a pull request at that point).