### PR TITLE
Increase the delay between PubChem retries

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=30, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=5, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=5, backoff=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=10, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3


### PR DESCRIPTION
The live API test still fails in CI. It ends up failing 4 times in a row:

```
test_geometry_from_pubchem_live_api failed on attempt 1! Retrying!
...
test_geometry_from_pubchem_live_api failed on attempt 2! Retrying!
...
test_geometry_from_pubchem_live_api failed on attempt 3! Retrying!
...
test_geometry_from_pubchem_live_api failed after 4 attempts!
```

Let's increase the retry delay.