### PR TITLE
Fix broken string in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ __version__ = runpy.run_path('src/openfermion/_version.py')['__version__']
 assert __version__, 'Version string cannot be empty'
 
 description = (
-    'Package to compile and analyze quantum algorithms for ' 'simulating fermionic systems.'
+    'Package to compile and analyze quantum algorithms for simulating fermionic systems.'
 )
 
 # The readme file is used as the long_description.

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ from setuptools import find_packages, setup
 __version__ = runpy.run_path('src/openfermion/_version.py')['__version__']
 assert __version__, 'Version string cannot be empty'
 
-description = (
-    'Package to compile and analyze quantum algorithms for simulating fermionic systems.'
-)
+description = 'Package to compile and analyze quantum algorithms for simulating fermionic systems.'
 
 # The readme file is used as the long_description.
 with open('README.md', 'r', encoding='utf-8') as readme:


### PR DESCRIPTION
I didn't notice that my push for fixing the broken string didn't succeed, but I had already click the button to merge PR #1378. This contains the change that should have been part of that PR.