### PR TITLE
Robustify the Pubchem live api pytest test

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -152,10 +152,7 @@ class OpenFermionPubChemTest(unittest.TestCase):
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=2)
+    @pytest.mark.flaky(retries=3, delay=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
-        try:
-            water_geometry = geometry_from_pubchem('water')  # pragma: no cover
-            self.assertEqual(len(water_geometry), 3)  # pragma: no cover
-        except pubchempy.ServerBusyError:  # pragma: no cover
-            pytest.skip('PubChem server is busy.')
+        water_geometry = geometry_from_pubchem('water')
+        self.assertEqual(len(water_geometry), 3)

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import numpy
 import pytest
+import pubchempy
 
 from openfermion.chem.pubchem import geometry_from_pubchem
 from openfermion.testing.testing_utils import module_importable

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -156,7 +156,5 @@ class OpenFermionPubChemTest(unittest.TestCase):
         try:
             water_geometry = geometry_from_pubchem('water')  # pragma: no cover
             self.assertEqual(len(water_geometry), 3)  # pragma: no cover
-        except Exception as e:  # pragma: no cover
-            if 'ServerBusyError' in type(e).__name__:
-                pytest.skip('PubChem API is busy.')
-            raise
+        except pubchempy.ServerBusyError:  # pragma: no cover
+            pytest.skip('PubChem server is busy.')

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -12,7 +12,6 @@
 
 """Tests for pubchem.py."""
 
-import time
 import unittest
 from unittest.mock import patch
 
@@ -154,5 +153,10 @@ class OpenFermionPubChemTest(unittest.TestCase):
 
     @pytest.mark.flaky(retries=3, delay=2)
     def test_geometry_from_pubchem_live_api(self):
-        water_geometry = geometry_from_pubchem('water')  # pragma: no cover
-        self.assertEqual(len(water_geometry), 3)  # pragma: no cover
+        try:
+            water_geometry = geometry_from_pubchem('water')  # pragma: no cover
+            self.assertEqual(len(water_geometry), 3)  # pragma: no cover
+        except Exception as e:  # pragma: no cover
+            if 'ServerBusyError' in type(e).__name__:
+                pytest.skip('PubChem API is busy.')
+            raise


### PR DESCRIPTION
The Pubchem server often returns a "server busy" error. The code in pubchem_test.py would retry the test in those situations (as desired), but it turned out that the error still got propagated up and cause pytest to report a failure.

This PR tries to make the test more robust against server busy errors.