### PR TITLE
Set a fixed random seed during testing

### DIFF
--- a/src/openfermion/conftest.py
+++ b/src/openfermion/conftest.py
@@ -11,9 +11,9 @@
 #   limitations under the License.
 
 import os
+import random
 import pytest
 import numpy as np
-import random
 
 
 def pytest_configure(config):

--- a/src/openfermion/conftest.py
+++ b/src/openfermion/conftest.py
@@ -9,9 +9,20 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
 import os
+import pytest
+import numpy as np
+import random
 
 
 def pytest_configure(config):
     # fail tests when using deprecated cirq functionality
     os.environ['CIRQ_TESTING'] = "true"
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    """Set a fixed random seed when testing."""
+    random.seed(0)
+    np.random.seed(0)


### PR DESCRIPTION
Some of the tests became more flaky with the move to NumPy 2. In all cases, random numbers were involved at some point. Setting a fixed random seed made the tests reproducible and (so far) seems to have stopped the flakiness.