### PR TITLE
Add support for arbitrarily large spin states

### DIFF
--- a/src/openfermion/chem/molecular_data.py
+++ b/src/openfermion/chem/molecular_data.py
@@ -275,10 +275,10 @@ def name_molecule(geometry, basis, multiplicity, charge, description):
     }
     if multiplicity in multiplicity_dict:
         name += '_{}'.format(multiplicity_dict[multiplicity])
-    elif isinstance(multiplicity, (int, numpy.integer)) and multiplicity > 0:
+    elif multiplicity > 0:
         name += '_{}-multiplet'.format(multiplicity)
     else:
-        raise MoleculeNameError('Invalid spin multiplicity provided.')
+        raise ValueError('Invalid spin multiplicity provided.')
 
     # Add charge.
     if charge > 0:
@@ -493,7 +493,12 @@ class MolecularData:
         # Metadata fields which must be provided.
         self.geometry = geometry
         self.basis = basis
-        self.multiplicity = multiplicity
+        if isinstance(
+            multiplicity, (int, float, numpy.integer, numpy.floating)
+        ) and multiplicity == int(multiplicity):
+            self.multiplicity = int(multiplicity)
+        else:
+            raise ValueError('Invalid spin multiplicity provided.')
 
         # Metadata fields with default values.
         self.charge = charge
@@ -502,7 +507,7 @@ class MolecularData:
         self.description = description
 
         # Name molecule and get associated filename
-        self.name = name_molecule(geometry, basis, multiplicity, charge, description)
+        self.name = name_molecule(geometry, basis, self.multiplicity, charge, description)
         if filename:
             if filename[-5:] == '.hdf5':
                 filename = filename[: (len(filename) - 5)]

