### PR TITLE
Partly fix #1008 and #1024: update dependencies and environment files for NumPy 2

### DIFF
--- a/dev_tools/requirements/deps/oldest-versions.txt
+++ b/dev_tools/requirements/deps/oldest-versions.txt
@@ -1,3 +1,3 @@
 # Used as a constraint file for pytest-max-compat
-cirq-core~=1.0.0
-cirq-google~=1.0.0
+cirq-core~=1.4.1
+cirq-google~=1.4.1

--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -1,8 +1,8 @@
-cirq-core
+cirq-core>=1.5
 deprecation
 h5py>=3.10.0
 networkx
-numpy>=1.24,<2.0
+numpy>=2.0
 pubchempy
 requests~=2.32.2
 

--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -1,8 +1,8 @@
-cirq-core>=1.5
+cirq-core>=1.4.1
 deprecation
 h5py>=3.10.0
 networkx
-numpy>=2.0
+numpy>=1.26
 pubchempy
 requests~=2.32.2
 

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -6,7 +6,7 @@
 #
 ase==3.24.0
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
 astroid==3.3.8
     # via pylint
@@ -61,11 +61,11 @@ isort==6.0.0
     # via pylint
 jax==0.4.38
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
     #   jax
 jsonschema==4.23.0
@@ -96,7 +96,7 @@ mypy-extensions==1.0.0
     #   mypy
 nbformat==5.10.4
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 networkx==3.4.2
     # via
@@ -156,26 +156,26 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pyscf==2.8.0
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
 pytest==8.3.4
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.25.3
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 pytest-cov==6.0.0
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 pytest-xdist==3.6.1
     # via
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -5,7 +5,9 @@
 #    pip-compile --output-file=envs/dev.env.txt deps/format.txt deps/mypy.txt deps/pip-tools.txt deps/pylint.txt deps/pytest.txt deps/resource_estimates_runtime.txt deps/runtime.txt
 #
 ase==3.24.0
-    # via -r deps/resource_estimates_runtime.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 astroid==3.3.8
     # via pylint
 attrs==25.1.0
@@ -21,7 +23,7 @@ certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via -r deps/runtime.txt
 click==8.1.8
     # via
@@ -58,9 +60,12 @@ iniconfig==2.0.0
 isort==6.0.0
     # via pylint
 jax==0.4.38
-    # via -r deps/resource_estimates_runtime.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
     #   jax
 jsonschema==4.23.0
@@ -90,12 +95,14 @@ mypy-extensions==1.0.0
     #   black
     #   mypy
 nbformat==5.10.4
-    # via -r deps/pytest.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 networkx==3.4.2
     # via
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -148,19 +155,28 @@ pyproject-hooks==1.2.0
     #   build
     #   pip-tools
 pyscf==2.8.0
-    # via -r deps/resource_estimates_runtime.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 pytest==8.3.4
     # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.25.3
-    # via -r deps/pytest.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 pytest-cov==6.0.0
-    # via -r deps/pytest.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 pytest-xdist==3.6.1
-    # via -r deps/pytest.txt
+    # via
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -62,10 +62,8 @@ isort==6.0.0
 jax==0.4.38
     # via
     #   -r deps/resource_estimates_runtime.txt
-    #   -r deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
-    #   -r deps/resource_estimates_runtime.txt
     #   -r deps/resource_estimates_runtime.txt
     #   jax
 jsonschema==4.23.0
@@ -96,7 +94,6 @@ mypy-extensions==1.0.0
     #   mypy
 nbformat==5.10.4
     # via
-    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 networkx==3.4.2
     # via
@@ -157,10 +154,8 @@ pyproject-hooks==1.2.0
 pyscf==2.8.0
     # via
     #   -r deps/resource_estimates_runtime.txt
-    #   -r deps/resource_estimates_runtime.txt
 pytest==8.3.4
     # via
-    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
@@ -168,14 +163,11 @@ pytest==8.3.4
 pytest-asyncio==0.25.3
     # via
     #   -r deps/pytest.txt
-    #   -r deps/pytest.txt
 pytest-cov==6.0.0
     # via
     #   -r deps/pytest.txt
-    #   -r deps/pytest.txt
 pytest-xdist==3.6.1
     # via
