### PR TITLE
Fix #885: type coercion due to slightly incorrect default value

### DIFF
--- a/src/openfermion/ops/operators/fermion_operator_test.py
+++ b/src/openfermion/ops/operators/fermion_operator_test.py
@@ -12,8 +12,8 @@
 
 """Tests fermion_operator.py."""
 
-import unittest
 import sympy
+import unittest
 
 from openfermion.ops.operators.fermion_operator import FermionOperator
 from openfermion.hamiltonians import number_operator

--- a/src/openfermion/ops/operators/fermion_operator_test.py
+++ b/src/openfermion/ops/operators/fermion_operator_test.py
@@ -9,8 +9,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Tests  fermion_operator.py."""
+
+"""Tests fermion_operator.py."""
+
 import unittest
+import sympy
 
 from openfermion.ops.operators.fermion_operator import FermionOperator
 from openfermion.hamiltonians import number_operator
@@ -78,3 +81,10 @@ class FermionOperatorTest(unittest.TestCase):
     def test_is_two_body_number_conserving_out_of_order(self):
         op = FermionOperator(((0, 1), (2, 0), (1, 1), (3, 0)))
         self.assertTrue(op.is_two_body_number_conserving())
+
+    def test_add_sympy_rational(self):
+        """Test adding operators with sympy.Rational coefficients."""
+        a = FermionOperator('0^ 0', sympy.Rational(1, 2))
+        b = FermionOperator('1^ 1', sympy.Rational(1, 2))
+        c = a + b
+        self.assertIsInstance(c.terms[((0, 1), (0, 0))], sympy.Rational)

--- a/src/openfermion/ops/operators/symbolic_operator.py
+++ b/src/openfermion/ops/operators/symbolic_operator.py
@@ -433,7 +433,7 @@ class SymbolicOperator(metaclass=abc.ABCMeta):
         """
         if isinstance(addend, type(self)):
             for term in addend.terms:
-                self.terms[term] = self.terms.get(term, 0.0) + addend.terms[term]
+                self.terms[term] = self.terms.get(term, 0) + addend.terms[term]
                 if self._issmall(self.terms[term]):
                     del self.terms[term]
         elif isinstance(addend, COEFFICIENT_TYPES):

--- a/src/openfermion/ops/operators/symbolic_operator.py
+++ b/src/openfermion/ops/operators/symbolic_operator.py
@@ -480,7 +480,7 @@ class SymbolicOperator(metaclass=abc.ABCMeta):
         """
         if isinstance(subtrahend, type(self)):
             for term in subtrahend.terms:
-                self.terms[term] = self.terms.get(term, 0.0) - subtrahend.terms[term]
+                self.terms[term] = self.terms.get(term, 0) - subtrahend.terms[term]
                 if self._issmall(self.terms[term]):
                     del self.terms[term]
         elif isinstance(subtrahend, COEFFICIENT_TYPES):

--- a/src/openfermion/ops/operators/symbolic_operator_test.py
+++ b/src/openfermion/ops/operators/symbolic_operator_test.py
@@ -9,13 +9,15 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
 """Tests  symbolic_operator.py."""
+
 import copy
+import numpy
+import sympy
 import unittest
 import warnings
 
-import numpy
-import sympy
 from openfermion.config import EQ_TOLERANCE
 from openfermion.testing.testing_utils import EqualsTester
 

--- a/src/openfermion/ops/operators/symbolic_operator_test.py
+++ b/src/openfermion/ops/operators/symbolic_operator_test.py
@@ -20,6 +20,7 @@ from openfermion.config import EQ_TOLERANCE
 from openfermion.testing.testing_utils import EqualsTester
 
 from openfermion.ops.operators.symbolic_operator import SymbolicOperator
+from openfermion.ops.operators.fermion_operator import FermionOperator
 
 
 class DummyOperator1(SymbolicOperator):
@@ -686,6 +687,14 @@ class SymbolicOperatorTest1(unittest.TestCase):
         self.assertEqual(len(a.terms), 2)
         self.assertTrue(a.terms[term_a] - coeff_a == 0)
         self.assertTrue(a.terms[term_b] - coeff_b - 0.5 == 0)
+
+    def test_add_sympy_new_term(self):
+        """Test adding a new term with a sympy coefficient."""
+        x = sympy.Symbol('x')
+        op = FermionOperator('1^', x)
+        op += FermionOperator('2', 2 * x)
+        self.assertEqual(op.terms[((1, 1),)], x)
+        self.assertEqual(op.terms[((2, 0),)], 2 * x)
 
     def test_radd(self):
         term_a = ((1, 1), (3, 0), (8, 1))


### PR DESCRIPTION
When adding a new term to a `SymbolicOperator` with a sympy coefficient, the coefficient was being cast to a float. This was because the default value for a new term was `0.0`, which is a float. This commit changes the default value to `0`, which is an integer. This ensures that the type of the coefficient is preserved when adding new terms.