### PR TITLE
Add workflow for checking PR titles & descriptions

### DIFF
--- a/.github/workflows/pr-text-checker.yaml
+++ b/.github/workflows/pr-text-checker.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Summary: check the subject and description of each PR for basic best
+# practices and fail with an error if a PR doesn't meet the conditions.
+
+name: Pull request text checker
+run-name: >-
+  Check title and description of
+  PR #${{github.event.inputs.pr-number || github.event.pull_request.number}}
+  by ${{github.actor}}
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  check-text-length:
+    name: "Minimum length check"
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Check the lengths of the PR title and description
+        env:
+          SHELLOPTS: ${{runner.debug && 'xtrace' || '' }}
+        run: |
+          pr_title=$(jq -r ".pull_request.title" "${GITHUB_EVENT_PATH}")
+          pr_body=$(jq -r ".pull_request.body" "${GITHUB_EVENT_PATH}")
+
+          read -ra title_words <<< "${pr_title}"
+          if [[ ${#title_words[@]} -lt 2 ]]; then
+            echo "::error::PR title must contain at least two words."
+            error=1
+          fi
+          if [[ -z "${pr_body}" || ${#pr_body} -lt 10 ]]; then
+            echo "::error::PR description must be at least 10 characters long."
+            error=1
+          fi
+
+          if [[ -v error ]]; then
+            {
+            printf "❌ Problem(s) found with the PR title and/or description."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi


### PR DESCRIPTION
This workflow adds very simple checks for minimum requirements: a title that has at least two words, and a description that is at least 10 characters long. 

The goal is to block PRs that lack descriptions or have titles that are unlikely to be informative. A search of past PRs in this repo shows that this has happened in the past.

In the future, more checks could be added as additional jobs in this workflow. For example, we should also check for the presence of non-inclusive terms such as "blacklist".