-    #   -r deps/pytest.txt
     #   -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -4,13 +4,11 @@
 #
 #    pip-compile --output-file=envs/dev.env.txt deps/format.txt deps/mypy.txt deps/pip-tools.txt deps/pylint.txt deps/pytest.txt deps/resource_estimates_runtime.txt deps/runtime.txt
 #
-ase==3.24.0
-    # via
-    #   -r deps/resource_estimates_runtime.txt
-    #   -r deps/resource_estimates_runtime.txt
-astroid==3.3.8
+ase==3.25.0
+    # via -r deps/resource_estimates_runtime.txt
+astroid==3.3.10
     # via pylint
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   cirq-core
     #   jsonschema
@@ -19,62 +17,61 @@ black==25.1.0
     # via -r deps/format.txt
 build==1.2.2.post1
     # via pip-tools
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 cirq-core==1.5.0
     # via -r deps/runtime.txt
-click==8.1.8
+click==8.2.1
     # via
     #   black
     #   pip-tools
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
 deprecation==2.1.0
     # via -r deps/runtime.txt
-dill==0.3.9
+dill==0.4.0
     # via pylint
 duet==0.2.9
     # via cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -r deps/runtime.txt
     #   pyscf
 idna==3.10
     # via requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-isort==6.0.0
+isort==6.0.1
     # via pylint
 jax==0.4.38
-    # via
-    #   -r deps/resource_estimates_runtime.txt
+    # via -r deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
     #   -r deps/resource_estimates_runtime.txt
     #   jax
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via nbformat
 kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   ase
     #   cirq-core
@@ -86,15 +83,14 @@ ml-dtypes==0.5.1
     #   jaxlib
 mpmath==1.3.0
     # via sympy
-mypy==1.14.1
+mypy==1.16.0
     # via -r deps/mypy.txt
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
 nbformat==5.10.4
-    # via
-    #   -r deps/pytest.txt
+    # via -r deps/pytest.txt
 networkx==3.4.2
     # via
     #   -r deps/runtime.txt
@@ -117,7 +113,7 @@ numpy==2.2.6
     #   types-networkx
 opt-einsum==3.4.0
     # via jax
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -126,54 +122,54 @@ packaging==24.2
     #   pytest
 pandas==2.2.3
     # via cirq-core
-pandas-stubs==2.2.3.241126
+pandas-stubs==2.2.3.250527
     # via -r deps/mypy.txt
 pathspec==0.12.1
-    # via black
-pillow==11.1.0
+    # via
+    #   black
+    #   mypy
+pillow==11.2.1
     # via matplotlib
 pip-tools==7.4.1
     # via -r deps/pip-tools.txt
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   black
     #   jupyter-core
     #   pylint
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pubchempy==1.0.4
     # via -r deps/runtime.txt
-pylint==3.3.4
+pygments==2.19.1
+    # via pytest
+pylint==3.3.7
     # via -r deps/pylint.txt
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via matplotlib
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyscf==2.8.0
-    # via
-    #   -r deps/resource_estimates_runtime.txt
-pytest==8.3.4
+pyscf==2.9.0
+    # via -r deps/resource_estimates_runtime.txt
+pytest==8.4.0
     # via
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
-    # via
-    #   -r deps/pytest.txt
-pytest-cov==6.0.0
-    # via
-    #   -r deps/pytest.txt
-pytest-xdist==3.6.1
-    # via
-    #   -r deps/pytest.txt
+pytest-asyncio==1.0.0
+    # via -r deps/pytest.txt
+pytest-cov==6.1.1
+    # via -r deps/pytest.txt
+pytest-xdist==3.7.0
+    # via -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via pandas
 referencing==0.36.2
     # via
@@ -181,11 +177,11 @@ referencing==0.36.2
     #   jsonschema-specifications
 requests==2.32.3
     # via -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -197,7 +193,7 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -218,24 +214,25 @@ traitlets==5.14.3
     # via
     #   jupyter-core
     #   nbformat
-types-networkx==3.4.2.20241227
+types-networkx==3.5.0.20250531
     # via -r deps/mypy.txt
-types-pytz==2025.1.0.20250204
+types-pytz==2025.2.0.20250516
     # via pandas-stubs
