### PR TITLE
Use `python3` as interpreter instead of `python`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
           cache-dependency-path: ${{env.python_dep_files}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         env:
@@ -214,7 +214,7 @@ jobs:
           cache-dependency-path: ${{env.python_dep_files}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         run: |
@@ -249,7 +249,7 @@ jobs:
           cache-dependency-path: ${{env.python_dep_files}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         run: |
@@ -280,7 +280,7 @@ jobs:
           python-version: ${{env.python_compat_ver}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         run: pip install -r dev_tools/requirements/max_compat/pytest-max-compat.env.txt
@@ -310,7 +310,7 @@ jobs:
           cache-dependency-path: ${{env.python_dep_files}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         run: pip install -r dev_tools/requirements/envs/pytest.env.txt
@@ -441,7 +441,7 @@ jobs:
           cache-dependency-path: ${{env.python_dep_files}}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install requirements
         run: pip install -r dev_tools/requirements/envs/pytest.env.txt

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To install the latest version of OpenFermion in development mode, run the follow
 ```shell
 git clone https://github.com/quantumlib/OpenFermion
 cd OpenFermion
-python -m pip install -e .
+python3 -m pip install -e .
 ```
 
 ## Plugins

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -75,7 +75,7 @@ check/pytest . \
 pytest_result=$?
 
 # Analyze coverage files.
-PYTHONPATH="$(pwd)" python dev_tools/check_incremental_coverage_annotations.py "${rev}"
+PYTHONPATH="$(pwd)" python3 dev_tools/check_incremental_coverage_annotations.py "${rev}"
 cover_result=$?
 
 # Clean up generated coverage files.

--- a/dev_tools/check_incremental_coverage_annotations.py
+++ b/dev_tools/check_incremental_coverage_annotations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018 Google LLC
 #

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -90,6 +90,6 @@ fi
 
 # Python wheel.
 echo -e "${GREEN}Producing Python package files...${RESET}"
-python -m build --outdir "$out_dir"
+python3 -m build --outdir "$out_dir"
 
 echo -e "${GREEN}Finished – output is in $out_dir${RESET}"

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -64,7 +64,7 @@ PYTHON_VERSION=python3
 RUNTIME_DEPS_FILE="${REPO_ROOT}/dev_tools/requirements/envs/pytest.env.txt"
 echo "Working in a fresh virtualenv at ${tmp_dir}/${PYTHON_VERSION}"
 virtualenv --quiet "${tmp_dir}/${PYTHON_VERSION}"
-"${tmp_dir}/${PYTHON_VERSION}/bin/python" -m pip install --quiet --upgrade pip
+"${tmp_dir}/${PYTHON_VERSION}/bin/python3" -m pip install --quiet --upgrade pip
 
 # Install package.
 if [ "${PYPI_REPO_NAME}" == "TEST" ]; then
@@ -76,8 +76,8 @@ echo Installing "${PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi
 
 # Check that code runs without dev deps.
 echo Checking that code executes
-"${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import openfermion; print(openfermion.FermionOperator((1, 1)))"
-"${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import openfermion; print(openfermion.QubitOperator((1, 'X')))"
+"${tmp_dir}/${PYTHON_VERSION}/bin/python3" -c "import openfermion; print(openfermion.FermionOperator((1, 1)))"
+"${tmp_dir}/${PYTHON_VERSION}/bin/python3" -c "import openfermion; print(openfermion.QubitOperator((1, 'X')))"
 
 # Run basic tests.
 echo Installing Pytest

--- a/dev_tools/requirements/Dockerfile
+++ b/dev_tools/requirements/Dockerfile
@@ -29,4 +29,4 @@ COPY deps/ ./deps/
 COPY run-pip-compiles.py ./
 
 ARG PLATFORM="default"
-RUN python run-pip-compiles.py --platform $PLATFORM
+RUN python3 run-pip-compiles.py --platform $PLATFORM


### PR DESCRIPTION
Style guidances and our own experiences with Python portability are such that invocations of `python` should be changed to use `python3`.