### PR TITLE
Fix #1120: change unsafe regex in symbolic_operator.py

### DIFF
--- a/src/openfermion/ops/operators/symbolic_operator.py
+++ b/src/openfermion/ops/operators/symbolic_operator.py
@@ -161,7 +161,7 @@ class SymbolicOperator(metaclass=abc.ABCMeta):
             '1.5 [2^ 3] + 1.4 [3^ 0]'
         """
 
-        pattern = r'(.*?)\[(.*?)\]'  # regex for a term
+        pattern = r'([^[\]]*)\[([^\]]*)\]'  # regex for a term
         for match in re.findall(pattern, long_string, flags=re.DOTALL):
             # Determine the coefficient for this term
             coef_string = re.sub(r"\s+", "", match[0])

--- a/src/openfermion/ops/operators/symbolic_operator_test.py
+++ b/src/openfermion/ops/operators/symbolic_operator_test.py
@@ -332,6 +332,98 @@ class SymbolicOperatorTest1(unittest.TestCase):
         correct = DummyOperator1('3^ 2', complex(-2.3, -1.7))
         self.assertEqual(len((fermion_op - correct).terms), 0)
 
+    def test_init_long_str_regex(self):
+        """Test the regex for parsing long string initializations."""
+        # Test coefficient variations
+        op = DummyOperator1('1.5 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        op = DummyOperator1('-1.5 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -1.5))
+
+        op = DummyOperator1('2 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 2.0))
+
+        op = DummyOperator1('-2 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -2.0))
+
+        op = DummyOperator1('.5 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 0.5))
+
+        op = DummyOperator1('(1+2j) [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1 + 2j))
+
+        op = DummyOperator1('( 1 + 2j ) [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1 + 2j))
+
+        op = DummyOperator1('-(1+2j) [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -1 - 2j))
+
+        op = DummyOperator1('3j [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 3j))
+
+        op = DummyOperator1('-3j [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -3j))
+
+        op = DummyOperator1('+1.5 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        op = DummyOperator1('- 1.5 [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -1.5))
+
+        op = DummyOperator1('[0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.0))
+
+        op = DummyOperator1('-[0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -1.0))
+
+        op = DummyOperator1('+[0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.0))
+
+        # Test spacing variations
+        op = DummyOperator1('1.5[0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        op = DummyOperator1('1.5  [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        op = DummyOperator1('1.5 [ 0^ 1 ]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        op = DummyOperator1(' 1.5 [0^ 1] ')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.5))
+
+        # Test multiple terms
+        op = DummyOperator1('1.5 [0^ 1] + 2.0 [2^ 3]')
+        correct = DummyOperator1('0^ 1', 1.5) + DummyOperator1('2^ 3', 2.0)
+        self.assertTrue(op == correct)
+
+        op = DummyOperator1('1.5 [0^ 1] - 2.0 [2^ 3]')
+        correct = DummyOperator1('0^ 1', 1.5) + DummyOperator1('2^ 3', -2.0)
+        self.assertTrue(op == correct)
+
+        op = DummyOperator1('1.5[0^ 1] - 2.0 [ 2^ 3 ]')
+        correct = DummyOperator1('0^ 1', 1.5) + DummyOperator1('2^ 3', -2.0)
+        self.assertTrue(op == correct)
+
+        # Test multiline strings
+        op = DummyOperator1('1.5 [0^ 1]\n+\n2.0 [2^ 3]')
+        correct = DummyOperator1('0^ 1', 1.5) + DummyOperator1('2^ 3', 2.0)
+        self.assertTrue(op == correct)
+
+        # Test edge cases
+        op = DummyOperator1('1.5 []')
+        self.assertTrue(op == DummyOperator1((), 1.5))
+
+        op = DummyOperator1('1.5 [] - 0.5 []')
+        self.assertTrue(op == DummyOperator1((), 1.0))
+
+        op = DummyOperator1('+ [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', 1.0))
+
+        op = DummyOperator1('- [0^ 1]')
+        self.assertTrue(op == DummyOperator1('0^ 1', -1.0))
+
     def test_merges_multiple_whitespace(self):
         fermion_op = DummyOperator1('        \n ')
         self.assertEqual(fermion_op.terms, {(): 1})


### PR DESCRIPTION
CodeQL scan [report #566](https://github.com/quantumlib/OpenFermion/security/code-scanning/566) flagged a regex used on line 165 of
`src/openfermion/ops/operators/symbolic_operator.py` as being potential subject to a DoS attach. The warning is this:

```python
pattern = r'(.*?)\[(.*?)\]'  # regex for a term
for match in re.findall(pattern, long_string, flags=re.DOTALL):
```

```
This regular expression that depends on a user-provided value
 may run slow on strings with many repetitions of 'a'.
This regular expression that depends on a user-provided value
 may run slow on strings starting with '[' and with many repetitions of '[a'.
This regular expression that depends on a user-provided value
 may run slow on strings with many repetitions of 'a'.
This regular expression that depends on a user-provided value
 may run slow on strings starting with '[' and with many repetitions of '[a'.
```

This changes the regular expression to avoid `.*` yet still be able to match the same patterns as before. Additional tests in `symbolic_operator_test.py` verify that this will parse strings correctly.