-types-requests==2.32.0.20241016
+types-requests==2.32.0.20250602
     # via -r deps/mypy.txt
-types-setuptools==75.8.0.20250110
+types-setuptools==80.9.0.20250529
     # via -r deps/mypy.txt
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   astroid
     #   black
     #   cirq-core
+    #   exceptiongroup
     #   mypy
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   requests
     #   types-requests

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/format.env.txt deps/format.txt deps/runtime.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -12,11 +12,11 @@ black==25.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c envs/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -24,11 +24,11 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-click==8.1.8
+click==8.2.1
     # via
     #   -c envs/dev.env.txt
     #   black
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -44,11 +44,11 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -60,7 +60,7 @@ kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -68,7 +68,7 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -87,7 +87,7 @@ numpy==2.2.6
     #   matplotlib
     #   pandas
     #   scipy
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -101,11 +101,11 @@ pathspec==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -113,7 +113,7 @@ pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -122,7 +122,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -130,7 +130,7 @@ requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -143,7 +143,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -156,16 +156,16 @@ tqdm==4.67.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c envs/dev.env.txt
     #   black
     #   cirq-core
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -77,7 +77,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/mypy.env.txt deps/mypy.txt deps/runtime.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c envs/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -20,7 +20,7 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -36,11 +36,11 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -52,7 +52,7 @@ kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -60,11 +60,11 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-mypy==1.14.1
+mypy==1.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   -c envs/dev.env.txt
     #   mypy
@@ -85,7 +85,7 @@ numpy==2.2.6
     #   pandas-stubs
     #   scipy
     #   types-networkx
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -94,11 +94,15 @@ pandas==2.2.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandas-stubs==2.2.3.241126
+pandas-stubs==2.2.3.250527
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-pillow==11.1.0
+pathspec==0.12.1
+    # via
+    #   -c envs/dev.env.txt
+    #   mypy
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -106,7 +110,7 @@ pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -115,7 +119,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -123,7 +127,7 @@ requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -136,7 +140,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -149,32 +153,32 @@ tqdm==4.67.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-types-networkx==3.4.2.20241227
+types-networkx==3.5.0.20250531
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-pytz==2025.1.0.20250204
+types-pytz==2025.2.0.20250516
     # via
     #   -c envs/dev.env.txt
     #   pandas-stubs
-types-requests==2.32.0.20241016
+types-requests==2.32.0.20250602
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-setuptools==75.8.0.20250110
+types-setuptools==80.9.0.20250529
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   mypy
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -73,7 +73,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -8,11 +8,11 @@ build==1.2.2.post1
     # via
     #   -c envs/dev.env.txt
     #   pip-tools
-click==8.1.8
+click==8.2.1
     # via
     #   -c envs/dev.env.txt
     #   pip-tools
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   build

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -7,7 +7,7 @@
 ase==3.24.0
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 astroid==3.3.8
     # via
     #   -c envs/dev.env.txt
@@ -90,11 +90,11 @@ isort==6.0.0
 jax==0.4.38
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
     #   jax
 jsonschema==4.23.0
     # via
@@ -133,7 +133,7 @@ mpmath==1.3.0
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 networkx==3.4.2
     # via
     #   -c envs/dev.env.txt
@@ -196,26 +196,26 @@ pyparsing==3.2.1
 pyscf==2.8.0
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
+    #   -r deps/resource_estimates_runtime.txt
 pytest==8.3.4
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.25.3
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 pytest-cov==6.0.0
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 pytest-xdist==3.6.1
     # via
     #   -c envs/dev.env.txt
-    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
+    #   -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pylint.env.txt deps/pylint.txt deps/runtime.txt
 #
-ase==3.24.0
+ase==3.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-astroid==3.3.8
+astroid==3.3.10
     # via
     #   -c envs/dev.env.txt
     #   pylint
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   jsonschema
     #   referencing
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c envs/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -30,11 +30,11 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -46,7 +46,7 @@ deprecation==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dill==0.3.9
+dill==0.4.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -54,7 +54,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -66,11 +66,11 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -79,11 +79,11 @@ idna==3.10
     # via
     #   -c envs/dev.env.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-isort==6.0.0
