### PR TITLE
Fix mypy errors in batch 2 part 2 (#1282)

### DIFF
--- a/src/openfermion/circuits/gates/fermionic_simulation.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation.py
@@ -131,18 +131,18 @@ def fermionic_simulation_gates_from_interaction_operator(
         )
         if gate:
             gates[modes] = gate
-    for modes in itertools.combinations(range(n_qubits), 3):
+    for modes3 in itertools.combinations(range(n_qubits), 3):
         gate = CubicFermionicSimulationGate.from_interaction_operator(
-            operator=operator, modes=modes
+            operator=operator, modes=modes3
         )
         if gate:
-            gates[modes] = gate
-    for modes in itertools.combinations(range(n_qubits), 4):
+            gates[modes3] = gate
+    for modes4 in itertools.combinations(range(n_qubits), 4):
         gate = QuarticFermionicSimulationGate.from_interaction_operator(
-            operator=operator, modes=modes
+            operator=operator, modes=modes4
         )
         if gate:
-            gates[modes] = gate
+            gates[modes4] = gate
     return gates
 
 

--- a/src/openfermion/circuits/primitives/ffft.py
+++ b/src/openfermion/circuits/primitives/ffft.py
@@ -235,7 +235,7 @@ def _ffft(qubits: Sequence[cirq.Qid], factors: List[int]) -> cirq.OP_TREE:
     # ny is a first prime factor, nx is a product of all the remaining ones.
     factors_y = factors[:1]
     factors_x = factors[1:]
-    ny = int(np.prod(factors_y))
+    ny = factors[0]
     nx = n // ny
 
     permutation = [(i % ny) * nx + (i // ny) for i in range(n)]

--- a/src/openfermion/circuits/primitives/ffft.py
+++ b/src/openfermion/circuits/primitives/ffft.py
@@ -235,7 +235,7 @@ def _ffft(qubits: Sequence[cirq.Qid], factors: List[int]) -> cirq.OP_TREE:
     # ny is a first prime factor, nx is a product of all the remaining ones.
     factors_y = factors[:1]
     factors_x = factors[1:]
-    ny = np.prod(factors_y)
+    ny = int(np.prod(factors_y))
     nx = n // ny
 
     permutation = [(i % ny) * nx + (i // ny) for i in range(n)]

--- a/src/openfermion/transforms/opconversions/binary_code_transform.py
+++ b/src/openfermion/transforms/opconversions/binary_code_transform.py
@@ -146,7 +146,7 @@ def binary_code_transform(hamiltonian: FermionOperator, code: BinaryCode) -> Qub
             # get count exponent, parity exponent addition
             fermionic_indices = numpy.append(fermionic_indices, op_tuple[0])
             count = numpy.count_nonzero(fermionic_indices[:op_idx] == op_tuple[0])
-            updated_parity += numpy.count_nonzero(fermionic_indices[:op_idx] < op_tuple[0])
+            updated_parity += int(numpy.count_nonzero(fermionic_indices[:op_idx] < op_tuple[0]))
 
             # update term
             extracted = extractor(code.decoder[op_tuple[0]])

--- a/src/openfermion/transforms/opconversions/binary_code_transform.py
+++ b/src/openfermion/transforms/opconversions/binary_code_transform.py
@@ -139,14 +139,14 @@ def binary_code_transform(hamiltonian: FermionOperator, code: BinaryCode) -> Qub
         transformed_term = QubitOperator(())
 
         # keep track of indices appeared before
-        fermionic_indices = numpy.array([])
+        fermionic_indices: list[int] = []
 
         # for each multiplier
         for op_idx, op_tuple in enumerate(reversed(term)):
             # get count exponent, parity exponent addition
-            fermionic_indices = numpy.append(fermionic_indices, op_tuple[0])
-            count = numpy.count_nonzero(fermionic_indices[:op_idx] == op_tuple[0])
-            updated_parity += int(numpy.count_nonzero(fermionic_indices[:op_idx] < op_tuple[0]))
+            fermionic_indices.append(op_tuple[0])
+            count = fermionic_indices[:op_idx].count(op_tuple[0])
+            updated_parity += sum(idx < op_tuple[0] for idx in fermionic_indices[:op_idx])
 
             # update term
             extracted = extractor(code.decoder[op_tuple[0]])

--- a/src/openfermion/transforms/opconversions/bksf.py
+++ b/src/openfermion/transforms/opconversions/bksf.py
@@ -340,7 +340,7 @@ def edge_operator_b(edge_matrix_indices: numpy.ndarray, i: int) -> QubitOperator
     qubit_position_matrix = numpy.array(numpy.where(edge_matrix_indices == i))
     qubit_position = qubit_position_matrix[1][:]
     qubit_position = numpy.sort(qubit_position)
-    operator = tuple()
+    operator: tuple[tuple[int, str], ...] = ()
     for d1 in qubit_position:
         operator += ((int(d1), 'Z'),)
     B_i += QubitOperator(operator)
@@ -359,7 +359,7 @@ def edge_operator_aij(edge_matrix_indices: numpy.ndarray, i: int, j: int) -> Qub
         An instance of QubitOperator
     """
     a_ij = QubitOperator()
-    operator = tuple()
+    operator: tuple[tuple[int, str], ...] = ()
     position_ij = -1
     qubit_position_i = numpy.array(numpy.where(edge_matrix_indices == i))
     for edge_index in range(numpy.size(edge_matrix_indices[0, :])):
@@ -401,7 +401,7 @@ def vacuum_operator(edge_matrix_indices: numpy.ndarray) -> QubitOperator:
 
     """
     # Initialize qubit operator.
-    g = networkx.Graph()
+    g: networkx.Graph = networkx.Graph()
     g.add_edges_from(tuple(edge_matrix_indices.transpose()))
     stabs = numpy.array(networkx.cycle_basis(g))
     vac_operator = QubitOperator(())


### PR DESCRIPTION
Mechanical typing fixes in four files: numpy int casts, local annotations, and loop variable renaming. No behavior changes.