### PR TITLE
Fix factor of 2 in Rz operator in trotter_export_to_qgates_test.py

### DIFF
--- a/src/openfermion/circuits/trotter_exp_to_qgates.py
+++ b/src/openfermion/circuits/trotter_exp_to_qgates.py
@@ -243,19 +243,21 @@ def pauli_exp_to_qasm(qubit_operator_list, evolution_time=1.0, qubit_list=None, 
                 if len(qids) > 0:
                     ret_list = ret_list + [
                         "C-Phase {} {} {}".format(
-                            -2 * term_coeff * evolution_time, ancilla, qids[-1]
+                            2 * term_coeff * evolution_time, ancilla, qids[-1]
                         )
                     ]
                     ret_list = ret_list + [
-                        "Rz {} {}".format(1 * term_coeff * evolution_time, ancilla)
+                        "Rz {} {}".format(-1 * term_coeff * evolution_time, ancilla)
                     ]
                 else:
                     ret_list = ret_list + [
-                        "Rz {} {}".format(1 * term_coeff * evolution_time, ancilla)
+                        "Rz {} {}".format(-1 * term_coeff * evolution_time, ancilla)
                     ]
             else:
                 if len(qids) > 0:
-                    ret_list = ret_list + ["Rz {} {}".format(term_coeff * evolution_time, qids[-1])]
+                    ret_list = ret_list + [
+                        "Rz {} {}".format(2 * term_coeff * evolution_time, qids[-1])
+                    ]
 
             # 4. Second set of CNOTs
             ret_list = ret_list + cnots2

--- a/src/openfermion/circuits/trotter_exp_to_qgates.py
+++ b/src/openfermion/circuits/trotter_exp_to_qgates.py
@@ -233,37 +233,29 @@ def pauli_exp_to_qasm(qubit_operator_list, evolution_time=1.0, qubit_list=None, 
             # Exponentiating each Pauli string requires five parts
 
             # 1. Perform basis rotations
-            ret_list = ret_list + string_basis_1
+            ret_list.extend(string_basis_1)
 
             # 2. First set CNOTs
-            ret_list = ret_list + cnots1
+            ret_list.extend(cnots1)
 
             # 3. Rotation (Note kexp & Ntrot)
             if ancilla is not None:
                 if len(qids) > 0:
-                    ret_list = ret_list + [
+                    ret_list.append(
                         "C-Phase {} {} {}".format(
                             2 * term_coeff * evolution_time, ancilla, qids[-1]
                         )
-                    ]
-                    ret_list = ret_list + [
-                        "Rz {} {}".format(-1 * term_coeff * evolution_time, ancilla)
-                    ]
-                else:
-                    ret_list = ret_list + [
-                        "Rz {} {}".format(-1 * term_coeff * evolution_time, ancilla)
-                    ]
+                    )
+                ret_list.append("Rz {} {}".format(-term_coeff * evolution_time, ancilla))
             else:
                 if len(qids) > 0:
-                    ret_list = ret_list + [
-                        "Rz {} {}".format(2 * term_coeff * evolution_time, qids[-1])
-                    ]
+                    ret_list.append("Rz {} {}".format(2 * term_coeff * evolution_time, qids[-1]))
 
             # 4. Second set of CNOTs
-            ret_list = ret_list + cnots2
+            ret_list.extend(cnots2)
 
             # 5. Rotate back to Z basis
-            ret_list = ret_list + string_basis_2
+            ret_list.extend(string_basis_2)
 
             for gate in ret_list:
                 yield gate

--- a/src/openfermion/circuits/trotter_exp_to_qgates_test.py
+++ b/src/openfermion/circuits/trotter_exp_to_qgates_test.py
@@ -210,7 +210,7 @@ class TrottQasmTest(unittest.TestCase):
         # Correct string
         strcorrect = '''5
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4'''
 
         self.assertEqual(qasmstr, strcorrect)
@@ -231,7 +231,7 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -255,8 +255,8 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-C-Phase -1.0 ancilla 3
-Rz 0.5 ancilla
+C-Phase 1.0 ancilla 3
+Rz -0.5 ancilla
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -284,8 +284,8 @@ H q0
 Rx 1.5707963267948966 q3
 CNOT q0 q1
 CNOT q1 q3
-C-Phase -1.0 ancilla q3
-Rz 0.5 ancilla
+C-Phase 1.0 ancilla q3
+Rz -0.5 ancilla
 CNOT q1 q3
 CNOT q0 q1
 H q0
@@ -300,7 +300,7 @@ Rx -1.5707963267948966 q3'''
         qasmstr += "\n".join(trotterize_exp_qubop_to_qasm(self.op_id, ancilla='ancilla'))
 
         strcorrect = '''1
-Rz 1.0 ancilla'''
+Rz -1.0 ancilla'''
 
         self.assertEqual(qasmstr, strcorrect)
 
@@ -329,13 +329,13 @@ Rz 1.0 ancilla'''
         # the order in which the operators loop.
         strcorrect1 = '''5
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4
 H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
@@ -346,13 +346,13 @@ H 0
 Rx 1.5707963267948966 3
 CNOT 0 1
 CNOT 1 3
-Rz 0.5 3
+Rz 1.0 3
 CNOT 1 3
 CNOT 0 1
 H 0
 Rx -1.5707963267948966 3
 CNOT 3 4
-Rz 0.6 4
+Rz 1.2 4
 CNOT 3 4'''
         try:
             self.assertEqual(qasmstr, strcorrect1)


### PR DESCRIPTION
Fixes #721 (supersedes #1343). A factor of 2 error in Rz gates is corrected when outputting a Trotter decomposition to QASM (for both the controlled and uncontrolled versions). The corresponding tests are also corrected.