### PR TITLE
Fix inconsistencies in double factorization cost estimation

### DIFF
--- a/src/openfermion/resource_estimates/df/compute_cost_df.py
+++ b/src/openfermion/resource_estimates/df/compute_cost_df.py
@@ -81,13 +81,13 @@ def compute_cost(
         )
 
     # Bits of precision for rotation
-    br = int(np.argmin(oh) + 1)
+    br_first = int(np.argmin(oh) + 1)
 
     # The following costs are from the list starting on page 50.
 
     # The cost for preparing an equal superposition for preparing the first
     # register in step 1 (a). We double this cost to account for the inverse.
-    cost1a = 2 * (3 * nL + 2 * br - 3 * eta - 9)
+    cost1a = 2 * (3 * nL + 2 * br_first - 3 * eta - 9)
 
     # The output size for the QROM for the first state preparation in Eq. (C27)
     bp1 = nL + chi
@@ -103,9 +103,13 @@ def compute_cost(
     # The total cost for preparing the first register in step 1.
     cost1 = cost1a + cost1b + cost1cd
 
+    # The number of bits for rotating the ancilla for the second preparation.
+    # We are just entering this manually because it is a typical value.
+    br_second = 7
+
     # The output size for the QROM for the data to prepare the equal
     # superposition on the second register, as given in Eq. (C29).
-    bo = nxi + nLxi + br + 1
+    bo = nxi + nLxi + br_second + 1
 
     # This is step 2. This is the cost of outputting the data to prepare the
     # equal superposition on the second register. We will assume it is not
@@ -113,13 +117,9 @@ def compute_cost(
     # outputting the rotations.
     cost2 = QR(L + 1, bo)[1] + QI(L + 1)[1]
 
-    # The number of bits for rotating the ancilla for the second preparation.
-    # We are just entering this manually because it is a typical value.
-    br = 7
-
     # The cost of preparing an equal superposition over the second register in
     # a controlled way. We pay this cost 4 times.
-    cost3a = 4 * (7 * nxi + 2 * br - 6)
+    cost3a = 4 * (7 * nxi + 2 * br_second - 6)
 
     # The cost of the offset to apply the QROM for state preparation on the
     # second register.

--- a/src/openfermion/resource_estimates/df/compute_cost_df_test.py
+++ b/src/openfermion/resource_estimates/df/compute_cost_df_test.py
@@ -50,4 +50,4 @@ def test_li_df():
     output = df.compute_cost(N, LAM, DE, L, LXI, CHI, BETA, stps=20000)
     stps2 = output[0]
     output = df.compute_cost(N, LAM, DE, L, LXI, CHI, BETA, stps2)
-    assert output == (35008, 64404812736, 6404)
+    assert output == (35011, 64410331887, 6405)

--- a/src/openfermion/resource_estimates/pbc/df/compute_df_resources.py
+++ b/src/openfermion/resource_estimates/pbc/df/compute_df_resources.py
@@ -185,13 +185,13 @@ def _compute_cost(
         )
 
     # Bits of precision for rotation
-    br = int(np.argmin(oh) + 1)
+    br_first = int(np.argmin(oh) + 1)
 
     # The following costs are from the list starting on page 50.
 
     # The cost for preparing an equal superposition for preparing the first
     # register in step 1 (a). We double this cost to account for the inverse.
-    cost1a = 2 * (3 * nL + 2 * br - 3 * eta - 9)
+    cost1a = 2 * (3 * nL + 2 * br_first - 3 * eta - 9)
 
     # The output size for the QROM for the first state preparation in Eq. (C27)
     bp1 = nL + chi
@@ -207,9 +207,13 @@ def _compute_cost(
     # The total cost for preparing the first register in step 1.
     cost1 = cost1a + cost1b + cost1cd
 
+    # The number of bits for rotating the ancilla for the second preparation.
+    # We are just entering this manually because it is a typical value.
+    br_second = 7
+
     # The output size for the QROM for the data to prepare the equal
     # superposition on the second register, as given in Eq. (C29).
-    bo = nxi + nLxi + br + 1
+    bo = nxi + nLxi + br_second + 1
     bo = bo + nNk  # account for k-point sampling outputting values of Q.
 
     # This is step 2. This is the cost of outputting the data to prepare the
@@ -218,13 +222,9 @@ def _compute_cost(
     # outputting the rotations.
     cost2 = QR3(L + 1, bo)[1] + QI(L + 1)[1]
 
-    # The number of bits for rotating the ancilla for the second preparation.
-    # We are just entering this manually because it is a typical value.
-    br = 7
-
     # The cost of preparing an equal superposition over the second register in
     # a controlled way. We pay this cost 4 times.
-    cost3a = 4 * (7 * nxi + 2 * br - 6)
+    cost3a = 4 * (7 * nxi + 2 * br_second - 6)
 
     # The cost of the offset to apply the QROM for state preparation on the
     # second register.

--- a/src/openfermion/resource_estimates/pbc/df/compute_df_resources_test.py
+++ b/src/openfermion/resource_estimates/pbc/df/compute_df_resources_test.py
@@ -55,15 +55,15 @@ def test_costing():
 
     res = _compute_cost(nLi, lamLi, dE, LLi, LxiLi, chi, betaLi, 2, 2, 2, 20_000)
     res = _compute_cost(nLi, lamLi, dE, LLi, LxiLi, chi, betaLi, 2, 2, 2, res[0])
-    # print(res) # 79212, 145727663004, 13873
-    assert np.isclose(res[0], 79212)
-    assert np.isclose(res[1], 145727663004)
-    assert np.isclose(res[2], 13873)
+    # print(res) # 79215, 145733182155, 13874
+    assert np.isclose(res[0], 79215)
+    assert np.isclose(res[1], 145733182155)
+    assert np.isclose(res[2], 13874)
     res = _compute_cost(nLi, lamLi, dE, LLi, LxiLi, chi, betaLi, 3, 5, 1, res[0])
-    # print(res) # 86042, 158292930114, 14952
-    assert np.isclose(res[0], 86042)
-    assert np.isclose(res[1], 158292930114)
-    assert np.isclose(res[2], 14952)
+    # print(res) # 86045, 158298449265, 14953
+    assert np.isclose(res[0], 86045)
+    assert np.isclose(res[1], 158298449265)
+    assert np.isclose(res[2], 14953)
 
 
 @pytest.mark.skipif(not HAVE_DEPS_FOR_RESOURCE_ESTIMATES, reason='pyscf and/or jax not installed.')
@@ -123,10 +123,10 @@ def test_costing_helper():
         chi=chi,
         beta=betaLi,
     )
-    # print(res) # 79212, 145727663004, 13873
-    assert np.isclose(res.toffolis_per_step, 86042)
-    assert np.isclose(res.total_toffolis, 158292930114)
-    assert np.isclose(res.logical_qubits, 14952)
+    # print(res) # 86045, 158298449265, 14953
+    assert np.isclose(res.toffolis_per_step, 86045)
+    assert np.isclose(res.total_toffolis, 158298449265)
+    assert np.isclose(res.logical_qubits, 14953)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes #839. Double factorization uses different precisions for $\theta$ for the first and second factorizations (leading to differences in gate counts), but when estimating the cost of double factorization, the first precision is used for both factorizations. This was corrected and the tests updated to reflect the changed cost function.