+isort==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -96,15 +96,15 @@ jaxlib==0.4.38
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
     #   jax
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -112,7 +112,7 @@ kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -158,7 +158,7 @@ opt-einsum==3.4.0
     # via
     #   -c envs/dev.env.txt
     #   jax
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -168,16 +168,16 @@ pandas==2.2.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   pylint
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -185,34 +185,38 @@ pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pylint==3.3.4
+pygments==2.19.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pytest
+pylint==3.3.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-pyscf==2.8.0
+pyscf==2.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-pytest==8.3.4
+pytest==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -221,7 +225,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -234,12 +238,12 @@ requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -256,7 +260,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -280,17 +284,18 @@ traitlets==5.14.3
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
     #   cirq-core
+    #   exceptiongroup
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -7,7 +7,7 @@
 ase==3.24.0
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/resource_estimates_runtime.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
 astroid==3.3.8
     # via
     #   -c envs/dev.env.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -90,11 +90,11 @@ isort==6.0.0
 jax==0.4.38
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/resource_estimates_runtime.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
 jaxlib==0.4.38
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/resource_estimates_runtime.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
     #   jax
 jsonschema==4.23.0
     # via
@@ -133,13 +133,13 @@ mpmath==1.3.0
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/pytest.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
 networkx==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -196,26 +196,26 @@ pyparsing==3.2.1
 pyscf==2.8.0
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/resource_estimates_runtime.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/resource_estimates_runtime.txt
 pytest==8.3.4
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/pytest.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.25.3
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/pytest.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
 pytest-cov==6.0.0
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/pytest.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
 pytest-xdist==3.6.1
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/pytest.txt
+    #   -r /Users/mhucka/project-files/google/github/openfermion/dev_tools/requirements/deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest-extra.env.txt deps/pytest.txt deps/resource_estimates_runtime.txt deps/runtime.txt
 #
-ase==3.24.0
+ase==3.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   jsonschema
     #   referencing
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c envs/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -26,11 +26,11 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -46,7 +46,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -58,11 +58,11 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -71,7 +71,7 @@ idna==3.10
     # via
     #   -c envs/dev.env.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -84,15 +84,15 @@ jaxlib==0.4.38
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
     #   jax
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -100,7 +100,7 @@ kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -142,7 +142,7 @@ opt-einsum==3.4.0
     # via
     #   -c envs/dev.env.txt
     #   jax
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -152,15 +152,15 @@ pandas==2.2.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -168,30 +168,34 @@ pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pyparsing==3.2.1
+pygments==2.19.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pytest
+pyparsing==3.2.3
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-pyscf==2.8.0
+pyscf==2.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/resource_estimates_runtime.txt
-pytest==8.3.4
+pytest==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -200,7 +204,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -213,12 +217,12 @@ requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -235,7 +239,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -254,16 +258,17 @@ traitlets==5.14.3
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
+    #   exceptiongroup
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -123,7 +123,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.1
+cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -103,7 +103,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-numpy==1.26.4
+numpy==2.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   jsonschema
     #   referencing
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c envs/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -22,11 +22,11 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -42,7 +42,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -54,11 +54,11 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -66,19 +66,19 @@ idna==3.10
     # via
     #   -c envs/dev.env.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -86,7 +86,7 @@ kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -113,7 +113,7 @@ numpy==2.2.6
     #   matplotlib
     #   pandas
     #   scipy
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -123,15 +123,15 @@ pandas==2.2.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -139,26 +139,30 @@ pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pyparsing==3.2.1
+pygments==2.19.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pytest
+pyparsing==3.2.3
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-pytest==8.3.4
+pytest==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -167,7 +171,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -180,12 +184,12 @@ requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -198,7 +202,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -217,16 +221,17 @@ traitlets==5.14.3
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
+    #   exceptiongroup
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/max_compat/dev.env.txt
+++ b/dev_tools/requirements/max_compat/dev.env.txt
@@ -4,21 +4,22 @@
 #
 #    pip-compile --constraint=deps/oldest-versions.txt --output-file=max_compat/dev.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
