### PR TITLE
Replace assert in reverse_jordan_wigner.py

### DIFF
--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
@@ -82,7 +82,7 @@ def reverse_jordan_wigner(qubit_operator, n_qubits=None):
 
                 # Get next non-identity operator acting below 'working_qubit'.
                 if len(working_term.terms) != 1:
-                    raise ValueError('Qubit operator term needs to be a single term')
+                    raise ValueError('QubitOperator must contain exactly one term')
                 working_qubit = pauli_operator[0] - 1
                 for working_operator in reversed(list(working_term.terms)[0]):
                     if working_operator[0] <= working_qubit:

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
@@ -82,7 +82,10 @@ def reverse_jordan_wigner(qubit_operator, n_qubits=None):
 
                 # Get next non-identity operator acting below 'working_qubit'.
                 if len(working_term.terms) != 1:
-                    raise ValueError('QubitOperator must contain exactly one term')
+                    raise ValueError(
+                        'QubitOperator must contain exactly one term. '
+                        f'Found {len(working_term.terms)} terms: {working_term!r}'
+                    )
                 working_qubit = pauli_operator[0] - 1
                 for working_operator in reversed(list(working_term.terms)[0]):
                     if working_operator[0] <= working_qubit:

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner.py
@@ -81,7 +81,8 @@ def reverse_jordan_wigner(qubit_operator, n_qubits=None):
                     working_term.terms[list(working_term.terms)[0]] = 1.0
 
                 # Get next non-identity operator acting below 'working_qubit'.
-                assert len(working_term.terms) == 1
+                if len(working_term.terms) != 1:
+                    raise ValueError('Qubit operator term needs to be a single term')
                 working_qubit = pauli_operator[0] - 1
                 for working_operator in reversed(list(working_term.terms)[0]):
                     if working_operator[0] <= working_qubit:

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
@@ -166,9 +166,7 @@ class ReverseJWTest(unittest.TestCase):
             'openfermion.transforms.opconversions.reverse_jordan_wigner.' 'QubitOperator.__mul__'
         ) as mock_mul:
             mock_mul.return_value = QubitOperator('X0') + QubitOperator('Y0')
-            with self.assertRaisesRegex(
-                ValueError, 'QubitOperator must contain exactly one term'
-            ):
+            with self.assertRaisesRegex(ValueError, 'QubitOperator must contain exactly one term'):
                 reverse_jordan_wigner(QubitOperator('X1'))
 
     def test_jw_convention(self):

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
@@ -167,7 +167,7 @@ class ReverseJWTest(unittest.TestCase):
         ) as mock_mul:
             mock_mul.return_value = QubitOperator('X0') + QubitOperator('Y0')
             with self.assertRaisesRegex(
-                ValueError, 'Qubit operator term needs to be a single term'
+                ValueError, 'QubitOperator must contain exactly one term'
             ):
                 reverse_jordan_wigner(QubitOperator('X1'))
 

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
@@ -162,11 +162,13 @@ class ReverseJWTest(unittest.TestCase):
             reverse_jordan_wigner(3)
 
     def test_reverse_jw_multi_term_error(self):
-        with patch('openfermion.transforms.opconversions.reverse_jordan_wigner.'
-                   'QubitOperator.__mul__') as mock_mul:
+        with patch(
+            'openfermion.transforms.opconversions.reverse_jordan_wigner.' 'QubitOperator.__mul__'
+        ) as mock_mul:
             mock_mul.return_value = QubitOperator('X0') + QubitOperator('Y0')
             with self.assertRaisesRegex(
-                    ValueError, 'Qubit operator term needs to be a single term'):
+                ValueError, 'Qubit operator term needs to be a single term'
+            ):
                 reverse_jordan_wigner(QubitOperator('X1'))
 
     def test_jw_convention(self):

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
@@ -166,7 +166,9 @@ class ReverseJWTest(unittest.TestCase):
             'openfermion.transforms.opconversions.reverse_jordan_wigner.' 'QubitOperator.__mul__'
         ) as mock_mul:
             mock_mul.return_value = QubitOperator('X0') + QubitOperator('Y0')
-            with self.assertRaisesRegex(ValueError, 'QubitOperator must contain exactly one term'):
+            with self.assertRaisesRegex(
+                ValueError, 'QubitOperator must contain exactly one term. Found 2 terms'
+            ):
                 reverse_jordan_wigner(QubitOperator('X1'))
 
     def test_jw_convention(self):

--- a/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
+++ b/src/openfermion/transforms/opconversions/reverse_jordan_wigner_test.py
@@ -12,6 +12,7 @@
 """Tests  reverse_jordan_wigner.py."""
 
 import unittest
+from unittest.mock import patch
 
 from openfermion.ops.operators import FermionOperator, QubitOperator
 from openfermion.transforms.opconversions import jordan_wigner, normal_ordered
@@ -159,6 +160,14 @@ class ReverseJWTest(unittest.TestCase):
     def test_bad_type(self):
         with self.assertRaises(TypeError):
             reverse_jordan_wigner(3)
+
+    def test_reverse_jw_multi_term_error(self):
+        with patch('openfermion.transforms.opconversions.reverse_jordan_wigner.'
+                   'QubitOperator.__mul__') as mock_mul:
+            mock_mul.return_value = QubitOperator('X0') + QubitOperator('Y0')
+            with self.assertRaisesRegex(
+                    ValueError, 'Qubit operator term needs to be a single term'):
+                reverse_jordan_wigner(QubitOperator('X1'))
 
     def test_jw_convention(self):
         """Test that the Jordan-Wigner convention places the Z-string on


### PR DESCRIPTION
Replace an `assert` in a non-test context with raising an exception.