### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/openfermion/chem/reduced_hamiltonian.py
+++ b/src/openfermion/chem/reduced_hamiltonian.py
@@ -6,6 +6,10 @@ from openfermion.ops.representations import InteractionOperator
 def make_reduced_hamiltonian(
     molecular_hamiltonian: InteractionOperator, n_electrons: int
 ) -> InteractionOperator:
+    if n_electrons < 2:
+        raise ValueError(
+            'n_electrons must be at least 2 to avoid division by zero.'
+        )
     r"""
     Construct the reduced Hamiltonian.
 

--- a/src/openfermion/linalg/rdm_reconstruction.py
+++ b/src/openfermion/linalg/rdm_reconstruction.py
@@ -16,6 +16,10 @@ def valdemoro_reconstruction(tpdm, n_electrons):
     Returns:
         six-tensor reprsenting the three-RDM
     """
+    if n_electrons < 2:
+        raise ValueError(
+            'n_electrons must be at least 2 to avoid division by zero.'
+        )
     opdm = (2 / (n_electrons - 1)) * np.einsum('ijjk', tpdm)
     unconnected_tpdm = wedge(opdm, opdm, (1, 1), (1, 1))
     unconnected_d3 = wedge(opdm, unconnected_tpdm, (1, 1), (2, 2))


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `src/openfermion/chem/reduced_hamiltonian.py:L48`

In `make_reduced_hamiltonian`, the function calculates `normalization = 1 / (4 * (n_electrons - 1))` without validating that `n_electrons > 1`. If `n_electrons` is 1, this causes a ZeroDivisionError. Additionally, if `n_electrons` is 0 or negative, the behavior is undefined and could lead to incorrect scientific results.

## Solution

Add input validation at the beginning of the function to ensure `n_electrons >= 2`, raising a `ValueError` with a descriptive message if not. Consider also validating that `n_electrons` is a positive integer.

## Changes

- `src/openfermion/chem/reduced_hamiltonian.py` (modified)
- `src/openfermion/linalg/rdm_reconstruction.py` (modified)