### PR TITLE
Fix modification of rotation matrix in Givens rotation

### DIFF
--- a/src/openfermion/circuits/primitives/optimal_givens_decomposition.py
+++ b/src/openfermion/circuits/primitives/optimal_givens_decomposition.py
@@ -52,6 +52,7 @@ def optimal_givens_decomposition(
                 should be ordered in linear physical order.
         unitary:
     """
+    unitary = unitary.copy()
     N = unitary.shape[0]
     right_rotations = []
     left_rotations = []

--- a/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
+++ b/src/openfermion/circuits/primitives/optimal_givens_decomposition_test.py
@@ -235,3 +235,14 @@ def test_circuit_generation_state():
     cirq_wf = simulator.simulate(circuit).final_state_vector
 
     assert numpy.allclose(cirq_wf, test_final_state.flatten())
+
+
+def test_consecutive_optimal_givens_decomposition():
+    n_qubits = 3
+    qubits = cirq.LineQubit.range(n_qubits)
+    mat = cirq.testing.random_unitary(n_qubits)
+
+    circuit1 = cirq.Circuit(optimal_givens_decomposition(qubits, mat))
+    circuit2 = cirq.Circuit(optimal_givens_decomposition(qubits, mat))
+
+    assert circuit1 == circuit2


### PR DESCRIPTION
Fixes #761 (supersedes #1344). In the `optimal_givens_decomposition()` function, the rotation matrix was modified, leading to different results when the function was called again with the same rotation matrix. The function now makes a copy of the rotation matrix parameter to avoid this issue. A test was added to ensure consecutive calls to `optimal_givens_decomposition()` yield identical results.