### PR TITLE
Fix #1064: replace calls to deprecated method `orbital_energies`

### DIFF
--- a/src/openfermion/circuits/slater_determinants.py
+++ b/src/openfermion/circuits/slater_determinants.py
@@ -103,11 +103,9 @@ def gaussian_state_preparation_circuit(
     if not isinstance(quadratic_hamiltonian, QuadraticHamiltonian):
         raise ValueError('Input must be an instance of QuadraticHamiltonian.')
 
-    (
-        orbital_energies,
-        transformation_matrix,
-        _,
-    ) = quadratic_hamiltonian.diagonalizing_bogoliubov_transform(spin_sector=spin_sector)
+    (orbital_energies, transformation_matrix, _) = (
+        quadratic_hamiltonian.diagonalizing_bogoliubov_transform(spin_sector=spin_sector)
+    )
 
     if quadratic_hamiltonian.conserves_particle_number:
         if occupied_orbitals is None:
@@ -221,7 +219,7 @@ def jw_get_gaussian_state(quadratic_hamiltonian, occupied_orbitals=None):
     n_qubits = quadratic_hamiltonian.n_qubits
 
     # Compute the energy
-    orbital_energies, constant = quadratic_hamiltonian.orbital_energies()
+    orbital_energies, _, constant = quadratic_hamiltonian.diagonalizing_bogoliubov_transform()
     if occupied_orbitals is None:
         # The ground energy is desired
         if quadratic_hamiltonian.conserves_particle_number:

--- a/src/openfermion/circuits/slater_determinants_test.py
+++ b/src/openfermion/circuits/slater_determinants_test.py
@@ -198,7 +198,9 @@ class JWGetGaussianStateTest(unittest.TestCase):
             )
 
             # Compute the true energy
-            orbital_energies, constant = quadratic_hamiltonian.orbital_energies()
+            orbital_energies, _, constant = (
+                quadratic_hamiltonian.diagonalizing_bogoliubov_transform()
+            )
             energy = numpy.sum(orbital_energies[occupied_orbitals]) + constant
 
             # Check that the energies match
@@ -228,7 +230,9 @@ class JWGetGaussianStateTest(unittest.TestCase):
             )
 
             # Compute the true energy
-            orbital_energies, constant = quadratic_hamiltonian.orbital_energies()
+            orbital_energies, _, constant = (
+                quadratic_hamiltonian.diagonalizing_bogoliubov_transform()
+            )
             energy = numpy.sum(orbital_energies[occupied_orbitals]) + constant
 
             # Check that the energies match

--- a/src/openfermion/ops/representations/polynomial_tensor_test.py
+++ b/src/openfermion/ops/representations/polynomial_tensor_test.py
@@ -488,7 +488,7 @@ class PolynomialTensorTest(unittest.TestCase):
         # Initialize a particle-number-conserving quadratic Hamiltonian
         # and compute its orbital energies
         quad_ham = random_quadratic_hamiltonian(n_qubits, True, real=real)
-        orbital_energies, constant = quad_ham.orbital_energies()
+        orbital_energies, _, constant = quad_ham.diagonalizing_bogoliubov_transform()
 
         # Rotate a basis where the Hamiltonian is diagonal
         _, diagonalizing_unitary, _ = quad_ham.diagonalizing_bogoliubov_transform()
@@ -504,7 +504,8 @@ class PolynomialTensorTest(unittest.TestCase):
         self.assertTrue(quad_ham.conserves_particle_number)
 
         # Check that the orbital energies and constant are the same
-        new_orbital_energies, new_constant = quad_ham.orbital_energies()
+        new_orbital_energies, _, new_constant = quad_ham.diagonalizing_bogoliubov_transform()
+
         self.assertTrue(numpy.allclose(orbital_energies, new_orbital_energies))
         self.assertAlmostEqual(constant, new_constant)
 

--- a/src/openfermion/ops/representations/quadratic_hamiltonian_test.py
+++ b/src/openfermion/ops/representations/quadratic_hamiltonian_test.py
@@ -121,13 +121,15 @@ class QuadraticHamiltonianTest(unittest.TestCase):
     def test_orbital_energies(self):
         """Test getting the orbital energies."""
         # Test the particle-number-conserving case
-        orbital_energies, constant = self.quad_ham_pc.orbital_energies()
+        orbital_energies, _, constant = self.quad_ham_pc.diagonalizing_bogoliubov_transform()
+
         # Test the ground energy
         energy = numpy.sum(orbital_energies[orbital_energies < 0.0]) + constant
         self.assertAlmostEqual(energy, self.pc_ground_energy)
 
         # Test the non-particle-number-conserving case
-        orbital_energies, constant = self.quad_ham_npc.orbital_energies()
+        orbital_energies, _, constant = self.quad_ham_npc.diagonalizing_bogoliubov_transform()
+
         # Test the ground energy
         energy = constant
         self.assertAlmostEqual(energy, self.npc_ground_energy)
@@ -265,11 +267,9 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         quad_ham = get_quadratic_hamiltonian(reorder(get_fermion_operator(quad_ham), up_then_down))
 
         for spin_sector in range(2):
-            (
-                orbital_energies,
-                transformation_matrix,
-                _,
-            ) = quad_ham.diagonalizing_bogoliubov_transform(spin_sector=spin_sector)
+            (orbital_energies, transformation_matrix, _) = (
+                quad_ham.diagonalizing_bogoliubov_transform(spin_sector=spin_sector)
+            )
 
             def index_map(i):
                 return i + spin_sector * 5
@@ -286,7 +286,7 @@ class QuadraticHamiltonianTest(unittest.TestCase):
         quad_ham = random_quadratic_hamiltonian(
             5, conserves_particle_number=True, expand_spin=False
         )
-        orbital_energies, _ = quad_ham.orbital_energies()
+        orbital_energies, _, _ = quad_ham.diagonalizing_bogoliubov_transform()
 
         _, transformation_matrix, _ = quad_ham.diagonalizing_bogoliubov_transform()
         numpy.testing.assert_allclose(
@@ -337,7 +337,9 @@ class DiagonalizingCircuitTest(unittest.TestCase):
             numpy.testing.assert_allclose(discrepancy, 0.0, atol=1e-7)
 
             # Check that the eigenvalues are in the expected order
-            orbital_energies, constant = quadratic_hamiltonian.orbital_energies()
+            orbital_energies, _, constant = (
+                quadratic_hamiltonian.diagonalizing_bogoliubov_transform()
+            )
             for index in range(2**n_qubits):
                 bitstring = bin(index)[2:].zfill(n_qubits)
                 subset = [j for j in range(n_qubits) if bitstring[j] == '1']
@@ -374,7 +376,9 @@ class DiagonalizingCircuitTest(unittest.TestCase):
             numpy.testing.assert_allclose(discrepancy, 0.0, atol=1e-7)
 
             # Check that the eigenvalues are in the expected order
-            orbital_energies, constant = quadratic_hamiltonian.orbital_energies()
+            orbital_energies, _, constant = (
+                quadratic_hamiltonian.diagonalizing_bogoliubov_transform()
+            )
             for index in range(2**n_qubits):
                 bitstring = bin(index)[2:].zfill(n_qubits)
                 subset = [j for j in range(n_qubits) if bitstring[j] == '1']


### PR DESCRIPTION
Method `orbital_energies` in is deprecated in file `quadratic_determinants.py`; its replacement is method `diagonalizing_bogoliubov_transform`.