### PR TITLE
Add a job to CI workflow to print debug info if any job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -634,12 +634,22 @@ jobs:
 
       - name: Dump GitHub context
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_CONTEXT: ${{toJson(github)}}
         shell: bash
         run: echo "$GITHUB_CONTEXT"
 
       - name: Dump runner context
         env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
+          RUNNER_CONTEXT: ${{toJson(runner)}}
         shell: bash
         run: echo "${RUNNER_CONTEXT}"
+
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{toJson(strategy)}}
+        run: echo "$STRATEGY_CONTEXT"
+
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{toJson(matrix)}}
+        run: echo "$MATRIX_CONTEXT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     name: (Python pytest matrix)
     needs: [changes, setup]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{matrix.os}}
     timeout-minutes: 15
     strategy:
       matrix:
@@ -643,13 +643,3 @@ jobs:
           RUNNER_CONTEXT: ${{toJson(runner)}}
         shell: bash
         run: echo "${RUNNER_CONTEXT}"
-
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{toJson(strategy)}}
-        run: echo "$STRATEGY_CONTEXT"
-
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{toJson(matrix)}}
-        run: echo "$MATRIX_CONTEXT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -594,3 +594,52 @@ jobs:
     permissions: write-all
     with:
       reason: CI
+
+  print-debugging-info:
+    if: failure()
+    name: Print debugging info upon job failure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python with caching of pip dependencies
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+          architecture: 'x64'
+          cache: pip
+          cache-dependency-path: ${{env.python_dep_files}}
+
+      - name: Print contextual info
+        shell: bash
+        run: |
+          pwd
+          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
+          echo "The job_id is: $GITHUB_JOB"
+          echo "The id of this action is: $GITHUB_ACTION"
+          echo "The run id is: $GITHUB_RUN_ID"
+          echo "GitHub SHA: $GITHUB_SHA"
+          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
+          ls -la
+
+      - name: Print Python package versions
+        shell: bash
+        run: pip list
+
+      - name: Dump environment variables
+        shell: bash
+        run: env
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        shell: bash
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        shell: bash
+        run: echo "${RUNNER_CONTEXT}"

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -51,9 +51,15 @@ jobs:
         # to be available on as many os/arch combos as possible, while also
         # making all necessary Python dependencies available on those combos.
         python-version: ['3.11.9', '3.12.7', '3.13.1']
-        os: [ubuntu-24.04, macos-15, macos-14, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-14, windows-2025]
         arch: [x64, arm64]
         exclude:
+          - os: ubuntu-24.04
+            arch: arm64
+
+          - os: ubuntu-24.04-arm
+            arch: x64
+
           # MacOS 14 is only available for arm64.
           - os: macos-14
             arch: x64

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -35,7 +35,7 @@ on:
   # Allow manual invocation.
   workflow_dispatch:
 
-# Declare default permissions as read only.
+# Declare default workflow permissions as read only.
 permissions: read-all
 
 jobs:
@@ -50,18 +50,10 @@ jobs:
         # These Python versions were carefully selected by trial and error
         # to be available on as many os/arch combos as possible, while also
         # making all necessary Python dependencies available on those combos.
-        # TODO: add '3.13.1' once Cirq 1.5 is released.
-        python-version: ['3.10.11', '3.11.9', '3.12.7', '3.13.1']
-        os: [ubuntu-latest, ubuntu-22.04, macos-15, macos-14, windows-latest, windows-2022]
+        python-version: ['3.11.9', '3.12.7', '3.13.1']
+        os: [ubuntu-24.04, macos-15, macos-14, windows-2025]
         arch: [x64, arm64]
         exclude:
-          # Ubuntu runners no longer come in arm versions.
-          - os: ubuntu-latest
-            arch: arm64
-
-          - os: ubuntu-22.04
-            arch: arm64
-
           # MacOS 14 is only available for arm64.
           - os: macos-14
             arch: x64
@@ -70,11 +62,8 @@ jobs:
           - os: macos-15
             arch: x64
 
-          # Windows is only available for x64.
-          - os: windows-latest
-            arch: arm64
-
-          - os: windows-2022
+          # Windows 2025 is only available for x64.
+          - os: windows-2025
             arch: arm64
 
     steps:
