### PR TITLE
Avoid mutating optimal Givens input matrices

### DIFF
--- a/src/openfermion/circuits/primitives/optimal_givens_decomposition.py
+++ b/src/openfermion/circuits/primitives/optimal_givens_decomposition.py
@@ -52,6 +52,7 @@ def optimal_givens_decomposition(
                 should be ordered in linear physical order.
         unitary:
     """
+    unitary = unitary.copy()
     N = unitary.shape[0]
     right_rotations = []
     left_rotations = []

--- a/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
+++ b/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
@@ -198,6 +198,23 @@ def test_circuit_generation_and_accuracy():
         assert numpy.isclose(abs(numpy.trace(true_unitary.conj().T.dot(test_unitary))), 2**dim)
 
 
+def test_circuit_generation_does_not_mutate_input_unitary():
+    dim = 4
+    qubits = cirq.LineQubit.range(dim)
+    rng = numpy.random.default_rng(1618033)
+    u_generator = rng.random((dim, dim)) + 1j * rng.random((dim, dim))
+    u_generator = u_generator - numpy.conj(u_generator).T
+
+    unitary = scipy.linalg.expm(u_generator)
+    expected_unitary = unitary.copy()
+
+    first_circuit = cirq.Circuit(optimal_givens_decomposition(qubits, unitary))
+    second_circuit = cirq.Circuit(optimal_givens_decomposition(qubits, unitary))
+
+    assert numpy.allclose(unitary, expected_unitary)
+    assert first_circuit == second_circuit
+
+
 def test_circuit_generation_state():
     """
     Determine if we rotate the Hartree-Fock state correctly


### PR DESCRIPTION
Fixes #761.

## What changed
- Copy the caller-provided unitary before the optimal Givens decomposition uses it as an in-place workspace.
- Add regression coverage proving repeated decompositions with the same matrix leave the input unchanged and produce the same circuit.

## Verification
- `.venv\Scripts\python.exe -m pytest -p no:cacheprovider src\openfermion\circuits\primitives\optimal_givens_decomposition_test.py -q`
- `.venv\Scripts\python.exe -m black --check --workers 1 src\openfermion\circuits\primitives\optimal_givens_decomposition.py src\openfermion\circuits\primitives\optimal_givens_decomposition_test.py`
- `.venv\Scripts\python.exe -B -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding='utf-8'), filename=p) for p in ['src/openfermion/circuits/primitives/optimal_givens_decomposition.py','src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py']]"`
- `git diff --check`