### PR TITLE
Fix type casting error in thc_jax.py

### DIFF
--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax.py
@@ -213,7 +213,7 @@ def compute_objective_batched(
     lambda_z = jnp.sum(jnp.einsum("jpq->j", 0.5 * jnp.abs(mpq_normalized)) ** 2.0)
 
     res = 0.5 * jnp.sum((jnp.abs(deri)) ** 2) + penalty_param * lambda_z
-    return float(res)
+    return res
 
 
 def prepare_batched_data_indx_arrays(

--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax.py
@@ -27,6 +27,7 @@ be used as
 # pylint: disable=wrong-import-position
 import math
 import time
+from typing import cast
 
 import h5py
 import numpy as np
@@ -213,7 +214,7 @@ def compute_objective_batched(
     lambda_z = jnp.sum(jnp.einsum("jpq->j", 0.5 * jnp.abs(mpq_normalized)) ** 2.0)
 
     res = 0.5 * jnp.sum((jnp.abs(deri)) ** 2) + penalty_param * lambda_z
-    return res
+    return cast(float, res)
 
 
 def prepare_batched_data_indx_arrays(


### PR DESCRIPTION
When running mypy, an error would occur because the function compute_objective_batched in src/openfermion/resource_estimates/pbc/thc/factorizations/thc_jax.py did a `float()` cast on the value it was to return. The function is decorated with `@jax.jit`, making it a JIT-compiled function. During JAX's trace-compilation, the argument variables are abstract `Tracer` objects rather than concrete floats. Calling `float()` on a `Tracer` object causes a `jax.errors.ConcretizationTypeError` because the actual value is not known when building the JAX computation graph.

The change here uses `cast` from `typing`, which satisfies mypy's static analysis at compile-time and does not interfere with JAX's graph tracer.