### PR TITLE
Fix #1118: avoid using "-P" with grep

### DIFF
--- a/check/pytest
+++ b/check/pytest
@@ -47,7 +47,7 @@ if [ -z "${ACTUALLY_QUIET}" ]; then
 else
     # Filter out lines like "...F....x...      [ 42%]", with coloring.
     pytest -c dev_tools/conf/pytest.ini \
-           --rootdir="$rootdir" -q --color=yes "${PYTEST_ARGS[@]}" |
-        grep -Pv '^(.\[0m)?[\.FEsx]+(.\[36m)?\s+\[\s*\d+%\](.\[0m)?$'
+           --rootdir="$rootdir" -q --color=yes "${PYTEST_ARGS[@]}" | \
+        grep -Ev '^(\x1B\[0m)?[\.FEsx]+(\x1B\[36m)?[[:space:]]+\[[[:space:]]*[0-9]+%\](\x1B\[0m)?$'
     exit "${PIPESTATUS[0]}"
 fi


### PR DESCRIPTION
The default version of `grep` on macOS (at least through macOS 15) does not take a `-P` argument, which causes `check/pytest` to fail due to the call to `grep -P` on line 432:

```shell
grep -Pv '^(.\[0m)?[\.FEsx]+(.\[36m)?\s+\[\s*\d+%\](.\[0m)?$'
```

The problem is that `-P` is for using Perl-compatible regular expressions (PCRE), which are not standard in the BSD version of grep that comes with macOS. Switching to grep's extended regex syntax using `-E` resolves the problem.