### PR TITLE
Increase the delay between PubChem retries again

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=4, delay=15, backoff=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=4, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=30, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=5, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=20, backoff=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=4, delay=15, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=10, backoff=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=20, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=3, delay=5, backoff=2, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=3, delay=10, backoff=2, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3


### PR DESCRIPTION
The tests still fail during merges due to a server busy error. This increases the delay even more.