+    #   cirq-core
     #   jsonschema
     #   referencing
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-cirq-core==1.0.0
+cirq-core==1.4.1
     # via
     #   -c deps/oldest-versions.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,35 +27,35 @@ deprecation==2.1.0
     # via -r deps/runtime.txt
 duet==0.2.9
     # via cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via -r deps/runtime.txt
 idna==3.10
     # via requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via nbformat
 kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via cirq-core
 mpmath==1.3.0
     # via sympy
 nbformat==5.10.4
     # via -r deps/pytest.txt
-networkx==2.8.8
+networkx==3.4.2
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -67,40 +68,42 @@ numpy==1.26.4
     #   matplotlib
     #   pandas
     #   scipy
-packaging==24.2
+packaging==25.0
     # via
     #   deprecation
     #   matplotlib
     #   pytest
 pandas==2.2.3
     # via cirq-core
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via jupyter-core
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pubchempy==1.0.4
     # via -r deps/runtime.txt
-pyparsing==3.2.1
+pygments==2.19.1
+    # via pytest
+pyparsing==3.2.3
     # via matplotlib
-pytest==8.3.4
+pytest==8.4.0
     # via
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==1.0.0
     # via -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r deps/pytest.txt
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via pandas
 referencing==0.36.2
     # via
@@ -108,11 +111,11 @@ referencing==0.36.2
     #   jsonschema-specifications
 requests==2.32.3
     # via -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -120,7 +123,7 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -134,11 +137,12 @@ traitlets==5.14.3
     # via
     #   jupyter-core
     #   nbformat
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   cirq-core
+    #   exceptiongroup
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests

--- a/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
+++ b/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
@@ -4,29 +4,30 @@
 #
 #    pip-compile --constraint=deps/oldest-versions.txt --constraint=max_compat/dev.env.txt --output-file=max_compat/pytest-max-compat.env.txt deps/pytest.txt deps/runtime.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c max_compat/dev.env.txt
+    #   cirq-core
     #   jsonschema
     #   referencing
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c max_compat/dev.env.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c max_compat/dev.env.txt
     #   requests
-cirq-core==1.0.0
+cirq-core==1.4.1
     # via
     #   -c deps/oldest-versions.txt
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.8.2
     # via
     #   -c max_compat/dev.env.txt
     #   pytest-cov
@@ -42,7 +43,7 @@ duet==0.2.9
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest
@@ -54,11 +55,11 @@ fastjsonschema==2.21.1
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
-fonttools==4.55.8
+fonttools==4.58.1
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-h5py==3.12.1
+h5py==3.13.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -66,19 +67,19 @@ idna==3.10
     # via
     #   -c max_compat/dev.env.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
@@ -86,7 +87,7 @@ kiwisolver==1.4.8
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-matplotlib==3.10.0
+matplotlib==3.10.3
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
@@ -98,7 +99,7 @@ nbformat==5.10.4
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
-networkx==2.8.8
+networkx==3.4.2
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -113,7 +114,7 @@ numpy==1.26.4
     #   matplotlib
     #   pandas
     #   scipy
-packaging==24.2
+packaging==25.0
     # via
     #   -c max_compat/dev.env.txt
     #   deprecation
@@ -123,15 +124,15 @@ pandas==2.2.3
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -c max_compat/dev.env.txt
     #   jupyter-core
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest
@@ -139,26 +140,30 @@ pubchempy==1.0.4
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-pyparsing==3.2.1
+pygments==2.19.1
+    # via
+    #   -c max_compat/dev.env.txt
+    #   pytest
+pyparsing==3.2.3
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-pytest==8.3.4
+pytest==8.4.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==1.0.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt
@@ -167,7 +172,7 @@ python-dateutil==2.9.0.post0
     #   -c max_compat/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
@@ -180,12 +185,12 @@ requests==2.32.3
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-rpds-py==0.22.3
+rpds-py==0.25.1
     # via
     #   -c max_compat/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.15.1
+scipy==1.15.3
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -198,7 +203,7 @@ sortedcontainers==2.4.0
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -217,16 +222,17 @@ traitlets==5.14.3
     #   -c max_compat/dev.env.txt
     #   jupyter-core
     #   nbformat
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
+    #   exceptiongroup
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c max_compat/dev.env.txt
     #   requests


### PR DESCRIPTION
This updates the minimum version of NumPy to 2, and cirq-core to 1.5 (the latter is needed to support NumPy 2).