### PR TITLE
Update Dockerfile and its README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,8 @@ OpenFermion (or any of its plugins) using the standard procedure.
 ## What's included?
 
 - Git
-- Python 3
+- Python 3.12
+- [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main)
 - [OpenFermion](https://github.com/quantumlib/OpenFermion)
 - [Cirq](https://github.com/quantumlib/Cirq)
 - [Psi4](http://www.psicode.org)
@@ -27,6 +28,25 @@ OpenFermion (or any of its plugins) using the standard procedure.
 
 ## Setting up Docker for the first time
 
+The Dockerfile is based on the [Ubuntu image](https://hub.docker.com/_/ubuntu) (ver. 22.04).
+It creates a Python (ver. 3.12) virtual environemnt (named `fermion`) using Miniconda and installs all dependencies within it. Psi4 is installed with a conda [command](https://psicode.org/installs/v191/).
+The default configuration uses the Miniconda installer (ver. 25.5.1-1) for Python 3.12 on Linux `aarch64` architecture.
+
+### Customizing the Environment
+You can manually edit the Dockerfile if you need to set up a different development environment (e.g., change the Ubuntu, Python, Miniconda, or Psi4 version).
+
+If your local machine builds Linux `x86_64` architecture with the Dockerfile, the `wget` command 
+for the Miniconda installer (Line 40 in the Dockerfile)
+```
+wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh && \
+```
+must be changed to 
+```
+wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
+```
+You can check other Miniconda installers [here](https://repo.anaconda.com/miniconda/).
+
+### Building Docker Image
 You first need to install [Docker](https://www.docker.com/).
 Once Docker is setup, one can navigate to the folder containing the
 Dockerfile for building the OpenFermion image (docker/dockerfile) and run
@@ -39,31 +59,14 @@ where "openfermion_docker" is just an arbitrary name for our docker image.
 Building the Dockerfile starts from a base image of Ubuntu and then installs
 OpenFermion, its plugins, and the necessary applications needed for running these
 programs. This is a fairly involved setup and will take some time
-(perhaps up to thiry minutes depending on the computer). Once installation has
-completed, run the image with
+(perhaps up to thirty minutes depending on the computer) and disk space (several gigabytes). Once installation has completed, run the image with
 
 ```
-docker run -it openfermion_docker
+docker run -it --name openfermion_container -v $(pwd):/root/workspace openfermion_docker
 ```
-
-With this command the terminal enters a new environment which emulates Ubuntu with
-OpenFermion and accessories installed. To transfer files from somewhere on the disk to the Docker
-container, first run `docker ps` in a separate terminal from the one running
-Docker. This returns a list of running containers, e.g.:
-
+where "openfermion_container" is an arbitrary choice for the name of our docker container. This command will mount your current local directory to `/root/workspace` inside the running container. You can activate the virtual environment `fermion` in the container with
 ```
-+CONTAINER ID        IMAGE               COMMAND             CREATED
-+STATUS              PORTS               NAMES
-+3cc87ed4205b        5a67a4d66d05        "/bin/bash"         2 hours ago
-+Up 2 hours                              competent_feynman
-```
-
-In this example, the container name is "competent_feynman" (the name is
-random and generated automatically). Using this name, one can then copy
-files into the active Docker session from other terminal using:
-
-```
-docker cp [path to file on disk] [container name]:[path in container]
+source activate fermion
 ```
 
 An alternative way of loading files onto the Docker container is through

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,7 @@
 # Docker setup for OpenFermion and select plugins
 
 This Docker image contains [OpenFermion](https://github.com/quantumlib/OpenFermion)
-and its available plugins for
-[Cirq](https://github.com/quantumlib/Cirq),
-[Psi4](https://github.com/quantumlib/OpenFermion-Psi4), and
-[PySCF](https://github.com/quantumlib/OpenFermion-PySCF).
+and its several available plugins.
 Check out Docker's [website](https://www.docker.com/what-container) for a description of
 what a container image is and why it can be so useful.
 The Docker-based installation is extremely robust and runs on any operating
@@ -18,17 +15,13 @@ OpenFermion (or any of its plugins) using the standard procedure.
 - Python 3.12
 - [Miniforge](https://github.com/conda-forge/miniforge)
 - [OpenFermion](https://github.com/quantumlib/OpenFermion)
-- [Cirq](https://github.com/quantumlib/Cirq)
 - [Psi4](http://www.psicode.org)
-- [PySCF](https://github.com/sunqm/pyscf)
-- [OpenFermion-Cirq](https://github.com/quantumlib/OpenFermion-Cirq)
 - [OpenFermion-Psi4](https://github.com/quantumlib/OpenFermion-Psi4)
 - [OpenFermion-PySCF](https://github.com/quantumlib/OpenFermion-PySCF)
 
 
 ## Setting up Docker for the first time
 The Dockerfile is based on the [Ubuntu image](https://hub.docker.com/_/ubuntu) (ver. 22.04).
-Two Linux architectures are supported in the Dockerfile: x86_64 (amd64) and aarch64 (arm64).
 Detecting your host's architecture is handled automatically through the following docker image building process, so you don't have to check it manually.
 It creates a Python (ver. 3.12) virtual environment (named `fermion`) using Miniforge and installs all dependencies within it. Psi4 is installed with a [conda command](https://psicode.org/installs/v191/).
 
@@ -45,8 +38,7 @@ docker build -t openfermion_docker .
 where "openfermion_docker" is just an arbitrary name for our docker image.
 Building the Dockerfile starts from a base image of Ubuntu and then installs
 OpenFermion, its plugins, and the necessary applications needed for running these
-programs. This is a fairly involved setup and will take some time
-(perhaps up to thirty minutes, depending on the computer) and disk space (several gigabytes). 
+programs. This will take few minutes (depending on the computer) and disk space (several gigabytes). 
 
 Line 18 in the Dockerfile
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ OpenFermion (or any of its plugins) using the standard procedure.
 
 - Git
 - Python 3.12
-- [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main)
+- [Miniforge](https://github.com/conda-forge/miniforge)
 - [OpenFermion](https://github.com/quantumlib/OpenFermion)
 - [Cirq](https://github.com/quantumlib/Cirq)
 - [Psi4](http://www.psicode.org)
@@ -29,27 +29,27 @@ OpenFermion (or any of its plugins) using the standard procedure.
 ## Setting up Docker for the first time
 
 The Dockerfile is based on the [Ubuntu image](https://hub.docker.com/_/ubuntu) (ver. 22.04).
-It creates a Python (ver. 3.12) virtual environemnt (named `fermion`) using Miniconda and installs all dependencies within it. Psi4 is installed with a conda [command](https://psicode.org/installs/v191/).
-The default configuration uses the Miniconda installer (ver. 25.5.1-1) for Python 3.12 on Linux `aarch64` architecture.
+It creates a Python (ver. 3.12) virtual environemnt (named `fermion`) using Miniforge and installs all dependencies within it. Psi4 is installed with a conda [command](https://psicode.org/installs/v191/).
+The default configuration uses the latest Miniforge installer on Linux `aarch64` architecture.
 
 ### Customizing the Environment
-You can manually edit the Dockerfile if you need to set up a different development environment (e.g., change the Ubuntu, Python, Miniconda, or Psi4 version).
+You can manually edit the Dockerfile if you need to set up a different development environment (e.g., changing the Ubuntu, Python, Miniforge, or Psi4 version).
 
 If your local machine builds Linux `x86_64` architecture with the Dockerfile, the `wget` command 
-for the Miniconda installer (Line 40 in the Dockerfile)
+for the Miniforge installer (Line 40 in the Dockerfile)
 ```
-wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh && \
+wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
 ```
 must be changed to 
 ```
-wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
+wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
 ```
-You can check other Miniconda installers [here](https://repo.anaconda.com/miniconda/).
+You can check other Miniforge installers [here](https://github.com/conda-forge/miniforge?tab=readme-ov-file#requirements-and-installers).
 
 ### Building Docker Image
 You first need to install [Docker](https://www.docker.com/).
 Once Docker is setup, one can navigate to the folder containing the
-Dockerfile for building the OpenFermion image (docker/dockerfile) and run
+Dockerfile for building the OpenFermion image (/docker/dockerfile) and run
 
 ```
 docker build -t openfermion_docker .
@@ -59,15 +59,21 @@ where "openfermion_docker" is just an arbitrary name for our docker image.
 Building the Dockerfile starts from a base image of Ubuntu and then installs
 OpenFermion, its plugins, and the necessary applications needed for running these
 programs. This is a fairly involved setup and will take some time
-(perhaps up to thirty minutes depending on the computer) and disk space (several gigabytes). Once installation has completed, run the image with
+(perhaps up to thirty minutes depending on the computer) and disk space (several gigabytes). 
 
+### Running the Container
+Once the image has been built, run the image with
 ```
 docker run -it --name openfermion_container -v $(pwd):/root/workspace openfermion_docker
 ```
-where "openfermion_container" is an arbitrary choice for the name of our docker container. This command will mount your current local directory to `/root/workspace` inside the running container. You can activate the virtual environment `fermion` in the container with
+where "openfermion_container" is an arbitrary choice for the name of our docker container. This command will mount your current local directory to `/root/workspace` inside the running container.
+By default, the virtual environment `fermion` is automatically activated in the running container.
+After installing the `Dev Containers` extension in Visual Studio Code, 
+you can open the container with the following option:
 ```
-source activate fermion
+Command Palette -> Dev Containers: Attach to Running Container..
 ```
+and select `openfermion_container` for this example.
 
 An alternative way of loading files onto the Docker container is through
 remote repos such as GitHub. Git is installed in the Docker image.

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -14,8 +14,6 @@
 
 FROM ubuntu:22.04
 
-USER root
-
 WORKDIR /root/workspace
 COPY . /root/workspace
 
@@ -25,17 +23,18 @@ ENV PATH="/root/conda/bin:${PATH}"
 ENV PYTHONPATH=/root/pyscf
 
 RUN apt-get update && \
-    apt-get install -y build-essential \
-        bzip2 \
-        cmake \
-        git \
-        wget \
-        libblas-dev \
-        liblapack-dev \
-        curl
+    apt-get install -y --no-install-recommends bzip2=1.0.8-5build1 \
+    cmake=3.22.1-1ubuntu1.22.04.2 \
+    git=1:2.34.1-1ubuntu1.15 \
+    wget=1.21.2-2ubuntu1.1 \
+    libblas-dev=3.10.0-2ubuntu1 \
+    liblapack-dev=3.10.0-2ubuntu1 \
+    # in order to verify github's certificate
+    ca-certificates=20240203~22.04.1 \
+    build-essential=12.9ubuntu3
 
 # Install miniforge https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline
-RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh" && \
+RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/download/25.3.1-0/Miniforge3-25.3.1-0-$(uname)-$(uname -m).sh" && \
     bash Miniforge3.sh -b -p "${HOME}/conda" && \
     conda init bash && \
     conda update -n base -c conda-forge conda && \
@@ -43,14 +42,13 @@ RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/lat
     conda create -n fermion psi4 python=3.12 -c conda-forge -y && \
     conda install -n fermion pip -y && \
     # Install OpenFermion, Cirq, and plugins
-    conda run -n fermion pip install openfermion \ cirq \ openfermioncirq \ openfermionpsi4 \ openfermionpyscf && \
-    # Install PySCF
-    cd /root && \
-    git clone https://github.com/sunqm/pyscf && \
-    cd /root/pyscf/pyscf/lib && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
+    conda run -n fermion pip install openfermion \ cirq \ openfermioncirq \ openfermionpsi4 \ openfermionpyscf
+
+# Install PySCF
+WORKDIR /root
+RUN git clone https://github.com/sunqm/pyscf
+WORKDIR /root/pyscf/pyscf/lib/build
+RUN cmake .. && \
     make
 
 # Activate venv (fermion)

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -12,48 +12,49 @@
 
 # Dockerfile for OpenFermion, Cirq, and select plugins.
 
-FROM ubuntu
+FROM ubuntu:22.04
 
 USER root
 
-RUN apt-get update
+WORKDIR /root/workspace
+COPY . /root/workspace
 
-# Install utilities
-RUN apt-get install -y bzip2
-RUN apt-get install -y cmake
-RUN apt-get install -y git
-RUN apt-get install -y wget
-RUN apt-get install -y libblas-dev
-RUN apt-get install -y liblapack-dev
+# Set PATH for miniconda
+ENV PATH=/root/miniconda3/bin:$PATH
+# Set PATH for pyscf
+ENV PYTHONPATH=/root/pyscf
 
-# Install Python 3
-RUN apt-get install -y python3
+RUN apt-get update && \
+    apt-get install -y build-essential \
+        bzip2 \
+        cmake \
+        git \
+        wget \
+        libblas-dev \
+        liblapack-dev \
+        curl
 
-# Install pip.
-RUN apt-get install -y python3-pip
-
-# Install Psi4.
-RUN cd /root; wget http://vergil.chemistry.gatech.edu/psicode-download/psi4conda-1.2.1-py36-Linux-x86_64.sh
-RUN echo '/root/psi4conda' | bash /root/psi4conda-1.2.1-py36-Linux-x86_64.sh
-RUN rm /root/psi4conda-1.2.1-py36-Linux-x86_64.sh
-RUN export PATH=/root/psi4conda/bin:$PATH
-
-# Install PySCF.
-RUN cd /root; git clone https://github.com/sunqm/pyscf
-RUN cd /root/pyscf/pyscf/lib; mkdir build; cd build; cmake ..; make
-
-# Install OpenFermion, Cirq, and plugins.
-RUN pip3 install openfermion
-RUN pip3 install cirq
-RUN pip3 install openfermioncirq
-RUN pip3 install openfermionpsi4
-RUN pip3 install openfermionpyscf
-
-# Update paths
-RUN export PATH=/root/psi4conda/bin:$PATH
-RUN export PYTHONPATH=/root/pyscf:$PYTHONPATH
-
-# Make python point to python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-ENTRYPOINT bash
+# Install miniconda for python 3.12, Linux aarch
+# https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions
+RUN mkdir -p ~/miniconda3 && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh && \
+    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && \
+    rm ~/miniconda3/miniconda.sh && \
+    /bin/bash -c "source ~/miniconda3/bin/activate" && \
+    conda init --all && \
+    # To accept a channel's Terms of Service
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+    # Create virtual env (fermion) with installing Psi4
+    conda create -n fermion psi4 python=3.12 -c conda-forge -y && \
+    conda install -n fermion pip -y && \
+    # Install OpenFermion, Cirq, and plugins
+    conda run -n fermion pip install openfermion \ cirq \ openfermioncirq \ openfermionpsi4 \ openfermionpyscf && \
+    # Install PySCF
+    cd /root && \
+    git clone https://github.com/sunqm/pyscf && \
+    cd /root/pyscf/pyscf/lib && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -19,37 +19,28 @@ COPY . /root/workspace
 
 # Set PATH for miniforge
 ENV PATH="/root/conda/bin:${PATH}"
-# Set PATH for pyscf
-ENV PYTHONPATH=/root/pyscf
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends bzip2=1.0.8-5build1 \
-    cmake=3.22.1-1ubuntu1.22.04.2 \
-    git=1:2.34.1-1ubuntu1.15 \
+    apt-get install -y --no-install-recommends git=1:2.34.1-1ubuntu1.15 \
     wget=1.21.2-2ubuntu1.1 \
     libblas-dev=3.10.0-2ubuntu1 \
     liblapack-dev=3.10.0-2ubuntu1 \
     # in order to verify github's certificate
     ca-certificates=20240203~22.04.1 \
-    build-essential=12.9ubuntu3
+    build-essential=12.9ubuntu3 && \
+    # delete the apt-get lists after the installation
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install miniforge https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline
 RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/download/25.3.1-0/Miniforge3-25.3.1-0-$(uname)-$(uname -m).sh" && \
     bash Miniforge3.sh -b -p "${HOME}/conda" && \
+    rm Miniforge3.sh && \
     conda init bash && \
-    conda update -n base -c conda-forge conda && \
     # Create virtual env (fermion) with installing Psi4
-    conda create -n fermion psi4 python=3.12 -c conda-forge -y && \
-    conda install -n fermion pip -y && \
-    # Install OpenFermion, Cirq, and plugins
-    conda run -n fermion pip install openfermion \ cirq \ openfermioncirq \ openfermionpsi4 \ openfermionpyscf
-
-# Install PySCF
-WORKDIR /root
-RUN git clone https://github.com/sunqm/pyscf
-WORKDIR /root/pyscf/pyscf/lib/build
-RUN cmake .. && \
-    make
+    conda create -n fermion psi4==1.10 python=3.12 -c conda-forge -y && \
+    # Install OpenFermion and plugins
+    conda install -n fermion -c conda-forge openfermion==1.7.1 openfermionpsi4==0.5 openfermionpyscf==0.5 -y
 
 # Activate venv (fermion)
 RUN echo "conda activate fermion" >> ~/.bashrc

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -19,8 +19,8 @@ USER root
 WORKDIR /root/workspace
 COPY . /root/workspace
 
-# Set PATH for miniconda
-ENV PATH=/root/miniconda3/bin:$PATH
+# Set PATH for miniforge
+ENV PATH="/root/conda/bin:${PATH}"
 # Set PATH for pyscf
 ENV PYTHONPATH=/root/pyscf
 
@@ -34,17 +34,11 @@ RUN apt-get update && \
         liblapack-dev \
         curl
 
-# Install miniconda for python 3.12, Linux aarch
-# https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions
-RUN mkdir -p ~/miniconda3 && \
-    wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-1-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh && \
-    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && \
-    rm ~/miniconda3/miniconda.sh && \
-    /bin/bash -c "source ~/miniconda3/bin/activate" && \
-    conda init --all && \
-    # To accept a channel's Terms of Service
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+# Install miniforge https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline
+RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh" && \
+    bash Miniforge3.sh -b -p "${HOME}/conda" && \
+    conda init bash && \
+    conda update -n base -c conda-forge conda && \
     # Create virtual env (fermion) with installing Psi4
     conda create -n fermion psi4 python=3.12 -c conda-forge -y && \
     conda install -n fermion pip -y && \
@@ -58,3 +52,6 @@ RUN mkdir -p ~/miniconda3 && \
     cd build && \
     cmake .. && \
     make
+
+# Activate venv (fermion)
+RUN echo "conda activate fermion" >> ~/.bashrc


### PR DESCRIPTION
The original Dockerfile has issues and is not working. Ubuntu and Python versions are not specified, and the link to Psi4 is expired. This pull request fixes the Dockerfile and updates its README.md to match.

The new configuration has been tested on an Apple Silicon Mac (M4). Customization for other platforms is straightforward and can be understood easily with the updated README.md.

Changes to Dockerfile:
1. Pin versions for Ubuntu (22.04) and Python (3.12).
2. Add `WORKDIR` to mount local files.
3. Set `PATH` with `ENV`.
4. Psi4 is installed with a conda command instead of `wget`.
5. Dependencies are installed inside of a virtual environment (`fermion`).
6. Reduce the number of `RUN` commands to reduce the number of layers.

Changes to its README.md:
1. Put some details on the Dockerfile in the first paragraph of Setting up ~.
2. Add details to customization.
3. Change `docker run` command and introduce a simpler way to mount local files. So some previous explanations are deleted.