### PR TITLE
Fix #926: remove self-assignment

### DIFF
--- a/src/openfermion/resource_estimates/pbc/hamiltonian/cc_extensions.py
+++ b/src/openfermion/resource_estimates/pbc/hamiltonian/cc_extensions.py
@@ -69,7 +69,6 @@ def build_approximate_eris(krcc_inst, eri_helper, eris=None):
         eri_kpt = eri_helper.get_eri(kpts) / nkpts
         if dtype == float:
             eri_kpt = eri_kpt.real
-        eri_kpt = eri_kpt
         for kp, kq, kr in khelper.symm_map[(ikp, ikq, ikr)]:
             eri_kpt_symm = khelper.transform_symm(eri_kpt, kp, kq, kr).transpose(0, 2, 1, 3)
             out_eris.oooo[kp, kr, kq] = eri_kpt_symm[:nocc, :nocc, :nocc, :nocc]


### PR DESCRIPTION
On line 72, the variable eri_kpt is assigned to itself. It's not clear what it should be instead – either something is missing on the RHS or else it's just a pointless assignment.

```python
if dtype == float:
    eri_kpt = eri_kpt.real
eri_kpt = eri_kpt
```

Resolves issue #926.