### PR TITLE
Update some requirements to their latest versions

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -4,7 +4,7 @@ h5py>=3.10.0
 networkx
 numpy>=1.26
 pubchempy
-requests~=2.33.1
+requests~=2.34.0
 
 scipy~=1.15
 

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -6,7 +6,7 @@
 #
 ase==3.28.0
     # via -r deps/resource_estimates_runtime.txt
-ast-serialize==0.4.0
+ast-serialize==0.5.0
     # via mypy
 astroid==3.3.11
     # via pylint
@@ -19,17 +19,17 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     # via
     #   -r deps/runtime.txt
     #   pytest-asyncio
-black==26.3.1
+black==26.5.1
     # via -r deps/format.txt
 build==1.5.0
     # via pip-tools
-certifi==2026.4.22
+certifi==2026.5.20
     # via requests
 charset-normalizer==3.4.7
     # via requests
 cirq-core==1.5.0
     # via -r deps/runtime.txt
-click==8.3.3
+click==8.4.1
     # via
     #   black
     #   pip-tools
@@ -37,7 +37,7 @@ contourpy==1.3.2
     # via
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -59,7 +59,7 @@ h5py==3.16.0
     # via
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.15
+idna==3.17
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -143,7 +143,7 @@ pillow==12.2.0
     # via matplotlib
 pip-tools==7.5.3
     # via -r deps/pip-tools.txt
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   black
     #   jupyter-core
@@ -174,7 +174,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via -r deps/pytest.txt
 pytest-cov==7.1.0
     # via -r deps/pytest.txt
@@ -235,13 +235,13 @@ traitlets==5.15.0
     # via
     #   jupyter-core
     #   nbformat
-types-networkx==3.6.1.20260513
+types-networkx==3.6.1.20260518
     # via -r deps/mypy.txt
-types-pytz==2026.2.0.20260506
+types-pytz==2026.2.0.20260518
     # via pandas-stubs
-types-requests==2.33.0.20260513
+types-requests==2.33.0.20260518
     # via -r deps/mypy.txt
-types-setuptools==82.0.0.20260508
+types-setuptools==82.0.0.20260518
     # via -r deps/mypy.txt
 typing-extensions==4.15.0
     # via

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -6,6 +6,8 @@
 #
 ase==3.28.0
     # via -r deps/resource_estimates_runtime.txt
+ast-serialize==0.4.0
+    # via mypy
 astroid==3.3.11
     # via pylint
 attrs==26.1.0
@@ -19,7 +21,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     #   pytest-asyncio
 black==26.3.1
     # via -r deps/format.txt
-build==1.4.4
+build==1.5.0
     # via pip-tools
 certifi==2026.4.22
     # via requests
@@ -35,7 +37,7 @@ contourpy==1.3.2
     # via
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -51,13 +53,13 @@ execnet==2.1.2
     # via pytest-xdist
 fastjsonschema==2.21.2
     # via nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
 h5py==3.16.0
     # via
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.13
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -77,7 +79,7 @@ jupyter-core==5.9.1
     # via nbformat
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.9.0
+librt==0.11.0
     # via mypy
 matplotlib==3.10.9
     # via
@@ -91,7 +93,7 @@ ml-dtypes==0.5.4
     #   jaxlib
 mpmath==1.3.0
     # via sympy
-mypy==1.20.2
+mypy==2.1.0
     # via -r deps/mypy.txt
 mypy-extensions==1.1.0
     # via
@@ -188,13 +190,13 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytokens==0.4.1
     # via black
-pytz==2026.1.post1
+pytz==2026.2
     # via pandas
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via -r deps/runtime.txt
 rpds-py==0.30.0
     # via
@@ -225,21 +227,21 @@ tomli==2.4.1
     #   pip-tools
     #   pylint
     #   pytest
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via pylint
 tqdm==4.67.3
     # via cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   jupyter-core
     #   nbformat
-types-networkx==3.6.1.20260408
+types-networkx==3.6.1.20260513
     # via -r deps/mypy.txt
-types-pytz==2026.1.1.20260408
+types-pytz==2026.2.0.20260506
     # via pandas-stubs
-types-requests==2.33.0.20260408
+types-requests==2.33.0.20260513
     # via -r deps/mypy.txt
-types-setuptools==82.0.0.20260408
+types-setuptools==82.0.0.20260508
     # via -r deps/mypy.txt
 typing-extensions==4.15.0
     # via