@@ -91,22 +80,16 @@ jobs:
           cache-dependency-path: dev_tools/requirements/envs/pytest.env.txt
 
       - name: Install OpenFermion Python requirements
-        run: |
-          pip install -r dev_tools/requirements/envs/pytest.env.txt
-          echo '::group::List of installed pip packages and their versions'
-          pip list
-          echo '::endgroup::'
+        run: pip install -r dev_tools/requirements/envs/pytest.env.txt
 
       - name: Install cirq-core (current stable version)
-        run: |
-          pip install -U cirq-core ${{inputs.args}}
+        run: pip install -U cirq-core ${{inputs.args}}
 
       - name: Set up Pytest output problem matcher
         run: echo '::add-matcher::.github/problem-matchers/pytest.json'
 
       - name: Run Pytest
-        run: |
-          check/pytest
+        run: check/pytest
 
       - name: Print debugging info upon job failure
         if: failure()
@@ -114,31 +97,28 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{toJson(github)}}
           RUNNER_CONTEXT: ${{toJson(runner)}}
-          STRATEGY_CONTEXT: ${{toJson(strategy)}}
           MATRIX_CONTEXT: ${{toJson(matrix)}}
+          STRATEGY_CONTEXT: ${{toJson(strategy)}}
         run: |
-          printf -- "────── %s ──────\n" "current directory"
-          pwd
-          ls -laF
-
-          printf -- "────── %s ──────\n" "shell environment"
+          echo '::group:: Shell environment'
           env
-
-          printf -- "────── %s ──────\n" "Python package versions"
+          echo '::endgroup::'
+          echo '::group:: Installed Python packages'
           pip list
-
-          printf -- "────── %s ──────\n" "GitHub context"
+          echo '::endgroup::'
+          echo '::group:: GitHub context'
           echo "The job_id is: $GITHUB_JOB"
           echo "The id of this action is: $GITHUB_ACTION"
           echo "The run id is: $GITHUB_RUN_ID"
           echo "GitHub SHA: $GITHUB_SHA"
           echo "$GITHUB_CONTEXT"
-
-          printf -- "────── %s ──────\n" "runner context"
+          echo '::endgroup::'
+          echo '::group:: GitHub runner context'
           echo "$RUNNER_CONTEXT"
-
-          printf -- "────── %s ──────\n" "strategy context"
-          echo "$STRATEGY_CONTEXT"
-
-          printf -- "────── %s ──────\n" "matrix context"
+          echo '::endgroup::'
+          echo '::group:: Matrix context'
           echo "$MATRIX_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: Strategy context'
+          echo "$STRATEGY_CONTEXT"
+          echo '::endgroup::'

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -51,29 +51,21 @@ jobs:
         # to be available on as many os/arch combos as possible, while also
         # making all necessary Python dependencies available on those combos.
         # TODO: add '3.13.1' once Cirq 1.5 is released.
-        python-version: ['3.10.11', '3.11.9', '3.12.7']
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
+        python-version: ['3.10.11', '3.11.9', '3.12.7', '3.13.1']
+        os: [ubuntu-latest, ubuntu-22.04, macos-15, macos-14, windows-latest, windows-2022]
         arch: [x64, arm64]
         exclude:
           # MacOS 14 is only available for arm64.
           - os: macos-14
             arch: x64
 
+          # MacOS 15 is only available for arm64.
+          - os: macos-15
+            arch: x64
+
           # Windows is only available for x64.
           - os: windows-2022
             arch: arm64
-
-          # GitHub provides separate Ubuntu runners for ARM and x64.
-          # We have to exclude the incompatible combinations.
-          - os: ubuntu-22.04-arm
-            arch: x64
-          - os: ubuntu-22.04
-            arch: arm64
-
-          # 2025-01-31 dependency h5py fails to build on this combo (only).
-          - os: ubuntu-22.04-arm
-            arch: arm64
-            python-version: 3.12.7
 
     steps:
       - name: Check out a copy of the OpenFermion git repository

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -105,3 +105,62 @@ jobs:
       - name: Run Pytest
         run: |
           check/pytest
