### PR TITLE
Remove commented-out import in `binary_code.py`

### DIFF
--- a/src/openfermion/ops/operators/binary_code.py
+++ b/src/openfermion/ops/operators/binary_code.py
@@ -19,8 +19,6 @@ import scipy.sparse
 
 from openfermion.ops.operators import BinaryPolynomial
 
-# import openfermion.ops.operators._binary_polynomial as bp
-
 
 def shift_decoder(decoder, shift_constant):
     """Shifts the indices of a decoder by a constant.


### PR DESCRIPTION
Trivial code health cleanup: remove the unnecessary commented-out import of `_binary_polynomial` in `src/openfermion/ops/operators/binary_code.py.