### PR TITLE
Simplify & update CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,6 +263,7 @@ jobs:
           SHELLOPTS: ${{(inputs.debug || runner.debug) && 'xtrace'}}
         run: |
           echo '::add-matcher::.github/problem-matchers/jsonlint.json'
+          jsonlint --version
           jsonlint --check .
 
   docker-lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,8 @@ jobs:
         run: npm install -g @prantlf/jsonlint
 
       - name: Run jsonlint on JSON files
+        env:
+          SHELLOPTS: ${{(inputs.debug || runner.debug) && 'xtrace'}}
         run: |
           echo '::add-matcher::.github/problem-matchers/jsonlint.json'
           jsonlint --check .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,24 +239,6 @@ jobs:
           echo '::add-matcher::.github/problem-matchers/yamllint.json'
           yamllint -f github . CITATION.cff
 
-  json-lint:
-    name: JSON lint checks
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    steps:
-      - name: Check out a copy of the git repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install jsonlint
-        run: npm install -g @prantlf/jsonlint
-
-      - name: Run jsonlint on JSON files
-        run: |
-          echo '::add-matcher::.github/problem-matchers/jsonlint.json'
-          ls
-          jsonlint --version
-          jsonlint --check .
-
   docker-lint:
     name: Dockerfile lint checks
     if: github.repository_owner == 'quantumlib'
@@ -337,7 +319,6 @@ jobs:
     needs:
       - coverage
       - docker-lint
-      - json-lint
       - notebook-checks
       - pytest
       - pytest-compat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Continuous integration
