### PR TITLE
Add missing Python type annotations to code in `dev_tools/`

### DIFF
--- a/dev_tools/check_incremental_coverage_annotations.py
+++ b/dev_tools/check_incremental_coverage_annotations.py
@@ -22,7 +22,7 @@ from dev_tools import prepared_env, shell_tools
 from dev_tools.incremental_coverage import check_for_uncovered_lines
 
 
-def main():
+def main() -> None:
     if len(sys.argv) < 2:
         print(
             shell_tools.highlight(

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -15,6 +15,7 @@
 """Tool to generate external api_docs for OF (Shameless copy from TFQ)."""
 
 import os
+from typing import Any
 
 from absl import app
 from absl import flags
@@ -39,7 +40,7 @@ flags.DEFINE_string("site_path", "/reference/python/openfermion", "Path prefix i
 FLAGS = flags.FLAGS
 
 
-def main(unused_argv):
+def main(unused_argv: Any) -> None:
 
     doc_generator = generate_lib.DocGenerator(
         root_title="OpenFermion",

--- a/dev_tools/env_tools.py
+++ b/dev_tools/env_tools.py
@@ -68,7 +68,7 @@ def prepare_temporary_test_environment(
     verbose: bool,
     env_name: str = '.test_virtualenv',
     python_path: str = sys.executable,
-    commit_ids_known_callback: Callable[[PreparedEnv], None] = None,
+    commit_ids_known_callback: Optional[Callable[[PreparedEnv], None]] = None,
 ) -> PreparedEnv:
     """Prepares a temporary test environment at the (existing empty) directory.
 

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -109,7 +109,7 @@ def diff_to_new_interesting_lines(unified_diff_lines: List[str]) -> Dict[int, st
     return interesting_lines
 
 
-def fix_line_from_coverage_file(line):
+def fix_line_from_coverage_file(line: str) -> str:
     line = line.rstrip()
     if line.startswith('!'):
         line = line[1:]

--- a/dev_tools/incremental_coverage_test.py
+++ b/dev_tools/incremental_coverage_test.py
@@ -15,7 +15,7 @@
 from dev_tools import incremental_coverage
 
 
-def test_determine_ignored_lines():
+def test_determine_ignored_lines() -> None:
     f = incremental_coverage.determine_ignored_lines
 
     assert f("a = 0  # coverage: ignore") == {1}

--- a/dev_tools/prepared_env.py
+++ b/dev_tools/prepared_env.py
@@ -65,7 +65,7 @@ class PreparedEnv:
 
     def report_status_to_github(
         self, state: str, description: str, context: str, target_url: Optional[str] = None
-    ):
+    ) -> None:
         """Sets a commit status indicator on github.
 
         If not running from a pull request (i.e. repository is None), then this

--- a/dev_tools/prepared_env_security_test.py
+++ b/dev_tools/prepared_env_security_test.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 from unittest.mock import patch, MagicMock
 from dev_tools.prepared_env import PreparedEnv
 from dev_tools.github_repository import GithubRepository
@@ -6,7 +7,7 @@ from dev_tools.github_repository import GithubRepository
 
 class TestPreparedEnvSecurity(unittest.TestCase):
     @patch('requests.post')
-    def test_report_status_to_github_token_in_header(self, mock_post):
+    def test_report_status_to_github_token_in_header(self, mock_post: Any) -> None:
         # Setup
         mock_response = MagicMock()
         mock_response.status_code = 201

--- a/dev_tools/requirements/run-pip-compiles.py
+++ b/dev_tools/requirements/run-pip-compiles.py
@@ -40,7 +40,7 @@ import os
 import subprocess
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
-from typing import *
+from typing import Any, Dict, Set
 
 
 @dataclass
@@ -83,7 +83,7 @@ PLATFORMS = {
 }
 
 
-def run(*args: Any) -> subprocess.CompletedProcess:
+def run(*args: Any) -> subprocess.CompletedProcess[Any]:
     """Run a command using `subprocess`."""
     return subprocess.run(*args, check=True)
 

--- a/dev_tools/requirements/run-pip-compiles.py
+++ b/dev_tools/requirements/run-pip-compiles.py
@@ -83,12 +83,12 @@ PLATFORMS = {
 }
 
 
-def run(*args):
+def run(*args: Any) -> subprocess.CompletedProcess:
     """Run a command using `subprocess`."""
     return subprocess.run(*args, check=True)
 
 
-def pip_compile(env_name: str, env_recipe: EnvRecipe, env_out_dir: str, constrain=True):
+def pip_compile(env_name: str, env_recipe: EnvRecipe, env_out_dir: str, constrain: bool = True) -> None:
     """Run `pip-compile` to create the named environment."""
     dep_args = [f"deps/{dep_name}.txt" for dep_name in env_recipe.deps]
     dep_args += [f"--constraint=deps/{cons_name}.txt" for cons_name in env_recipe.addtl_constraints]
@@ -115,7 +115,7 @@ def get_dev_env_recipe(pr: PlatformRecipe) -> EnvRecipe:
     return EnvRecipe(all_deps, all_addtl_constraints)
 
 
-def make_platform_envs(pr: PlatformRecipe):
+def make_platform_envs(pr: PlatformRecipe) -> None:
     os.makedirs(pr.env_out_dir, exist_ok=True)
 
     # Pip compile the full dev environment
@@ -126,7 +126,7 @@ def make_platform_envs(pr: PlatformRecipe):
         pip_compile(env_name, env_recipe, pr.env_out_dir)
 
 
-def parse():
+def parse() -> None:
     """Parse command line arguments."""
     parser = ArgumentParser()
     parser.add_argument("--platform", default="default")
@@ -136,7 +136,7 @@ def parse():
     except KeyError:
         raise ValueError(f"Unknown platform {args.platform}")
 
-    return make_platform_envs(platform)
+    make_platform_envs(platform)
 
 
 if __name__ == "__main__":

--- a/dev_tools/requirements/run-pip-compiles.py
+++ b/dev_tools/requirements/run-pip-compiles.py
@@ -88,7 +88,9 @@ def run(*args: Any) -> subprocess.CompletedProcess:
     return subprocess.run(*args, check=True)
 
 
-def pip_compile(env_name: str, env_recipe: EnvRecipe, env_out_dir: str, constrain: bool = True) -> None:
+def pip_compile(
+    env_name: str, env_recipe: EnvRecipe, env_out_dir: str, constrain: bool = True
+) -> None:
     """Run `pip-compile` to create the named environment."""
     dep_args = [f"deps/{dep_name}.txt" for dep_name in env_recipe.deps]
     dep_args += [f"--constraint=deps/{cons_name}.txt" for cons_name in env_recipe.addtl_constraints]

--- a/dev_tools/requirements/run-pip-compiles.py
+++ b/dev_tools/requirements/run-pip-compiles.py
@@ -83,7 +83,7 @@ PLATFORMS = {
 }
 
 
-def run(*args: Any) -> subprocess.CompletedProcess[Any]:
+def run(*args: Any) -> subprocess.CompletedProcess:
     """Run a command using `subprocess`."""
     return subprocess.run(*args, check=True)
 

--- a/dev_tools/shell_tools.py
+++ b/dev_tools/shell_tools.py
@@ -124,7 +124,7 @@ def run_cmd(
     raise_on_fail: bool = True,
     log_run_to_stderr: bool = True,
     abbreviate_non_option_arguments: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> CommandOutput:
     """Invokes a subprocess and waits for it to finish.
 
@@ -204,7 +204,7 @@ def run_shell(
     err: Optional[Union[TeeCapture, IO[str]]] = sys.stderr,
     raise_on_fail: bool = True,
     log_run_to_stderr: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> CommandOutput:
     """Invokes a shell command and waits for it to finish.
 
@@ -267,7 +267,7 @@ def run_shell(
     return result
 
 
-def output_of(*cmd: Optional[str], **kwargs) -> str:
+def output_of(*cmd: Optional[str], **kwargs: Any) -> str:
     """Invokes a subprocess and returns its output as a string.
 
     Args:
@@ -276,9 +276,7 @@ def output_of(*cmd: Optional[str], **kwargs) -> str:
             a cwd (current working directory) argument.
 
     Returns:
-        A (captured output, captured error output, return code) triplet. The
-        captured outputs will be None if the out or err parameters were not set
-        to an instance of TeeCapture.
+        The output of the command.
 
     Raises:
          subprocess.CalledProcessError: The process returned a non-zero error

--- a/dev_tools/shell_tools_test.py
+++ b/dev_tools/shell_tools_test.py
@@ -14,28 +14,29 @@
 
 import subprocess
 import os
+from typing import Any, Callable, Optional
 
 import pytest
 
 from dev_tools import shell_tools
 
 
-def only_on_posix(func):
+def only_on_posix(func: Callable) -> Optional[Callable]:
     if os.name != 'posix':
         return None
     return func
 
 
-def run_cmd(*args, **kwargs):
+def run_cmd(*args: Any, **kwargs: Any) -> shell_tools.CommandOutput:
     return shell_tools.run_cmd(*args, log_run_to_stderr=False, **kwargs)
 
 
-def run_shell(*args, **kwargs):
+def run_shell(*args: Any, **kwargs: Any) -> shell_tools.CommandOutput:
     return shell_tools.run_shell(*args, log_run_to_stderr=False, **kwargs)
 
 
 @only_on_posix
-def test_run_cmd_raise_on_fail():
+def test_run_cmd_raise_on_fail() -> None:
     assert run_cmd('true') == (None, None, 0)
     assert run_cmd('true', raise_on_fail=False) == (None, None, 0)
 
@@ -45,7 +46,7 @@ def test_run_cmd_raise_on_fail():
 
 
 @only_on_posix
-def test_run_shell_raise_on_fail():
+def test_run_shell_raise_on_fail() -> None:
     assert run_shell('true') == (None, None, 0)
     assert run_shell('true', raise_on_fail=False) == (None, None, 0)
 
@@ -55,21 +56,21 @@ def test_run_shell_raise_on_fail():
 
 
 @only_on_posix
-def test_run_cmd_capture():
+def test_run_cmd_capture() -> None:
     assert run_cmd('echo', 'test', out=None) == (None, None, 0)
     assert run_cmd('echo', 'test', out=shell_tools.TeeCapture()) == ('test\n', None, 0)
     assert run_cmd('echo', 'test', out=None, err=shell_tools.TeeCapture()) == (None, '', 0)
 
 
 @only_on_posix
-def test_run_shell_capture():
+def test_run_shell_capture() -> None:
     assert run_shell('echo test 1>&2', err=None) == (None, None, 0)
     assert run_shell('echo test 1>&2', err=shell_tools.TeeCapture()) == (None, 'test\n', 0)
     assert run_shell('echo test 1>&2', err=None, out=shell_tools.TeeCapture()) == ('', None, 0)
 
 
 @only_on_posix
-def test_run_shell_does_not_deadlock_on_large_outputs():
+def test_run_shell_does_not_deadlock_on_large_outputs() -> None:
     assert run_shell(
         r"""python3 -c "import sys;"""
         r"""print((('o' * 99) + '\n') * 10000);"""
@@ -81,7 +82,7 @@ def test_run_shell_does_not_deadlock_on_large_outputs():
 
 
 @only_on_posix
-def test_output_of():
+def test_output_of() -> None:
     assert shell_tools.output_of('true') == ''
     with pytest.raises(subprocess.CalledProcessError):
         _ = shell_tools.output_of('false')


### PR DESCRIPTION
This adds type annotations where they were missing in some files under `dev_tools/`. This is limited in scope and was done partly to experiment with using Gemini CLI to do such tasks.

This partly addresses #1282.