### PR TITLE
Fix integer type in `binary_code_transform`

### DIFF
--- a/src/openfermion/transforms/opconversions/binary_code_transform.py
+++ b/src/openfermion/transforms/opconversions/binary_code_transform.py
@@ -158,7 +158,7 @@ def binary_code_transform(hamiltonian: FermionOperator, code: BinaryCode) -> Qub
             parity_term += parity_list[op_tuple[0]]
 
         # the parity sign and parity term
-        transformed_term *= QubitOperator((), (-1) ** updated_parity)
+        transformed_term *= QubitOperator((), (-1) ** int(updated_parity))
         transformed_term *= extractor(parity_term)
 
         # the update operator


### PR DESCRIPTION
on openfermion/transforms/opconversions/binary_code_transform.py line 163 it breaks (with numpy>2.) because (-1) ** updated_parity being updated_parity numpy.count_nonzero(fermionic_indices[:op_idx] < op_tuple[0]) line 146 (therefore a numpy.int) is not instance of int, as it is checked on openfermion/ops/operators/symbolic_operator.py  line 124