### PR TITLE
Add nsteps for Trotter expansion based on propagator error

### DIFF
--- a/src/openfermion/__init__.py
+++ b/src/openfermion/__init__.py
@@ -266,10 +266,12 @@ from openfermion.circuits import (
     error_bound,
     error_operator,
     trotter_steps_required,
+    trotter_steps_required_propagator,
     vpe_single_circuit,
     vpe_circuits_single_timestep,
     standard_vpe_rotation_set,
 )
+
 
 from openfermion.testing import (
     validate_trotterized_evolution,

--- a/src/openfermion/__init__.py
+++ b/src/openfermion/__init__.py
@@ -272,7 +272,6 @@ from openfermion.circuits import (
     standard_vpe_rotation_set,
 )
 
-
 from openfermion.testing import (
     validate_trotterized_evolution,
     random_interaction_operator_term,

--- a/src/openfermion/circuits/__init__.py
+++ b/src/openfermion/circuits/__init__.py
@@ -100,7 +100,6 @@ from .trotter import (
     trotter_steps_required_propagator,
 )
 
-
 from .vpe_circuits import (
     vpe_single_circuit,
     vpe_circuits_single_timestep,

--- a/src/openfermion/circuits/__init__.py
+++ b/src/openfermion/circuits/__init__.py
@@ -97,7 +97,9 @@ from .trotter import (
     error_bound,
     error_operator,
     trotter_steps_required,
+    trotter_steps_required_propagator,
 )
+
 
 from .vpe_circuits import (
     vpe_single_circuit,

--- a/src/openfermion/circuits/trotter/__init__.py
+++ b/src/openfermion/circuits/trotter/__init__.py
@@ -43,4 +43,9 @@ from .simulate_trotter import simulate_trotter
 
 from .trotter_algorithm import TrotterAlgorithm, TrotterStep
 
-from .trotter_error import error_bound, error_operator, trotter_steps_required
+from .trotter_error import (
+    error_bound,
+    error_operator,
+    trotter_steps_required,
+    trotter_steps_required_propagator,
+)

--- a/src/openfermion/circuits/trotter/trotter_error.py
+++ b/src/openfermion/circuits/trotter/trotter_error.py
@@ -178,7 +178,20 @@ def error_bound(terms, tight=False):
 
 
 def trotter_steps_required(trotter_error_bound, time, energy_precision):
-    """Determine the number of Trotter steps for accurate simulation.
+    r"""Determine the number of Trotter steps for accurate energy estimation.
+
+    This function calculates the number of steps required to bound the
+    systematic energy shift (eigenvalue shift) of the effective Hamiltonian
+    to a given precision. This is appropriate for applications like Quantum
+    Phase Estimation (QPE) where we only care about the eigenvalues of the
+    propagator. See appendix B from https://arxiv.org/pdf/1312.1695
+    This uses the following definition of error for time t and
+    number of steps r:
+
+
+    $$
+    \lvert E - E^{TS} \rvert = \frac{t^2}{r^2} E_{bound}(H)
+    $$
 
     Args:
         trotter_error_bound (float): Upper bound on Trotter error in the
@@ -187,11 +200,34 @@ def trotter_steps_required(trotter_error_bound, time, energy_precision):
         energy_precision (float): Acceptable shift in state energy.
 
     Returns:
-        The integer minimum number of Trotter steps required for
-        simulation to the desired precision.
-
-    Notes:
-        The number of Trotter steps required is an upper bound on the
-        true requirement, which may be lower.
+        The integer minimum number of Trotter steps required.
     """
-    return int(ceil(time * sqrt(trotter_error_bound / energy_precision)))
+    return int(ceil(abs(time) * sqrt(trotter_error_bound / energy_precision)))
+
+
+def trotter_steps_required_propagator(trotter_error_bound, time, prop_precision):
+    r"""Determine the number of Trotter steps for accurate state evolution.
+
+    This function calculates the number of steps required to bound the
+    error in the time evolution operator (propagator error / spectral norm error)
+    to a given fidelity precision. This is appropriate for quantum dynamics
+    applications where we care about the accuracy of the state itself over
+    time. This uses the following definition of error for time t and
+    number of steps r:
+
+    $$
+    \lVert U - U^{TS} \rVert = \frac{t^3}{r^2} E_{bound}(H)
+    $$
+
+    Args:
+        trotter_error_bound (float): Upper bound on Trotter error in the
+                                     state of interest.
+        time (float): The total simulation time.
+        prop_precision (float): Acceptable error in the time evolution
+                                    operator (propagator error).
+
+    Returns:
+        The integer minimum number of Trotter steps required.
+    """
+    atime = abs(time)
+    return int(ceil(atime * sqrt(atime * trotter_error_bound / prop_precision)))

--- a/src/openfermion/circuits/trotter/trotter_error.py
+++ b/src/openfermion/circuits/trotter/trotter_error.py
@@ -202,7 +202,11 @@ def trotter_steps_required(trotter_error_bound, time, energy_precision):
     Returns:
         The integer minimum number of Trotter steps required.
     """
-    return int(ceil(abs(time) * sqrt(trotter_error_bound / energy_precision)))
+    if energy_precision <= 0:
+        raise ValueError("energy_precision must be strictly positive.")
+    if time == 0:
+        return 0
+    return max(1, int(ceil(abs(time) * sqrt(trotter_error_bound / energy_precision))))
 
 
 def trotter_steps_required_propagator(trotter_error_bound, time, prop_precision):
@@ -229,5 +233,9 @@ def trotter_steps_required_propagator(trotter_error_bound, time, prop_precision)
     Returns:
         The integer minimum number of Trotter steps required.
     """
+    if prop_precision <= 0:
+        raise ValueError("prop_precision must be strictly positive.")
+    if time == 0:
+        return 0
     atime = abs(time)
-    return int(ceil(atime * sqrt(atime * trotter_error_bound / prop_precision)))
+    return max(1, int(ceil(atime * sqrt(atime * trotter_error_bound / prop_precision))))

--- a/src/openfermion/circuits/trotter/trotter_error.py
+++ b/src/openfermion/circuits/trotter/trotter_error.py
@@ -204,6 +204,8 @@ def trotter_steps_required(trotter_error_bound, time, energy_precision):
     """
     if energy_precision <= 0:
         raise ValueError("energy_precision must be strictly positive.")
+    if trotter_error_bound < 0:
+        raise ValueError("trotter_error_bound must be non-negative.")
     if time == 0:
         return 0
     return max(1, int(ceil(abs(time) * sqrt(trotter_error_bound / energy_precision))))
@@ -235,6 +237,8 @@ def trotter_steps_required_propagator(trotter_error_bound, time, prop_precision)
     """
     if prop_precision <= 0:
         raise ValueError("prop_precision must be strictly positive.")
+    if trotter_error_bound < 0:
+        raise ValueError("trotter_error_bound must be non-negative.")
     if time == 0:
         return 0
     atime = abs(time)

--- a/src/openfermion/circuits/trotter/trotter_error_test.py
+++ b/src/openfermion/circuits/trotter/trotter_error_test.py
@@ -24,6 +24,7 @@ from openfermion.circuits.trotter.trotter_error import (
     error_operator,
     error_bound,
     trotter_steps_required,
+    trotter_steps_required_propagator,
 )
 
 
@@ -161,8 +162,25 @@ class TrotterStepsRequiredTest(unittest.TestCase):
 
     def test_trotter_steps_required_negative_time(self):
         self.assertEqual(
-            trotter_steps_required(trotter_error_bound=0.1, time=3.3, energy_precision=0.11), 4
+            trotter_steps_required(trotter_error_bound=0.1, time=-3.3, energy_precision=0.11), 4
+        )
+
+    def test_trotter_steps_required_propagator(self):
+        self.assertEqual(
+            trotter_steps_required_propagator(
+                trotter_error_bound=0.3, time=2.5, prop_precision=0.04
+            ),
+            11,
+        )
+
+    def test_trotter_steps_required_propagator_negative_time(self):
+        self.assertEqual(
+            trotter_steps_required_propagator(
+                trotter_error_bound=0.1, time=-3.3, prop_precision=0.11
+            ),
+            6,
         )
 
     def test_return_type(self):
         self.assertIsInstance(trotter_steps_required(0.1, 0.1, 0.1), int)
+        self.assertIsInstance(trotter_steps_required_propagator(0.1, 0.1, 0.1), int)

--- a/src/openfermion/circuits/trotter/trotter_error_test.py
+++ b/src/openfermion/circuits/trotter/trotter_error_test.py
@@ -212,6 +212,14 @@ class TrotterStepsRequiredTest(unittest.TestCase):
                 trotter_error_bound=0.3, time=2.5, prop_precision=-0.04
             )
 
+    def test_trotter_steps_required_invalid_error_bound(self):
+        with self.assertRaises(ValueError):
+            trotter_steps_required(trotter_error_bound=-0.3, time=2.5, energy_precision=0.04)
+        with self.assertRaises(ValueError):
+            trotter_steps_required_propagator(
+                trotter_error_bound=-0.3, time=2.5, prop_precision=0.04
+            )
+
     def test_return_type(self):
         self.assertIsInstance(trotter_steps_required(0.1, 0.1, 0.1), int)
         self.assertIsInstance(trotter_steps_required_propagator(0.1, 0.1, 0.1), int)

--- a/src/openfermion/circuits/trotter/trotter_error_test.py
+++ b/src/openfermion/circuits/trotter/trotter_error_test.py
@@ -159,13 +159,6 @@ class TrotterStepsRequiredTest(unittest.TestCase):
         self.assertEqual(
             trotter_steps_required(trotter_error_bound=0.3, time=2.5, energy_precision=0.04), 7
         )
-
-    def test_trotter_steps_required_negative_time(self):
-        self.assertEqual(
-            trotter_steps_required(trotter_error_bound=0.1, time=-3.3, energy_precision=0.11), 4
-        )
-
-    def test_trotter_steps_required_propagator(self):
         self.assertEqual(
             trotter_steps_required_propagator(
                 trotter_error_bound=0.3, time=2.5, prop_precision=0.04
@@ -173,13 +166,51 @@ class TrotterStepsRequiredTest(unittest.TestCase):
             11,
         )
 
-    def test_trotter_steps_required_propagator_negative_time(self):
+    def test_trotter_steps_required_negative_time(self):
+        self.assertEqual(
+            trotter_steps_required(trotter_error_bound=0.1, time=-3.3, energy_precision=0.11), 4
+        )
         self.assertEqual(
             trotter_steps_required_propagator(
                 trotter_error_bound=0.1, time=-3.3, prop_precision=0.11
             ),
             6,
         )
+
+    def test_trotter_steps_required_zero_time(self):
+        self.assertEqual(
+            trotter_steps_required(trotter_error_bound=0.3, time=0.0, energy_precision=0.04), 0
+        )
+        self.assertEqual(
+            trotter_steps_required_propagator(
+                trotter_error_bound=0.3, time=0.0, prop_precision=0.04
+            ),
+            0,
+        )
+
+    def test_trotter_steps_required_zero_error_bound(self):
+        # Should return at least 1 step for non-zero time even if error bound is 0
+        self.assertEqual(
+            trotter_steps_required(trotter_error_bound=0.0, time=2.5, energy_precision=0.04), 1
+        )
+        self.assertEqual(
+            trotter_steps_required_propagator(
+                trotter_error_bound=0.0, time=2.5, prop_precision=0.04
+            ),
+            1,
+        )
+
+    def test_trotter_steps_required_invalid_precision(self):
+        with self.assertRaises(ValueError):
+            trotter_steps_required(trotter_error_bound=0.3, time=2.5, energy_precision=0.0)
+        with self.assertRaises(ValueError):
+            trotter_steps_required(trotter_error_bound=0.3, time=2.5, energy_precision=-0.04)
+        with self.assertRaises(ValueError):
+            trotter_steps_required_propagator(trotter_error_bound=0.3, time=2.5, prop_precision=0.0)
+        with self.assertRaises(ValueError):
+            trotter_steps_required_propagator(
+                trotter_error_bound=0.3, time=2.5, prop_precision=-0.04
+            )
 
     def test_return_type(self):
         self.assertIsInstance(trotter_steps_required(0.1, 0.1, 0.1), int)


### PR DESCRIPTION
Fixes #820. Currently we compute the number of steps in a Trotter expansion based on the desired error in the ground state energy. This PR adds a function to compute the number of steps based on the desired error in the propagator $U$ (which is different). This could be useful for certain use cases like dynamics. 

New tests are also added to cover this new function.