### PR TITLE
Update versions of Python and GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -594,3 +594,44 @@ jobs:
     permissions: write-all
     with:
       reason: CI
+
+  print-debugging-info:
+    if: failure()
+    name: Print debugging info upon job failure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python with caching of pip dependencies
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+          architecture: 'x64'
+          cache: pip
+          cache-dependency-path: ${{env.python_dep_files}}
+
+      - name: Print debugging info upon job failure
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{toJson(github)}}
+          RUNNER_CONTEXT: ${{toJson(runner)}}
+        run: |
+          echo '::group:: Shell environment'
+          env
+          echo '::endgroup::'
+          echo '::group:: Installed Python packages'
+          pip list
+          echo '::endgroup::'
+          echo '::group:: GitHub context'
+          echo "The job_id is: $GITHUB_JOB"
+          echo "The id of this action is: $GITHUB_ACTION"
+          echo "The run id is: $GITHUB_RUN_ID"
+          echo "GitHub SHA: $GITHUB_SHA"
+          echo "$GITHUB_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: GitHub runner context'
+          echo "$RUNNER_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: Matrix context'

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -96,3 +96,35 @@ jobs:
 
       - name: Run Pytest
         run: check/pytest
+
+      - name: Print debugging info upon job failure
+        if: failure()
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{toJson(github)}}
+          RUNNER_CONTEXT: ${{toJson(runner)}}
+          MATRIX_CONTEXT: ${{toJson(matrix)}}
+          STRATEGY_CONTEXT: ${{toJson(strategy)}}
+        run: |
+          echo '::group:: Shell environment'
+          env
+          echo '::endgroup::'
+          echo '::group:: Installed Python packages'
+          pip list
+          echo '::endgroup::'
+          echo '::group:: GitHub context'
+          echo "The job_id is: $GITHUB_JOB"
+          echo "The id of this action is: $GITHUB_ACTION"
+          echo "The run id is: $GITHUB_RUN_ID"
+          echo "GitHub SHA: $GITHUB_SHA"
+          echo "$GITHUB_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: GitHub runner context'
+          echo "$RUNNER_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: Matrix context'
+          echo "$MATRIX_CONTEXT"
+          echo '::endgroup::'
+          echo '::group:: Strategy context'
+          echo "$STRATEGY_CONTEXT"
+          echo '::endgroup::'


### PR DESCRIPTION
Cirq 1.6 has a Python minimum version of 3.11, which means this can no
longer test on 3.10.This is to account for changes in versions made available by GitHub and
for the increase in Python minimum version in Cirq 1.6.