+name: CI
 run-name: >-
   Run continuous integration tests on
   ${{github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number)
@@ -20,6 +20,10 @@ run-name: >-
   by @${{github.actor}}
 
 on:
+  push:
+    branches:
+      - main
+
   pull_request:
     types: [opened, synchronize]
     branches:
@@ -31,30 +35,21 @@ on:
 
   workflow_dispatch:
     inputs:
-      python_ver:
-        description: Normal version of Python to use
-        type: string
-
-      python_compat_ver:
-        description: Max compat version of Python
-        type: string
-
-permissions: read-all
-
-concurrency:
-  cancel-in-progress: true
-  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
 
 env:
   # Default Python version to use. Make sure to use full x.y.z number.
-  python_ver: '3.12.8'
+  python-version: '3.12.8'
 
   # Oldest Python version to use, for max_compat tests.
-  python_compat_ver: '3.11.9'
+  python-compat-version: '3.11.9'
 
   # Files listing dependencies we install using pip in the various jobs below.
   # This is used by setup-python to check whether its cache needs updating.
-  python_dep_files: >-
+  python-dep-files: >-
     dev_tools/requirements/envs/format.env.txt
     dev_tools/requirements/envs/mypy.env.txt
     dev_tools/requirements/envs/pylint.env.txt
@@ -62,89 +57,18 @@ env:
     dev_tools/requirements/envs/pytest.env.txt
     dev_tools/requirements/max_compat/pytest-max-compat.env.txt
 
+  # Turn on Bash script tracing globally if debug mode is on.
+  SHELLOPTS: ${{inputs.debug && 'xtrace'}}
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+permissions: read-all
+
 jobs:
-  # GitHub Actions can have path filters (i.e., the use of a "paths:" keyword
-  # on the trigger definitions in the "on:" block earlier in this file). Path
-  # filters *would* be the natural way to make workflows trigger only when the
-  # desired files are affected by a pull request – except that the way branch
-  # protection rules work today is: "If a workflow is skipped due to path
-  # filtering [...] then checks associated with that workflow will remain in a
-  # Pending state. A pull request that requires those checks to be successful
-  # will be blocked from merging." Surprisingly, GitHub doesn't provide
-  # guidance on how to handle this. Discussions about solutions sometimes
-  # suggest hacky solutions (c.f. https://stackoverflow.com/a/78003720/743730).
-  # The approach taken here is to forgo the use of path filtering rules in the
-  # trigger condition, and instead, do our own filtering using a combination
-  # of testing specific file patterns (in the changes job below) and "if:"
-  # conditions on individual jobs in the rest of this workflow.
-  changes:
-    name: Changed file filtering
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    outputs:
-      gha: ${{steps.filter.outputs.gha}}
-      gha_files: ${{steps.filter.outputs.gha_files}}
-
-      # The rest all test both the relevant files and ALSO tools & scripts b/c
-      # a change in the CI workflows or scripts can affect the check results.
-
-      python: ${{steps.filter.outputs.python || steps.filter.outputs.ci}}
-      python_files: ${{steps.filter.outputs.python_files}}
-
-      yaml: ${{steps.filter.outputs.yaml || steps.filter.outputs.ci}}
-      yaml_files: ${{steps.filter.outputs.yaml_files}}
-
-      json: ${{steps.filter.outputs.json || steps.filter.outputs.ci}}
-      json_files: ${{steps.filter.outputs.json_files}}
-
-      docker: ${{steps.filter.outputs.docker || steps.filter.outputs.ci}}
-      docker_files: ${{steps.filter.outputs.docker_files}}
-
-      shell: ${{steps.filter.outputs.shell || steps.filter.outputs.ci}}
-      shell_files: ${{steps.filter.outputs.shell_files}}
-
-      notebooks: ${{steps.filter.outputs.notebooks || steps.filter.outputs.ci}}
-      notebook_files: ${{steps.filter.outputs.notebooks_files}}
-    steps:
-      - name: Check out a copy of the OpenFermion git repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Determine files changed by this ${{github.event_name}} event
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          list-files: 'shell'
-          # The outputs will be variables named "foo_files" for a filter "foo".
-          filters: |
-            ci:
-              - '.github/workflows/**'
-              - 'check/**'
-              - 'dev_tools/**'
-            python:
-              - '**/*.py'
-              - 'dev_tools/conf/**'
-              - 'dev_tools/requirements/**/*.txt'
-              - 'docs/**/*-requirements.txt'
-              - 'pyproject.toml'
-            gha:
-              - '.github/workflows/*.yaml'
-            yaml:
-              - '*.cff'
-              - '**/*.yaml'
-            json:
-              - '**/*.json'
-            docker:
-              - '**/[Dd]ockerfile'
-            shell:
-              - '**/*.sh'
-              - 'check/*'
-            notebooks:
-              - '**/*.ipynb'
-
   python-checks:
-    if: needs.changes.outputs.python == 'true'
     name: Python file checks
-    needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -156,25 +80,18 @@ jobs:
       - name: Set up Python and restore cache
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
+          python-version: ${{env.python-version}}
           cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
+          cache-dependency-path: ${{env.python-dep-files}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
       - name: Install requirements
-        env:
-          files: >-
-            dev_tools/requirements/envs/format.env.txt
-            dev_tools/requirements/envs/pylint.env.txt
-            dev_tools/requirements/envs/mypy.env.txt
         run: |
-          requirements=()
-          for file in $files; do
-            requirements+=("-r" "$file")
-          done
-          pip install "${requirements[@]}"
+          pip install -r dev_tools/requirements/envs/format.env.txt
+          pip install -r dev_tools/requirements/envs/pylint.env.txt
+          pip install -r dev_tools/requirements/envs/mypy.env.txt
 
       - name: Check format
         run: |
@@ -192,15 +109,13 @@ jobs:
           check/mypy
 
   pytest:
-    if: needs.changes.outputs.python == 'true'
     name: Unit tests
-    needs: [changes, python-checks]
+    needs: python-checks
     runs-on: ${{matrix.os}}
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14, windows-2022 ]
-        cirq-version: [ 1.4.1 ]
+        os: [ ubuntu-24.04, macos-14, macos-15, windows-2022 ]
       fail-fast: false
     steps:
       - name: Check out a copy of the git repository
@@ -209,9 +124,9 @@ jobs:
       - name: Set up Python and restore cache
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
+          python-version: ${{env.python-version}}
           cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
+          cache-dependency-path: ${{env.python-dep-files}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -219,7 +134,6 @@ jobs:
       - name: Install requirements
         run: |
           pip install -r dev_tools/requirements/envs/pytest.env.txt
-          pip install cirq-core==${{matrix.cirq-version}}
 
       - name: Run pytest
         run: |
@@ -227,15 +141,13 @@ jobs:
           check/pytest -n auto -m "not slow"
 
   pytest-extra:
-    if: needs.changes.outputs.python == 'true'
     name: Extra unit tests
-    needs: [changes, python-checks]
+    needs: python-checks
     runs-on: ${{matrix.os}}
     timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14]
-        cirq-version: [ 1.4.1 ]
       fail-fast: false
     steps:
       - name: Check out a copy of the git repository
@@ -244,9 +156,9 @@ jobs:
       - name: Set up Python and restore cache
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
+          python-version: ${{env.python-version}}
           cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
+          cache-dependency-path: ${{env.python-dep-files}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -254,7 +166,6 @@ jobs:
       - name: Install requirements
         run: |
           pip install -r dev_tools/requirements/envs/pytest-extra.env.txt
-          pip install cirq-core==${{matrix.cirq-version}}
 
       - name: Run pytest
         run: |
@@ -262,9 +173,8 @@ jobs:
           check/pytest -n auto -m "not slow" src/openfermion/resource_estimates
 
   pytest-compat:
-    if: needs.changes.outputs.python == 'true'
     name: Python compatibility tests
-    needs: [changes, python-checks]
+    needs: python-checks
     # Note: this is deliberately Ubuntu 22 because this is a compatibility test.
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -277,7 +187,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{env.python_compat_ver}}
+          python-version: ${{env.python-compat-version}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -291,9 +201,8 @@ jobs:
           check/pytest -n auto -m "not slow"
 
   coverage:
-    if: needs.changes.outputs.python == 'true'
     name: Python code coverage tests
-    needs: [changes, python-checks]
+    needs: python-checks
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -305,9 +214,9 @@ jobs:
       - name: Set up Python and restore cache
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
+          python-version: ${{env.python-version}}
           cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
+          cache-dependency-path: ${{env.python-dep-files}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -321,13 +230,9 @@ jobs:
           check/pytest-and-incremental-coverage
 
   yaml-lint:
-    if: needs.changes.outputs.yaml == 'true'
     name: YAML lint checks
-    needs: changes
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    env:
-      CHANGED_FILES: ${{needs.changes.outputs.yaml_files}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -340,17 +245,12 @@ jobs:
       - name: Run yamllint
         run: |
           echo '::add-matcher::.github/problem-matchers/yamllint.json'
-          # shellcheck disable=SC2086
-          yamllint ${CHANGED_FILES}
+          yamllint -f github . CITATION.cff
 
   json-lint:
-    if: needs.changes.outputs.json == 'true'
     name: JSON lint checks
-    needs: changes
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    env:
-      CHANGED_FILES: ${{needs.changes.outputs.json_files}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -361,37 +261,36 @@ jobs:
       - name: Run jsonlint on JSON files
         run: |
           echo '::add-matcher::.github/problem-matchers/jsonlint.json'
-          # shellcheck disable=SC2086
-          jsonlint --continue ${CHANGED_FILES}
+          shopt -s globstar
+          files=(**/*.json)
+          if [[ ${#files[@]} -gt 0 ]]; then
+            jsonlint --check "${files[@]}"
+          fi
 
   docker-lint:
-    if: needs.changes.outputs.docker == 'true'
     name: Dockerfile lint checks
-    needs: changes
-    # This uses a Mac runner because hadolint isn't available via Linux apt.
-    runs-on: macos-14
-    timeout-minutes: 5
-    env:
-      CHANGED_FILES: ${{needs.changes.outputs.docker_files}}
+    if: github.repository_owner == 'quantumlib'
+    # ubuntu-slim runners don't have docker installed.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Check out a copy of the git repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Note: there is a hadolint GitHub Actions available, but it only accepts
-      # one Dockerfile to check. We have > 1 file to check, so we need the CLI.
-      - name: Install hadolint
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install hadolint
-
-      - name: Run hadolint on Dockerfiles that have been changed
+      - name: Run hadolint on Dockerfiles
+        env:
+          sha: 'sha256:e9dbf5113239ef2bf696d20c8f28d3019a47c26a38c98b89344d3e2846c4d5f8'
         run: |
           echo '::add-matcher::.github/problem-matchers/hadolint.json'
-          # shellcheck disable=SC2086
-          hadolint ${CHANGED_FILES}
+          shopt -s globstar
+          files=(**/[Dd]ockerfile*)
+          if [[ ${#files[@]} -gt 0 ]]; then
+            docker run --rm -v "${PWD}:/app" -w /app \
+            ghcr.io/hadolint/hadolint@${{env.sha}} /bin/hadolint "${files[@]}"
+          fi
 
   workflow-lint:
-    if: needs.changes.outputs.gha == 'true'
     name: GitHub workflow lint checks
-    needs: changes
     runs-on: ubuntu-slim
     timeout-minutes: 15
     steps:
@@ -406,27 +305,20 @@ jobs:
           pyflakes: false
 
   shell-script-lint:
-    if: needs.changes.outputs.shell == 'true'
     name: Shell script lint checks
-    needs: changes
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    env:
-      CHANGED_FILES: ${{needs.changes.outputs.shell_files}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Run shellcheck on shell scripts that have been changed
+      - name: Run shellcheck on shell scripts
         run: |
           echo '::add-matcher::.github/problem-matchers/shellcheck.json'
-          # shellcheck disable=SC2086
-          shellcheck ${CHANGED_FILES}
+          check/shellcheck
 
   notebook-checks:
-    if: needs.changes.outputs.notebooks == 'true'
     name: Notebook format checks
-    needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -436,9 +328,9 @@ jobs:
       - name: Set up Python and restore cache
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{inputs.python_ver || env.python_ver}}
+          python-version: ${{env.python-version}}
           cache: pip
-          cache-dependency-path: ${{env.python_dep_files}}
+          cache-dependency-path: ${{env.python-dep-files}}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,11 +34,6 @@ on:
       - checks_requested
 
   workflow_dispatch:
-    inputs:
-      debug:
-        description: 'Run with debugging options'
-        type: boolean
-        default: true
 
 env:
   # Default Python version to use. Make sure to use full x.y.z number.
@@ -56,9 +51,6 @@ env:
     dev_tools/requirements/envs/pytest-extra.env.txt
     dev_tools/requirements/envs/pytest.env.txt
     dev_tools/requirements/max_compat/pytest-max-compat.env.txt
-
-  # Turn on Bash script tracing globally if debug mode is on.
-  SHELLOPTS: ${{inputs.debug && 'xtrace'}}
 
 concurrency:
   cancel-in-progress: true
@@ -259,10 +251,9 @@ jobs:
         run: npm install -g @prantlf/jsonlint
 
       - name: Run jsonlint on JSON files
-        env:
-          SHELLOPTS: ${{(inputs.debug || runner.debug) && 'xtrace'}}
         run: |
           echo '::add-matcher::.github/problem-matchers/jsonlint.json'
+          ls
           jsonlint --version
           jsonlint --check .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,11 +261,7 @@ jobs:
       - name: Run jsonlint on JSON files
         run: |
           echo '::add-matcher::.github/problem-matchers/jsonlint.json'
-          shopt -s globstar
-          files=(**/*.json)
-          if [[ ${#files[@]} -gt 0 ]]; then
-            jsonlint --check "${files[@]}"
-          fi
+          jsonlint --check .
 
   docker-lint:
     name: Dockerfile lint checks


### PR DESCRIPTION
This removes the testing for changed files, and uses the approach we use in qsim of simply running tests. This is less efficient, but also less complicated and less likely to have false negatives.

Additional changes made:

- Test with `macos-15` runners too
- Eliminate arguments to `workflow_dispatch` because they were rarely useful – I need to find a better way to get more verbose debug output
- Remove JSON lint job because there are no JSON files except for the .github/problem-matchers
- Change shell script lint job to use `check/shellcheck`