+
+  print-debugging-info:
+    if: failure()
+    name: Print debugging info upon job failure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python with caching of pip dependencies
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+          architecture: 'x64'
+          cache: pip
+          cache-dependency-path: ${{env.python_dep_files}}
+
+      - name: Print contextual info
+        shell: bash
+        run: |
+          pwd
+          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
+          echo "The job_id is: $GITHUB_JOB"
+          echo "The id of this action is: $GITHUB_ACTION"
+          echo "The run id is: $GITHUB_RUN_ID"
+          echo "GitHub SHA: $GITHUB_SHA"
+          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
+          ls -la
+
+      - name: Print Python package versions
+        shell: bash
+        run: pip list
+
+      - name: Dump environment variables
+        shell: bash
+        run: env
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{toJson(github)}}
+        shell: bash
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{toJson(runner)}}
+        shell: bash
+        run: echo "${RUNNER_CONTEXT}"
+
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{toJson(strategy)}}
+        run: echo "$STRATEGY_CONTEXT"
+
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{toJson(matrix)}}
+        run: echo "$MATRIX_CONTEXT"

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -55,6 +55,13 @@ jobs:
         os: [ubuntu-latest, ubuntu-22.04, macos-15, macos-14, windows-latest, windows-2022]
         arch: [x64, arm64]
         exclude:
+          # Ubuntu runners no longer come in arm versions.
+          - os: ubuntu-latest
+            arch: arm64
+
+          - os: ubuntu-22.04
+            arch: arm64
+
           # MacOS 14 is only available for arm64.
           - os: macos-14
             arch: x64
@@ -64,6 +71,9 @@ jobs:
             arch: x64
 
           # Windows is only available for x64.
+          - os: windows-latest
+            arch: arm64
+
           - os: windows-2022
             arch: arm64
 

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -98,61 +98,37 @@ jobs:
         run: |
           check/pytest
 
-  print-debugging-info:
-    if: failure()
-    name: Print debugging info upon job failure
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - name: Check out a copy of the git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Set up Python with caching of pip dependencies
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
-          architecture: 'x64'
-          cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
-
-      - name: Print contextual info
+      - name: Print debugging info upon job failure
+        if: failure()
         shell: bash
+        env:
+          GITHUB_CONTEXT: ${{toJson(github)}}
+          RUNNER_CONTEXT: ${{toJson(runner)}}
+          STRATEGY_CONTEXT: ${{toJson(strategy)}}
+          MATRIX_CONTEXT: ${{toJson(matrix)}}
         run: |
+          printf -- "────── %s ──────\n" "current directory"
           pwd
-          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
+          ls -laF
+
+          printf -- "────── %s ──────\n" "shell environment"
+          env
+
+          printf -- "────── %s ──────\n" "Python package versions"
+          pip list
+
+          printf -- "────── %s ──────\n" "GitHub context"
           echo "The job_id is: $GITHUB_JOB"
           echo "The id of this action is: $GITHUB_ACTION"
           echo "The run id is: $GITHUB_RUN_ID"
           echo "GitHub SHA: $GITHUB_SHA"
-          printf '%.s─' $(seq 1 ${COLUMNS:-$(tput cols)})
-          ls -la
+          echo "$GITHUB_CONTEXT"
 
-      - name: Print Python package versions
-        shell: bash
-        run: pip list
+          printf -- "────── %s ──────\n" "runner context"
+          echo "$RUNNER_CONTEXT"
 
-      - name: Dump environment variables
-        shell: bash
-        run: env
+          printf -- "────── %s ──────\n" "strategy context"
+          echo "$STRATEGY_CONTEXT"
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{toJson(github)}}
-        shell: bash
-        run: echo "$GITHUB_CONTEXT"
-
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{toJson(runner)}}
-        shell: bash
-        run: echo "${RUNNER_CONTEXT}"
-
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{toJson(strategy)}}
-        run: echo "$STRATEGY_CONTEXT"
-
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{toJson(matrix)}}
-        run: echo "$MATRIX_CONTEXT"
+          printf -- "────── %s ──────\n" "matrix context"
+          echo "$MATRIX_CONTEXT"


### PR DESCRIPTION
Certain things are hard to figure out without more info. This adds a job that only triggers upon a failure in the workflow; the job prints various info like variable values and Python package versions.