--- a/src/openfermion/chem/molecular_data.py
+++ b/src/openfermion/chem/molecular_data.py
@@ -33,7 +33,9 @@ r"""NOTE ON PQRS CONVENTION:
 
 
 # Define error objects which inherit from Exception.
-class MoleculeNameError(Exception):
+class MoleculeNameError(ValueError):
+    """Exception raised when a molecule name is invalid or cannot be generated."""
+
     pass
 
 
@@ -278,7 +280,7 @@ def name_molecule(geometry, basis, multiplicity, charge, description):
     elif multiplicity > 0:
         name += '_{}-multiplet'.format(multiplicity)
     else:
-        raise ValueError('Invalid spin multiplicity provided.')
+        raise MoleculeNameError('Invalid spin multiplicity provided.')
 
     # Add charge.
     if charge > 0:
@@ -498,7 +500,7 @@ class MolecularData:
         ) and multiplicity == int(multiplicity):
             self.multiplicity = int(multiplicity)
         else:
-            raise ValueError('Invalid spin multiplicity provided.')
+            raise MoleculeNameError('Invalid spin multiplicity provided.')
 
         # Metadata fields with default values.
         self.charge = charge

--- a/src/openfermion/chem/molecular_data.py
+++ b/src/openfermion/chem/molecular_data.py
@@ -273,10 +273,12 @@ def name_molecule(geometry, basis, multiplicity, charge, description):
         11: 'undectet',
         12: 'duodectet',
     }
-    if multiplicity not in multiplicity_dict:
-        raise MoleculeNameError('Invalid spin multiplicity provided.')
-    else:
+    if multiplicity in multiplicity_dict:
         name += '_{}'.format(multiplicity_dict[multiplicity])
+    elif isinstance(multiplicity, (int, numpy.integer)) and multiplicity > 0:
+        name += '_{}-multiplet'.format(multiplicity)
+    else:
+        raise MoleculeNameError('Invalid spin multiplicity provided.')
 
     # Add charge.
     if charge > 0:

--- a/src/openfermion/chem/molecular_data_test.py
+++ b/src/openfermion/chem/molecular_data_test.py
@@ -30,6 +30,7 @@ from openfermion.chem.molecular_data import (
     bohr_to_angstroms,
     load_molecular_hamiltonian,
     MolecularData,
+    MoleculeNameError,
     geometry_from_file,
     MissingCalculationError,
     periodic_table,
@@ -100,15 +101,15 @@ class MolecularDataTest(unittest.TestCase):
         geometry = [('H', (0.0, 0.0, 0.0)), ('H', (0.0, 0.0, 0.7414))]
         basis = 'sto-3g'
         multiplicity = -1
-        with self.assertRaises(ValueError):
+        with self.assertRaises(MoleculeNameError):
             MolecularData(geometry, basis, multiplicity)
 
         # Test non-integer multiplicity
-        with self.assertRaises(ValueError):
+        with self.assertRaises(MoleculeNameError):
             MolecularData(geometry, basis, multiplicity=1.5)
 
         # Test zero multiplicity
-        with self.assertRaises(ValueError):
+        with self.assertRaises(MoleculeNameError):
             MolecularData(geometry, basis, multiplicity=0)
 
     def test_high_multiplicity(self):

--- a/src/openfermion/chem/molecular_data_test.py
+++ b/src/openfermion/chem/molecular_data_test.py
@@ -30,7 +30,6 @@ from openfermion.chem.molecular_data import (
     bohr_to_angstroms,
     load_molecular_hamiltonian,
     MolecularData,
-    MoleculeNameError,
     geometry_from_file,
     MissingCalculationError,
     periodic_table,
@@ -101,15 +100,15 @@ class MolecularDataTest(unittest.TestCase):
         geometry = [('H', (0.0, 0.0, 0.0)), ('H', (0.0, 0.0, 0.7414))]
         basis = 'sto-3g'
         multiplicity = -1
-        with self.assertRaises(MoleculeNameError):
+        with self.assertRaises(ValueError):
             MolecularData(geometry, basis, multiplicity)
 
         # Test non-integer multiplicity
-        with self.assertRaises(MoleculeNameError):
+        with self.assertRaises(ValueError):
             MolecularData(geometry, basis, multiplicity=1.5)
 
         # Test zero multiplicity
-        with self.assertRaises(MoleculeNameError):
+        with self.assertRaises(ValueError):
             MolecularData(geometry, basis, multiplicity=0)
 
     def test_high_multiplicity(self):
@@ -118,6 +117,19 @@ class MolecularDataTest(unittest.TestCase):
         basis = 'sto-3g'
         molecule = MolecularData(geometry, basis, multiplicity=13)
         self.assertEqual(molecule.name, 'H12_sto-3g_13-multiplet')
+
+    def test_float_multiplicity(self):
+        geometry = [('H', (0.0, 0.0, 0.0)), ('H', (0.0, 0.0, 0.7414))]
+        basis = 'sto-3g'
+
+        # Float multiplicity <= 12 should work and use name
+        molecule = MolecularData(geometry, basis, multiplicity=2.0)
+        self.assertEqual(molecule.name, 'H2_sto-3g_doublet')
+
+        # Float multiplicity > 12 should work and use number
+        geometry_high = [('H', (0.0, 0.0, i * 1.3)) for i in range(12)]
+        molecule_high = MolecularData(geometry_high, basis, multiplicity=13.0)
+        self.assertEqual(molecule_high.name, 'H12_sto-3g_13-multiplet')
 
     def test_geometry_from_file(self):
         water_geometry = [

--- a/src/openfermion/chem/molecular_data_test.py
+++ b/src/openfermion/chem/molecular_data_test.py
@@ -104,6 +104,21 @@ class MolecularDataTest(unittest.TestCase):
         with self.assertRaises(MoleculeNameError):
             MolecularData(geometry, basis, multiplicity)
 
+        # Test non-integer multiplicity
+        with self.assertRaises(MoleculeNameError):
+            MolecularData(geometry, basis, multiplicity=1.5)
+
+        # Test zero multiplicity
+        with self.assertRaises(MoleculeNameError):
+            MolecularData(geometry, basis, multiplicity=0)
+
+    def test_high_multiplicity(self):
+        # 12 hydrogens can support multiplicity 13
+        geometry = [('H', (0.0, 0.0, i * 1.3)) for i in range(12)]
+        basis = 'sto-3g'
+        molecule = MolecularData(geometry, basis, multiplicity=13)
+        self.assertEqual(molecule.name, 'H12_sto-3g_13-multiplet')
+
     def test_geometry_from_file(self):
         water_geometry = [
             ('O', (0.0, 0.0, 0.0)),


### PR DESCRIPTION
Fixes #809  Previously the spin state name was obtained using a dictionary mapping integer multiplicity to the name string. Only up to 11 unpaired electrons were supported this way, with an error thrown for anything larger. With this change, larger spins are named via n-multiplet (e.g. 12 unpaired electrons is named 13-multiplet).

Tests are added to check the naming for large spin states is correct, and that non-integer spin states still throw an error.