### PR TITLE
Increase number of retries for Pubchem test even more

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -149,7 +149,7 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=4, delay=30, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=8, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3


### PR DESCRIPTION
The Pubchem live api test in `src/openfermion/chem/pubchem_test.py` would still fail too frequently in CI. After finally finding a way to reproduce it locally, I tweaked the retries parameter for pytest so that it succeeds locally. That's not a guarantee it won't fail again in CI (because it depends on how busy the Pubchem server is at a given time), but the number of retries and delay now are so high that I haven't been able to get it to fail due to retries.

Approach to seeing retries in local testing:

```shell
pip install pytest-repeat
./check/pytest -n 4 --count=30 --repeat-scope=session  src/openfermion/chem/pubchem_test.py
```

The number of parallel threads in `-n` does not have to be 4 exactly, but lower numbers are less likely to trigger retries. The repeat count of 30 also can be a little bit lower, but at lower values, there's a higher chance that all tests will pass without retries (probably depending on the server load at the time).