### PR TITLE
Fix typo in property name in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.black]
 line-length = 100
-target_version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313']
 skip-string-normalization = true
 skip-magic-trailing-comma = true
 


### PR DESCRIPTION
Fix silly typo in the section for Black: `target_version` → `target-version`.