### PR TITLE
Replace noninclusive dummy and sanity language (#1290)

### DIFF
--- a/docs/fqe/tutorials/hamiltonian_time_evolution_and_expectation_estimation.ipynb
+++ b/docs/fqe/tutorials/hamiltonian_time_evolution_and_expectation_estimation.ipynb
@@ -162,7 +162,7 @@
    },
    "outputs": [],
    "source": [
-    "# dummy geometry\n",
+    "# placeholder geometry\n",
     "from openfermion.chem.molecular_data import spinorb_from_spatial\n",
     "from openfermion import jordan_wigner, get_sparse_operator, InteractionOperator, get_fermion_operator\n",
     "\n",

--- a/src/openfermion/resource_estimates/df/compute_cost_df.py
+++ b/src/openfermion/resource_estimates/df/compute_cost_df.py
@@ -229,7 +229,7 @@ def compute_cost(
 
     ancilla_cost = ac1 + ac2 + ac3 + ac4 + ac5 + ac6 + ac8 + ac9 + ac10 + ac11 + ac12 + ac13
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert ancilla_cost.is_integer()

--- a/src/openfermion/resource_estimates/molecule/pyscf_utils.py
+++ b/src/openfermion/resource_estimates/molecule/pyscf_utils.py
@@ -278,7 +278,7 @@ def get_num_active_alpha_beta(pyscf_mf, cas_electrons):
         num_alpha (int): number of alpha (spin-up) electrons in active space
         num_beta (int):  number of beta (spin-down) electrons in active space
     """
-    # Sanity checks and active space info
+    # Validate inputs and active space info
     total_electrons = pyscf_mf.mol.nelectron
     frozen_electrons = total_electrons - cas_electrons
     assert frozen_electrons % 2 == 0

--- a/src/openfermion/resource_estimates/pbc/df/compute_df_resources.py
+++ b/src/openfermion/resource_estimates/pbc/df/compute_df_resources.py
@@ -350,7 +350,7 @@ def _compute_cost(
 
     ancilla_cost = ac1 + ac2 + ac3 + ac4 + ac5 + ac6 + ac8 + ac9 + ac10 + ac11 + ac12 + ac13 + ac14
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert ancilla_cost.is_integer()

--- a/src/openfermion/resource_estimates/pbc/sf/compute_sf_resources.py
+++ b/src/openfermion/resource_estimates/pbc/sf/compute_sf_resources.py
@@ -298,7 +298,7 @@ def _compute_cost(
 
     total_qubit_count = ac1 + ac2 + ac3 + ac4 + ac5 + ac6 + ac7 + ac8 + ac9
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert total_qubit_count.is_integer()

--- a/src/openfermion/resource_estimates/pbc/sparse/compute_sparse_resources.py
+++ b/src/openfermion/resource_estimates/pbc/sparse/compute_sparse_resources.py
@@ -184,7 +184,7 @@ def _compute_cost(
 
     ancilla_cost = ac1 + ac2 + ac3 + ac6 + ac7 + ac8 + ac9
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert ancilla_cost.is_integer()

--- a/src/openfermion/resource_estimates/pbc/sparse/sparse_integrals.py
+++ b/src/openfermion/resource_estimates/pbc/sparse/sparse_integrals.py
@@ -67,7 +67,7 @@ def _ps_qr_two_body_terms(quad):
     """Symmetry inequivalent indices when kp = ks and kq = kr.
 
     A subset of the four-fold symmetry can be applied (pkp,qkq|rkq,skp) ->
-    (skp,rkq|qkq,pkp) by complex conj and dummy index exchange
+    (skp,rkq|qkq,pkp) by complex conj and summation index exchange
     """
     p, q, r, s = quad
     yield p, q, r, s
@@ -87,7 +87,7 @@ def _pr_qs_two_body_terms(quad):
     """Symmetry inequivalent indices when kp = kr and kq = ks.
 
     A subset of the four-fold symmetry can be applied (pkp,qkq|rkp,skq) ->
-    (rkp,skq|pkp,rkq) by dummy index exchange
+    (rkp,skq|pkp,rkq) by summation index exchange
     """
     p, q, r, s = quad
     yield p, q, r, s

--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
@@ -390,7 +390,7 @@ def test_kpoint_isdf_symmetries():
     _, minus_Q_G_map_unique = build_minus_q_g_mapping(cell, kpts, momentum_map)
     num_kpts = len(kpts)
     # Test symmetries from Appendix D of https://arxiv.org/pdf/2302.05531.pdf
-    # Test LHS for sanity too (need to uncomment)
+    # Test LHS as well (need to uncomment)
     grid_points = cell.gen_uniform_grids(mf.with_df.mesh)
     from pyscf.pbc.lib.kpts_helper import conj_mapping
 
@@ -402,7 +402,7 @@ def test_kpoint_isdf_symmetries():
     iGpq = G_unique[iq, ik]
     iGsr = G_unique[iq, ik_prime]
     ik_prime_minus_q = momentum_map[iq, ik_prime]
-    # Sanity check G mappings
+    # Check G mappings
     assert np.allclose(kpts[ik] - kpts[ik_minus_q] - kpts[iq], delta_Gs[iq][iGpq])
     assert np.allclose(kpts[ik_prime] - kpts[ik_prime_minus_q] - kpts[iq], delta_Gs[iq][iGsr])
     # (pk qk-Q | rk'-Q sk') = (q k-Q p k | sk' rk'-Q)*
@@ -413,7 +413,7 @@ def test_kpoint_isdf_symmetries():
     # kpt_pqrs = [ik, ik_minus_q, ik_prime_minus_q, ik_prime]
     # kpt_pqrs = [ik_minus_q, ik, ik_prime, ik_prime_minus_q]
     # eri_qpsr = build_eri(mf, kpt_pqrs).transpose((1, 0, 3, 2))
-    # Sanity check relationship
+    # Check relationship
     # assert np.allclose(eri_pqrs, eri_qpsr.conj())
     # Now check how to index into correct G when Q is conjugated
     # We want to find (-Q) + G_pq_comp + (Q + Gpq) = 0,
@@ -428,7 +428,7 @@ def test_kpoint_isdf_symmetries():
     zeta_test = kpt_thc.zeta[minus_iq][iGpq_comp, iGsr_comp]
     # F31 (pk qk-Q | rk'-Q sk') = (rk'-Q s k'| pk qk-Q)
     assert np.allclose(zeta_ref, zeta_test.conj())
-    # Sanity check do literal minus signs (should be complex
+    # Check literal minus signs (should be complex
     # conjugate)
     zeta_test = build_kpoint_zeta(
         mf.with_df, -kpts[iq], -delta_Gs[iq][iGpq], -delta_Gs[iq][iGsr], grid_points, kpt_thc.xi

--- a/src/openfermion/resource_estimates/sf/compute_cost_sf.py
+++ b/src/openfermion/resource_estimates/sf/compute_cost_sf.py
@@ -214,7 +214,7 @@ def compute_cost(
 
     total_qubit_count = ac1 + ac2 + ac3 + ac4 + ac5 + ac6 + ac7 + ac8 + ac9
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert total_qubit_count.is_integer()

--- a/src/openfermion/resource_estimates/sparse/costing_sparse.py
+++ b/src/openfermion/resource_estimates/sparse/costing_sparse.py
@@ -120,7 +120,7 @@ def cost_sparse(n: int, lam: float, d: int, dE: float, chi: int, stps: int) -> T
 
     ancilla_cost = ac1 + ac2 + ac3 + ac45 + ac6 + ac7 + ac8
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     assert cost.is_integer()
     assert iters.is_integer()
     assert ancilla_cost.is_integer()

--- a/src/openfermion/resource_estimates/thc/compute_cost_thc.py
+++ b/src/openfermion/resource_estimates/thc/compute_cost_thc.py
@@ -214,7 +214,7 @@ def compute_cost(
         print("  [+] iters = ", iters)
         print("  [+] aca = ", aca)
 
-    # Sanity checks before returning as int
+    # Validate values before returning as int
     # assert cost.is_integer()
     # assert iters.is_integer()
     # assert aca.is_integer()

--- a/src/openfermion/resource_estimates/thc/spacetime.py
+++ b/src/openfermion/resource_estimates/thc/spacetime.py
@@ -606,7 +606,7 @@ def group_steps(labels, tgates, qubits):
     for label, group in itertools.groupby(L, key_func):
         grouped_qubits.append(np.mean([i[1] for i in group]))
 
-    # sanity check -- shouldn't be losing total value in toffoli
+    # Validate total toffoli count is preserved
     if np.sum(tgates) != np.sum(grouped_tgates):
         raise RuntimeError('Sum of Toffoli gates does not equal sum of grouped gates.')
     return grouped_labels, grouped_tgates, grouped_qubits

--- a/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
+++ b/src/openfermion/transforms/opconversions/remove_symmetry_qubits_test.py
@@ -144,7 +144,7 @@ class ReduceSymmetryQubitsTest(unittest.TestCase):
     # e.g. system with 2 particles, 4 spin-orbitals, and want to determine
     # elements of one- and two-particle reduced density matrix
     def test_single_operator(self):
-        # Dummy operator acting only on 2 qubits of overall 4-qubit system
+        # Simple test operator acting only on 2 qubits of overall 4-qubit system
         op = FermionOperator("0^ 1^ 1 0") + FermionOperator("1^ 0^ 0 1")
         trafo_op = symmetry_conserving_bravyi_kitaev(op, active_fermions=2, active_orbitals=4)
         # Check via eigenspectrum -- needs to stay the same

--- a/src/openfermion/transforms/repconversions/qubit_tapering_from_stabilizer_test.py
+++ b/src/openfermion/transforms/repconversions/qubit_tapering_from_stabilizer_test.py
@@ -183,7 +183,7 @@ class TaperingTest(unittest.TestCase):
 
     def test_lookup_term(self):
         """Test for the auxiliar function _lookup_term."""
-        # Dummy test where the initial Pauli string is larger than the
+        # Edge-case test where the initial Pauli string is larger than the
         # updated one.
         start_op = list(QubitOperator('Z0 Z1 Z2 Z3').terms.keys())[0]
         updateop1 = QubitOperator('Z0 Z2', -1.0)

--- a/src/openfermion/utils/bch_expansion_test.py
+++ b/src/openfermion/utils/bch_expansion_test.py
@@ -93,7 +93,7 @@ class BCHTest(unittest.TestCase):
             self.assertAlmostEqual(norm(test - baseline), 0.0)
 
     def test_verification(self):
-        """Verify basic sanity checking on inputs"""
+        """Verify basic input validation"""
         with self.assertRaises(TypeError):
             order = 2
             _ = bch_expand(1, numpy.ones((2, 2)), order=order)

--- a/src/openfermion/utils/channel_state.py
+++ b/src/openfermion/utils/channel_state.py
@@ -143,7 +143,7 @@ def depolarizing_channel(density_matrix, probability, target_qubit, transpose=Fa
         probability (float): Probability error is applied p \in [0, 1]
         target_qubit (int/str): target for the channel error, if given special
             value "all", then a total depolarizing channel is applied.
-        transpose (bool): Dummy parameter to match signature of other
+        transpose (bool): Unused parameter to match signature of other
             channels but depolarizing channel is symmetric under
             conjugate transpose.
 

--- a/src/openfermion/utils/channel_state_test.py
+++ b/src/openfermion/utils/channel_state_test.py
@@ -120,7 +120,7 @@ class ChannelTest(unittest.TestCase):
         self.assertAlmostEqual(norm(correct_density_matrix - test_density_matrix), 0.0, places=6)
 
     def test_verification(self):
-        """Verify basic sanity checking on inputs"""
+        """Verify basic input validation"""
         with self.assertRaises(ValueError):
             _ = amplitude_damping_channel(self.density_matrix, 2, 1)
 


### PR DESCRIPTION
Comment and docstring edits per Khronos guidance, following quantumlib/Cirq#8120. No API or behavior changes. Intentionally leaves pylint option names and Sphinx config unchanged.

Closes #1290