### PR TITLE
Update docs/_book.yaml to fix broken doc builds

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -3,8 +3,6 @@ upper_tabs:
 - name: "Software"
   path: /software
   is_default: true
-  menu:
-  - include: /_book/menu_software.yaml
   lower_tabs:
     # Subsite tabs
     other:


### PR DESCRIPTION

The last refresh to quantumai.google removed
`/_book/menu_software.yaml`. This has caused the documentation workflow
to fail.

This may be the cause of the failures in #787. It will not be clear
until this is merged into main and the (internal) Google documentation
system runs its nightly update.
