### PR TITLE
Revise `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,5 +37,8 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
+[*.rst]
+indent_size = 3
+
 [{*.yaml,*.yml,*.cff}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,53 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Common editor configurations for this project.
-#
-# EditorConfig is a file format for specifying some common style parameters.
-# Many IDEs & editors read .editorconfig files, either natively or via plugins.
-# We mostly follow Google's style guides (https://google.github.io/styleguide/)
-# with only a few deviations for line length and indentation in some files.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 root = true
 
+# We mostly follow Google's style guides (https://google.github.io/styleguide/)
+# but prefer using 100 columns and 4-space indentation for most file types.
+
+# IMPORTANT: some of the other config files & entries in pyproject.toml have
+# the same settings and need to be updated if changes are made to this file.
 [*]
 charset = utf-8
+indent_size = 4
 indent_style = space
 insert_final_newline = true
+max_line_length = 100
 spelling_language = en-US
 trim_trailing_whitespace = true
-max_line_length = 100
 
-[{BUILD,*.BUILD,*.bzl,*.bazel,.bazelrc}]
-# Google doesn't have a style guideline for Bazel files. Most people use 4.
-indent_size = 4
-
-[{*.cc,*.h}]
-# Google style guidelines use 2.
-indent_size = 2
+[{COMMIT_EDITMSG,MERGE_MSG,SQUASH_MSG,TAG_EDITMSG}]
+max_line_length = 72
 
 [{*.js,*.ts}]
-# Google style guidelines use 2.
 indent_size = 2
 
 [*.json]
-# Not stated explicitly in Google's guidelines, but the examples use 2.
 indent_size = 2
 
-[*.py]
-# Google style guidelines use 4.
-indent_size = 4
-
-[*.rst]
-# Google doesn't have a style guideline for reStructuredText. Many people use 3.
-indent_size = 3
-
-[*.sh]
-# Google style guidelines use 2.
-indent_size = 4
-
-[{*.yaml,*.yml}]
-# Google doesn't have style guidelines for YAML. Most people use indent = 2.
+[{*.yaml,*.yml,*.cff}]
 indent_size = 2


### PR DESCRIPTION
This overhauls the `.editorconfig` file:

* Flip the way indent sizes are specified: use a global default of `indent_size`, and only list exceptions for different file types, instead of having no global default and needing to specify a value for every file type present in the repo. This simplifies the file and is more maintainable.

* Add entries for some `.git/` files such as `COMMIT_EDITMSG`.

* Streamline comments.