### PR TITLE
Fix PyPI README rendering metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,6 @@ Copyright 2017 The OpenFermion Developers.
 <div align="center">
   <a href="https://quantumai.google">
     <img width="15%" alt="Google Quantum AI"
-         src="https://raw.githubusercontent.com/quantumlib/OpenFermion/refs/heads/main/docs/images/quantum-ai-vertical.svg">
+         src="https://raw.githubusercontent.com/quantumlib/OpenFermion/main/docs/images/quantum-ai-vertical.svg">
   </a>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     maintainer_email='quantum-oss-maintainers@google.com',
     description=('The electronic structure package for quantum computers.'),
     long_description=long_description,
+    long_description_content_type='text/markdown',
     python_requires='>=3.10.0',
     install_requires=requirements,
     extras_require={'resources': resource_requirements},


### PR DESCRIPTION
Fixes #1317.

This fixes the PyPI README rendering metadata and uses the canonical raw GitHub URL for the Quantum AI logo image.

Changes:
- Declares `long_description_content_type='text/markdown'` so PyPI renders the README as Markdown/HTML instead of plain text.
- Replaces the `refs/heads/main` raw image URL with the canonical `/main/` raw URL.

Validation:
- `python -m build --sdist --wheel` from isolated venv `C:\hades\oss\.venvs\openfermion-1317`
- `python -m twine check dist\*`
- Verified generated metadata includes `Description-Content-Type: text/markdown`

Note: build emitted an existing setuptools license-classifier deprecation warning unrelated to this change.