### PR TITLE
Skip Pubchem live API test in CI

### DIFF
--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -78,7 +78,7 @@ using_pubchempy = pytest.mark.skipif(
 
 # Skip if running in a CI environment.
 skip_in_ci = pytest.mark.skipif(
-    os.environ.get('CI') == 'true',
+os.environ.get('CI'),
     reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
 )
 

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -158,7 +158,7 @@ class TestOpenFermionPubChem:
             _ = geometry_from_pubchem('water', structure='foo')
 
     @skip_in_ci
-    @pytest.mark.flaky(retries=4, delay=30, only_on=[pubchempy.ServerBusyError])
+    @pytest.mark.flaky(retries=8, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -78,7 +78,7 @@ using_pubchempy = pytest.mark.skipif(
 
 # Skip if running in a CI environment.
 skip_in_ci = pytest.mark.skipif(
-os.environ.get('CI'),
+    os.environ.get('CI'),
     reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
 )
 

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -76,12 +76,6 @@ using_pubchempy = pytest.mark.skipif(
     module_importable('pubchempy') is False, reason='Not detecting `pubchempy`.'
 )
 
-# Skip if running in a CI environment.
-skip_in_ci = pytest.mark.skipif(
-    'CI' in os.environ,
-    reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
-)
-
 
 @using_pubchempy
 class TestOpenFermionPubChem:
@@ -157,7 +151,11 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @skip_in_ci
+    # Skip if running in a CI environment.
+    @pytest.mark.skipif(
+        'CI' in os.environ,
+        reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
+    )
     @pytest.mark.flaky(retries=8, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -78,7 +78,7 @@ using_pubchempy = pytest.mark.skipif(
 
 # Skip if running in a CI environment.
 skip_in_ci = pytest.mark.skipif(
-    os.environ.get('CI'),
+    os.environ.get('CI', False) != False,
     reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
 )
 

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -12,9 +12,11 @@
 
 """Tests for pubchem.py."""
 
+import os
+
 import numpy
-import pytest
 import pubchempy
+import pytest
 
 from openfermion.chem.pubchem import geometry_from_pubchem
 from openfermion.testing.testing_utils import module_importable
@@ -72,6 +74,12 @@ def mock_get_compounds(name, searchtype, record_type='2d'):
 
 using_pubchempy = pytest.mark.skipif(
     module_importable('pubchempy') is False, reason='Not detecting `pubchempy`.'
+)
+
+# Skip if running in a CI environment.
+skip_in_ci = pytest.mark.skipif(
+    os.environ.get('CI') == 'true',
+    reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
 )
 
 
@@ -149,7 +157,8 @@ class TestOpenFermionPubChem:
         with pytest.raises(ValueError, match='Incorrect value for the argument structure'):
             _ = geometry_from_pubchem('water', structure='foo')
 
-    @pytest.mark.flaky(retries=8, delay=30, only_on=[pubchempy.ServerBusyError])
+    @skip_in_ci
+    @pytest.mark.flaky(retries=4, delay=30, only_on=[pubchempy.ServerBusyError])
     def test_geometry_from_pubchem_live_api(self):
         water_geometry = geometry_from_pubchem('water')
         assert len(water_geometry) == 3

--- a/src/openfermion/chem/pubchem_test.py
+++ b/src/openfermion/chem/pubchem_test.py
@@ -78,7 +78,7 @@ using_pubchempy = pytest.mark.skipif(
 
 # Skip if running in a CI environment.
 skip_in_ci = pytest.mark.skipif(
-    os.environ.get('CI', False) != False,
+    'CI' in os.environ,
     reason='Skipping Pubchem API tests in CI to avoid failures due to busy servers.',
 )
 


### PR DESCRIPTION
Even with many retries and long delays, the test fails for almost every PR. I don't know why this has been happening lately; perhaps Pubchem's servers have become overloaded lately (possibly due to an increase in the use of AI agents?). In any case, there seems to be no good solution to stop flaky failures in CI except to simply skip the test in CI.

The approach implemented here tests an environment variable set by GitHub in their runner environments. If that variable is set, the live API test is skipped; otherwise, it's run as usual. This means that developers in their normal local environments will run the tests as usual, and don't have to do anything special. In addition, our CI workflows don't need to change either.