### PR TITLE
Fix #928:

### DIFF
--- a/src/openfermion/contrib/representability/_multitensor.py
+++ b/src/openfermion/contrib/representability/_multitensor.py
@@ -102,6 +102,7 @@ class MultiTensor(object):
         bias_data_values = []
         # this forms the c-vector of ax + b = c
         inner_prod_data_values = []
+        n_rows = len(self.dual_basis.elements)
         for index, dual_element in enumerate(self.dual_basis):
             dcol, dval = self.synthesize_element(dual_element)
             dual_row_indices.extend([index] * len(dcol))
@@ -109,7 +110,7 @@ class MultiTensor(object):
             dual_data_values.extend(dval)
             inner_prod_data_values.append(float(dual_element.dual_scalar))
             bias_data_values.append(dual_element.constant_bias)
-        n_rows = len(self.dual_basis.elements)
+
         sparse_dual_operator = csr_matrix(
             (dual_data_values, (dual_row_indices, dual_col_indices)), [n_rows, self.vec_dim]
         )

--- a/src/openfermion/contrib/representability/_multitensor_test.py
+++ b/src/openfermion/contrib/representability/_multitensor_test.py
@@ -185,3 +185,20 @@ def test_cover_make_offset_dict():
     c = np.random.random((3, 3))
     with pytest.raises(TypeError):
         _ = MultiTensor.make_offset_dict([a, b, c])
+
+def test_synthesize_dual_basis_empty():
+    a = np.random.random((5, 5))
+    b = np.random.random((4, 4))
+    c = np.random.random((3, 3))
+    at = Tensor(tensor=a, name='a')
+    bt = Tensor(tensor=b, name='b')
+    ct = Tensor(tensor=c, name='c')
+    mt = MultiTensor([at, bt, ct], DualBasis(elements=[]))
+
+    A, c, b = mt.synthesize_dual_basis()
+    assert isinstance(A, sp.sparse.csr_matrix)
+    assert isinstance(c, sp.sparse.csr_matrix)
+    assert isinstance(b, sp.sparse.csr_matrix)
+    assert A.shape == (0, 50)
+    assert b.shape == (0, 1)
+    assert c.shape == (0, 1)


### PR DESCRIPTION
The `synthesize_dual_basis()` method had a potential `NameError` because it calculated the number of rows after a for loop. If the `dual_basis` was empty, the loop would not run, and a variable used later would be undefined. The fix was to move the line that calculates the number of rows to before the loop, ensuring it is always defined.