### PR TITLE
Remove downloads badge from top-level `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Electronic structure package for quantum computers.
 [![Compatible with Python versions 3.10 and higher](https://img.shields.io/badge/Python-3.10+-fcbc2c.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![Licensed under the Apache 2.0 license](https://img.shields.io/badge/License-Apache%202.0-3c60b1.svg?logo=opensourceinitiative&logoColor=white&style=flat-square)](https://github.com/quantumlib/OpenFermion/blob/main/LICENSE)
 [![OpenFermion project on PyPI](https://img.shields.io/pypi/v/OpenFermion.svg?logo=semantic-release&logoColor=white&label=Release&style=flat-square&color=fcbc2c)](https://pypi.org/project/OpenFermion)
-[![OpenFermion downloads per month from PyPI](https://img.shields.io/pypi/dm/openfermion?logo=PyPI&color=d56420&logoColor=white&style=flat-square&label=Downloads)](https://img.shields.io/pypi/dm/OpenFermion)
 
 [Features](#features) &ndash;
 [Installation](#installation) &ndash;


### PR DESCRIPTION
The Downloads badge at the top of our README file has lately displayed the message "rate limited by upstream service". This has been going on long enough that it leaves no confidence it will improve. The badge is nonessential eye candy and it is not worth the maintenance cost, so let's just remove it.