### PR TITLE
Fix QASM Pauli exponential Rz angle

### DIFF
--- a/src/openfermion/circuits/trotter_exp_to_qgates.py
+++ b/src/openfermion/circuits/trotter_exp_to_qgates.py
@@ -255,7 +255,9 @@ def pauli_exp_to_qasm(qubit_operator_list, evolution_time=1.0, qubit_list=None, 
                     ]
             else:
                 if len(qids) > 0:
-                    ret_list = ret_list + ["Rz {} {}".format(term_coeff * evolution_time, qids[-1])]
+                    ret_list = ret_list + [
+                        "Rz {} {}".format(2 * term_coeff * evolution_time, qids[-1])
+                    ]
 
             # 4. Second set of CNOTs
             ret_list = ret_list + cnots2

--- a/src/openfermion/circuits/trotter_exp_to_qgates_test.py
+++ b/src/openfermion/circuits/trotter_exp_to_qgates_test.py
@@ -210,10 +210,15 @@ class TrottQasmTest(unittest.TestCase):
         # Correct string
         strcorrect = '''5
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4'''
 
         self.assertEqual(qasmstr, strcorrect)
+
+    def test_pauli_exp_to_qasm_uses_rz_angle_for_exp_minus_i_theta_z(self):
+        qasmstr = "\n".join(pauli_exp_to_qasm([QubitOperator('Z0', 0.5)], evolution_time=3))
+
+        self.assertEqual(qasmstr, 'Rz 3.0 0')
 
     def test_qasm_string_XYZ(self):
         # Testing for correct QASM string output w/ Pauli-{X,Y,Z}
@@ -231,7 +236,7 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -329,13 +334,13 @@ Rz 1.0 ancilla'''
         # the order in which the operators loop.
         strcorrect1 = '''5
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4
 H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -346,13 +351,13 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
 Rx -1.5707963267948966 3
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4'''
         try:
             self.assertEqual(qasmstr, strcorrect1)


### PR DESCRIPTION
Fixes #721.

## Summary
- doubles the uncontrolled `Rz` angle emitted by `pauli_exp_to_qasm` so it implements `exp(-i * theta * Z)` rather than `exp(-i * theta * Z / 2)`
- updates existing QASM expectations for Pauli-Z strings
- adds a direct regression test with non-default `evolution_time`

## Validation
- `C:\hades\oss\.venvs\openfermion-1317\Scripts\python.exe -m pytest src\openfermion\circuits\trotter_exp_to_qgates_test.py -q`
- `C:\hades\oss\.venvs\openfermion-1317\Scripts\python.exe -m black --check src\openfermion\circuits\trotter_exp_to_qgates.py src\openfermion\circuits\trotter_exp_to_qgates_test.py`
- `C:\hades\oss\.venvs\openfermion-1317\Scripts\python.exe -m compileall -q src\openfermion\circuits\trotter_exp_to_qgates.py src\openfermion\circuits\trotter_exp_to_qgates_test.py`
- `git diff --check`

AI-assisted contribution: implemented with OpenAI Codex and reviewed locally before submission.