### PR TITLE
Avoid early exit in check/shellcheck due to spurious read failure

### DIFF
--- a/check/shellcheck
+++ b/check/shellcheck
@@ -43,11 +43,12 @@ for arg in "$@"; do
 done
 
 # Find all shell scripts in this repository.
-IFS=$'\n' read -r -d '' -a our_shell_scripts <<< "$(
+IFS=$'\n' read -r -d "" -a our_shell_scripts < <(
     git ls-files -z -- \
-        ':(exclude)*.'{hdf5,ipynb,json,md,py,rst,toml,ts,txt,yaml} | \
-    xargs -0 file | grep -i 'shell script' | cut -d: -f1
-)"
+        ':(exclude)*.'{hdf5,ipynb,json,md,py,rst,toml,ts,txt,yaml} |
+        xargs -0 file | grep -i 'shell script' | cut -d: -f1;
+    printf "\0"
+)
 
 # Verify our_shell_scripts array - require it must contain files below.
 declare -a required_shell_scripts


### PR DESCRIPTION
Problem: In bash `read -r -d "" VAR` expects a NUL character to terminate
the input line.  If missing read returns a failure exit status and thus
quits the shellcheck script due to its errexit option.

Solution: Terminate read input with the NUL character.
