### PR TITLE
Fix Python 3.12 deprecation warning about os.fork()

### DIFF
--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -144,6 +144,8 @@ class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
 class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):
     """A LinearOperator from a QubitOperator with multiple processors."""
 
+    _start_method_set = False
+
     def __init__(self, qubit_operator, n_qubits=None, options=None):
         """
         Args:
@@ -161,6 +163,10 @@ class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):
         self.qubit_operator = qubit_operator
         self.n_qubits = n_qubits
         self.options = options or LinearQubitOperatorOptions()
+
+        if not ParallelLinearQubitOperator._start_method_set:
+            multiprocessing.set_start_method('forkserver', force=True)
+            ParallelLinearQubitOperator._start_method_set = True
 
         self.qubit_operator_groups = list(
             qubit_operator.get_operator_groups(self.options.processes)


### PR DESCRIPTION
In Python 3.12, on Linux at least, `src/openfermion/testing/performance_benchmarks_test.py` produces the following warnings:

```
~/.pyenv/versions/3.12.5/lib/python3.12/multiprocessing/popen_fork.py:66: RuntimeWarning:
os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is
multithreaded, so this will likely lead to a deadlock.
self.pid = os.fork()
src/openfermion/testing/performance_benchmarks_test.py::test_run_linear_qop
src/openfermion/testing/performance_benchmarks_test.py::test_run_linear_qop
src/openfermion/testing/performance_benchmarks_test.py::test_run_linear_qop
src/openfermion/testing/performance_benchmarks_test.py::test_run_linear_qop
src/openfermion/testing/performance_benchmarks_test.py::test_run_linear_qop
~/.pyenv/versions/3.12.5/lib/python3.12/multiprocessing/popen_fork.py:66: 
DeprecationWarning: This process (pid=3069778) is multi-threaded, use of fork() 
may lead to deadlocks in the child. self.pid = os.fork()
```

This can be resolved by calling `multiprocessing.set_start_method()` in `__init__` of the  `ParallelLinearQuibitOperator` class.
