### PR TITLE
Increase flaky test retry in `pubchem_test.py`

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -152,7 +152,7 @@ class OpenFermionPubChemTest(unittest.TestCase):
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=10, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         self.assertEqual(len(water_geometry), 3)


### PR DESCRIPTION
CI is still failing with server busy errors. Maybe the problem is the retries are happening too close together?