### PR TITLE
Fix warning about asyncio.get_event_loop() in Python 3.12

### DIFF
--- a/dev_tools/shell_tools.py
+++ b/dev_tools/shell_tools.py
@@ -15,24 +15,13 @@
 import asyncio
 import subprocess
 import sys
-from typing import (
-    List,
-    Optional,
-    Tuple,
-    Union,
-    IO,
-    Any,
-    cast,
-    NamedTuple,
-)
+from typing import List, Optional, Tuple, Union, IO, Any, cast, NamedTuple
 
 from collections.abc import AsyncIterable
 
-CommandOutput = NamedTuple("CommandOutput", [
-    ('out', Optional[str]),
-    ('err', Optional[str]),
-    ('exit_code', int),
-])
+CommandOutput = NamedTuple(
+    "CommandOutput", [('out', Optional[str]), ('err', Optional[str]), ('exit_code', int)]
+)
 
 BOLD = 1
 DIM = 2
@@ -52,11 +41,7 @@ def highlight(text: str, color_code: int, bold: bool = False) -> str:
     Returns:
         The highlighted string.
     """
-    return '{}\033[{}m{}\033[0m'.format(
-        '\033[1m' if bold else '',
-        color_code,
-        text,
-    )
+    return '{}\033[{}m{}\033[0m'.format('\033[1m' if bold else '', color_code, text)
 
 
 class TeeCapture:
@@ -70,9 +55,9 @@ class TeeCapture:
         self.out_pipe = out_pipe
 
 
-async def _async_forward(async_chunks: AsyncIterable,
-                         out: Optional[Union[TeeCapture, IO[str]]]
-                        ) -> Optional[str]:
+async def _async_forward(
+    async_chunks: AsyncIterable, out: Optional[Union[TeeCapture, IO[str]]]
+) -> Optional[str]:
     """Prints/captures output from the given asynchronous iterable.
 
     Args:
@@ -99,9 +84,9 @@ async def _async_forward(async_chunks: AsyncIterable,
 
 
 async def _async_wait_for_process(
-        future_process: Any,
-        out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
-        err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr
+    future_process: Any,
+    out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
+    err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
 ) -> CommandOutput:
     """Awaits the creation and completion of an asynchronous process.
 
@@ -122,8 +107,7 @@ async def _async_wait_for_process(
     return CommandOutput(output, err_output, process.returncode)
 
 
-def abbreviate_command_arguments_after_switches(cmd: Tuple[str, ...]
-                                               ) -> Tuple[str, ...]:
+def abbreviate_command_arguments_after_switches(cmd: Tuple[str, ...]) -> Tuple[str, ...]:
     result = [cmd[0]]
     for i in range(1, len(cmd)):
         if not cmd[i].startswith('-'):
@@ -133,13 +117,15 @@ def abbreviate_command_arguments_after_switches(cmd: Tuple[str, ...]
     return tuple(result)
 
 
-def run_cmd(*cmd: Optional[str],
-            out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
-            err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
-            raise_on_fail: bool = True,
-            log_run_to_stderr: bool = True,
-            abbreviate_non_option_arguments: bool = False,
-            **kwargs) -> CommandOutput:
+def run_cmd(
+    *cmd: Optional[str],
+    out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
+    err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
+    raise_on_fail: bool = True,
+    log_run_to_stderr: bool = True,
+    abbreviate_non_option_arguments: bool = False,
+    **kwargs,
+) -> CommandOutput:
     """Invokes a subprocess and waits for it to finish.
 
     Args:
@@ -212,12 +198,14 @@ def run_cmd(*cmd: Optional[str],
     return result
 
 
-def run_shell(cmd: str,
-              out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
-              err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
-              raise_on_fail: bool = True,
-              log_run_to_stderr: bool = True,
-              **kwargs) -> CommandOutput:
+def run_shell(
+    cmd: str,
+    out: Optional[Union[TeeCapture, IO[str]]] = sys.stdout,
+    err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
+    raise_on_fail: bool = True,
+    log_run_to_stderr: bool = True,
+    **kwargs,
+) -> CommandOutput:
     """Invokes a shell command and waits for it to finish.
 
     Args:
@@ -296,9 +284,7 @@ def output_of(*cmd: Optional[str], **kwargs) -> str:
          subprocess.CalledProcessError: The process returned a non-zero error
             code and raise_on_fail was set.
     """
-    result = cast(
-        str,
-        run_cmd(*cmd, log_run_to_stderr=False, out=TeeCapture(), **kwargs).out)
+    result = cast(str, run_cmd(*cmd, log_run_to_stderr=False, out=TeeCapture(), **kwargs).out)
 
     # Strip final newline.
     if result.endswith('\n'):


### PR DESCRIPTION
In Python 3.12, the code in `shell_tools.py` produces the following warnings when running `check/pytest`:

```
dev_tools/shell_tools_test.py::test_run_cmd_raise_on_fail
dev_tools/shell_tools.py:185:
DeprecationWarning: There is no current event loop
result = asyncio.get_event_loop().run_until_complete(
```

The fix involves managing the event loop. The updated functions now try to get the current running event loop; if no loop is running, they create a new one, use it, and then close it.

Note: commit [c3ab0fa](https://github.com/quantumlib/OpenFermion/pull/1071/commits/c3ab0fab591d02668647a5d9074b0118a9c4a19e) has the actual code changes. Commit [ba775f5](https://github.com/quantumlib/OpenFermion/pull/1071/commits/ba775f57d62870ed87edf5a48affcfbfbce82901) contains purely formatting changes from applying `check/format-incremental`.