### PR TITLE
Fix #1062: ignore warning from a Cirq function about Qiskit

### DIFF
--- a/dev_tools/conf/pytest.ini
+++ b/dev_tools/conf/pytest.ini
@@ -4,3 +4,6 @@ markers =
 
 # Silence deprecation warnings about option "asyncio_default_fixture_loop_scope"
 asyncio_default_fixture_loop_scope = "function"
+
+filterwarnings =
+    ignore:Skipped assert_qasm_is_consistent_with_unitary because qiskit.*:UserWarning


### PR DESCRIPTION
The code in `src/openfermion/testing/wrapped.py` calls `cirq.testing.assert_implements_consistent_protocols`. The latter funtion prints warnings about the Cirq function
`assert_qasm_is_consistent_with_unitary` when Qiskit is not installed. This is irrelevant to testing OpenFermion; it doesn't do anything with QASM and we certainly don't want to introduce a dependency on Qiskit.

Resolves issue #1062.