@@ -252,7 +254,7 @@ typing-extensions==4.15.0
     #   referencing
 tzdata==2026.2
     # via pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   requests
     #   types-requests

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -49,7 +49,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -57,7 +57,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.13
+idna==3.15
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -131,11 +131,11 @@ pytokens==0.4.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -174,7 +174,7 @@ tzdata==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -12,11 +12,11 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-black==26.3.1
+black==26.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -28,7 +28,7 @@ cirq-core==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-click==8.3.3
+click==8.4.1
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -57,7 +57,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.15
+idna==3.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -110,7 +110,7 @@ pillow==12.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   -c envs/dev.env.txt
     #   black

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/mypy.env.txt deps/mypy.txt deps/runtime.txt
 #
+ast-serialize==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   mypy
 attrs==26.1.0
     # via
     #   -c envs/dev.env.txt
@@ -41,7 +45,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -49,7 +53,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.13
+idna==3.15
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -57,7 +61,7 @@ kiwisolver==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-librt==0.9.0
+librt==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   mypy
@@ -69,7 +73,7 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-mypy==1.20.2
+mypy==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
@@ -128,11 +132,11 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -162,19 +166,19 @@ tqdm==4.67.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-types-networkx==3.6.1.20260408
+types-networkx==3.6.1.20260513
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-pytz==2026.1.1.20260408
+types-pytz==2026.2.0.20260506
     # via
     #   -c envs/dev.env.txt
     #   pandas-stubs
-types-requests==2.33.0.20260408
+types-requests==2.33.0.20260513
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-setuptools==82.0.0.20260408
+types-setuptools==82.0.0.20260508
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
@@ -187,7 +191,7 @@ tzdata==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/mypy.env.txt
+++ b/dev_tools/requirements/envs/mypy.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/mypy.env.txt deps/mypy.txt deps/runtime.txt
 #
-ast-serialize==0.4.0
+ast-serialize==0.5.0
     # via
     #   -c envs/dev.env.txt
     #   mypy
@@ -16,7 +16,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -53,7 +53,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.15
+idna==3.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -166,19 +166,19 @@ tqdm==4.67.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-types-networkx==3.6.1.20260513
+types-networkx==3.6.1.20260518
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-pytz==2026.2.0.20260506
+types-pytz==2026.2.0.20260518
     # via
     #   -c envs/dev.env.txt
     #   pandas-stubs
-types-requests==2.33.0.20260513
+types-requests==2.33.0.20260518
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt
-types-setuptools==82.0.0.20260508
+types-setuptools==82.0.0.20260518
     # via
     #   -c envs/dev.env.txt
     #   -r deps/mypy.txt

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pip-tools.env.txt deps/pip-tools.txt
 #
-build==1.4.4
+build==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -8,7 +8,7 @@ build==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pip-tools
-click==8.3.3
+click==8.4.1
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -40,7 +40,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -72,7 +72,7 @@ fastjsonschema==2.21.2
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -81,7 +81,7 @@ h5py==3.16.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.13
+idna==3.15
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -242,7 +242,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -251,7 +251,7 @@ referencing==0.37.0
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -288,7 +288,7 @@ tomli==2.4.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -296,7 +296,7 @@ tqdm==4.67.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -313,7 +313,7 @@ tzdata==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -23,7 +23,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pytest-asyncio
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -40,7 +40,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -81,7 +81,7 @@ h5py==3.16.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.15
+idna==3.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -178,7 +178,7 @@ pillow==12.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -217,7 +217,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -36,7 +36,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -64,7 +64,7 @@ fastjsonschema==2.21.2
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -73,7 +73,7 @@ h5py==3.16.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.13
+idna==3.15
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -221,7 +221,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -230,7 +230,7 @@ referencing==0.37.0
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -270,7 +270,7 @@ tqdm==4.67.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -286,7 +286,7 @@ tzdata==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest-extra.env.txt
+++ b/dev_tools/requirements/envs/pytest-extra.env.txt
@@ -19,7 +19,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pytest-asyncio
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -36,7 +36,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -73,7 +73,7 @@ h5py==3.16.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pyscf
-idna==3.15
+idna==3.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -162,7 +162,7 @@ pillow==12.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -196,7 +196,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -32,7 +32,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -60,7 +60,7 @@ fastjsonschema==2.21.2
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -68,7 +68,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.13
+idna==3.15
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -188,7 +188,7 @@ python-dateutil==2.9.0.post0
     #   -c envs/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -197,7 +197,7 @@ referencing==0.37.0
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -233,7 +233,7 @@ tqdm==4.67.3
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -249,7 +249,7 @@ tzdata==2026.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -15,7 +15,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pytest-asyncio
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -32,7 +32,7 @@ contourpy==1.3.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -68,7 +68,7 @@ h5py==3.16.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.15
+idna==3.17
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -133,7 +133,7 @@ pillow==12.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -163,7 +163,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt

--- a/dev_tools/requirements/max_compat/dev.env.txt
+++ b/dev_tools/requirements/max_compat/dev.env.txt
@@ -13,7 +13,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     # via
     #   -r deps/runtime.txt
     #   pytest-asyncio
-certifi==2026.4.22
+certifi==2026.5.20
     # via requests
 charset-normalizer==3.4.7
     # via requests
@@ -25,7 +25,7 @@ contourpy==1.3.2
     # via
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -43,7 +43,7 @@ fonttools==4.63.0
     # via matplotlib
 h5py==3.16.0
     # via -r deps/runtime.txt
-idna==3.15
+idna==3.17
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -83,7 +83,7 @@ pandas==2.3.3
     # via cirq-core
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via jupyter-core
 pluggy==1.6.0
     # via
@@ -103,7 +103,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via -r deps/pytest.txt
 pytest-cov==7.1.0
     # via -r deps/pytest.txt

--- a/dev_tools/requirements/max_compat/dev.env.txt
+++ b/dev_tools/requirements/max_compat/dev.env.txt
@@ -25,7 +25,7 @@ contourpy==1.3.2
     # via
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -39,11 +39,11 @@ execnet==2.1.2
     # via pytest-xdist
 fastjsonschema==2.21.2
     # via nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
 h5py==3.16.0
     # via -r deps/runtime.txt
-idna==3.13
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -117,13 +117,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via pandas
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via -r deps/runtime.txt
 rpds-py==0.30.0
     # via
@@ -147,7 +147,7 @@ tomli==2.4.1
     #   pytest
 tqdm==4.67.3
     # via cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   jupyter-core
     #   nbformat
@@ -159,5 +159,5 @@ typing-extensions==4.15.0
     #   referencing
 tzdata==2026.2
     # via pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests

--- a/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
+++ b/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
@@ -33,7 +33,7 @@ contourpy==1.3.2
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via
     #   -c max_compat/dev.env.txt
     #   pytest-cov
@@ -61,7 +61,7 @@ fastjsonschema==2.21.2
     # via
     #   -c max_compat/dev.env.txt
     #   nbformat
-fonttools==4.62.1
+fonttools==4.63.0
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
@@ -69,7 +69,7 @@ h5py==3.16.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.13
+idna==3.15
     # via
     #   -c max_compat/dev.env.txt
     #   requests
@@ -189,7 +189,7 @@ python-dateutil==2.9.0.post0
     #   -c max_compat/dev.env.txt
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
@@ -198,7 +198,7 @@ referencing==0.37.0
     #   -c max_compat/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
@@ -234,7 +234,7 @@ tqdm==4.67.3
     # via
     #   -c max_compat/dev.env.txt
     #   cirq-core
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   -c max_compat/dev.env.txt
     #   jupyter-core
@@ -250,7 +250,7 @@ tzdata==2026.2
     # via
     #   -c max_compat/dev.env.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c max_compat/dev.env.txt
     #   requests

--- a/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
+++ b/dev_tools/requirements/max_compat/pytest-max-compat.env.txt
@@ -15,7 +15,7 @@ backports-asyncio-runner==1.2.0 ; python_full_version < "3.11"
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
     #   pytest-asyncio
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   -c max_compat/dev.env.txt
     #   requests
@@ -33,7 +33,7 @@ contourpy==1.3.2
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
     #   matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via
     #   -c max_compat/dev.env.txt
     #   pytest-cov
@@ -69,7 +69,7 @@ h5py==3.16.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/runtime.txt
-idna==3.15
+idna==3.17
     # via
     #   -c max_compat/dev.env.txt
     #   requests
@@ -134,7 +134,7 @@ pillow==12.2.0
     # via
     #   -c max_compat/dev.env.txt
     #   matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   -c max_compat/dev.env.txt
     #   jupyter-core
@@ -164,7 +164,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-retry
     #   pytest-xdist
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via
     #   -c max_compat/dev.env.txt
     #   -r deps/pytest.txt


### PR DESCRIPTION
This replaces the recent Dependabot PRs

* https://github.com/quantumlib/OpenFermion/pull/1305
* https://github.com/quantumlib/OpenFermion/pull/1303
* https://github.com/quantumlib/OpenFermion/pull/1302

with a single PR that also updates all the transitive dependencies by running the re-pip-compile script.