### PR TITLE
Avoid division by zero in `adagrad`

### DIFF
--- a/src/openfermion/resource_estimates/thc/utils/adagrad.py
+++ b/src/openfermion/resource_estimates/thc/utils/adagrad.py
@@ -37,10 +37,12 @@ def adagrad(step_size, momentum=0.9):
         m = np.zeros_like(x0)
         return x0, g_sq, m
 
-    def update(i, g, state):
+    def update(i, g, state, eps=1e-9):
         x, g_sq, m = state
         g_sq += np.square(g)
-        g_sq_inv_sqrt = np.where(g_sq > 0, 1.0 / np.sqrt(g_sq), 0.0)
+        # Add a small number to avoid division by zero
+        g_sq_safe = g_sq + eps
+        g_sq_inv_sqrt = 1.0 / np.sqrt(g_sq_safe)
         m = (1.0 - momentum) * (g * g_sq_inv_sqrt) + momentum * m
         x = x - step_size(i) * m
         return x, g_sq, m


### PR DESCRIPTION
The `update` subfunction in `adagrad()` will produce division-by-zero errors. These occur when running `check/pytest` in Python 3.12 with NumPy 2.x:

```
src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax_test.py::test_kpoint_thc_helper
src/openfermion/resource_estimates/pbc/thc/generate_costing_table_thc_test.py::test_generate_costing_table_thc
  /usr/local/google/home/mhucka/project-files/google/github/openfermion/src/openfermion/resource_estimates/thc/utils/adagrad.py:43:
  RuntimeWarning: divide by zero encountered in divide
    g_sq_inv_sqrt = np.where(g_sq > 0, 1.0 / np.sqrt(g_sq), 0.0)
```

A common method to avoid this situation is to add a small positive number to `g_sq` before taking the square root. This ensures that the value is never exactly zero, avoiding the division-by-zero problem. This approach is a common and robust method for avoiding zero denominators in gradient-based optimization. It also acts as a smoothing factor, preventing the update from becoming unstable when `g_sq` gets very small.