### PR TITLE
Update hadolint configuration

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,5 @@
+# Summary: configure the Dockerfile linter program "hadolint" for this project.
+#
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Hadolint (Dockerfile linter) used in this project's CI checks.
 # Info about options can be found at https://github.com/hadolint/hadolint/.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 format: tty
 no-color: false
 no-fail: false
 failure-threshold: error
+
+# Rule/error numbers are described at https://github.com/hadolint/hadolint/wiki
 ignored:
+  # Don't complain about not deleting the apt lists after every apt-get install.
+  - DL3009
   - DL3025
-  - DL3047
+  # Multiple consecutive RUN stmts are usually deliberate. Don't flag that.
   - DL3059


### PR DESCRIPTION
The `hadolint` warning DL3009 is only relevant when optimizing a docker container's size. It's not needed for security or other reasons. Not only is this rule annoying; following the rule can also increase docker image build times. The benefit does not seem to outweight the drawbacks, so I added it to the list of ignored rules.

Conversely, DL3047 (about the syntax of CMD statements) is probably better to keep, as a matter of modern practices surrounding Dockerfiles.