### PR TITLE
Support Cirq 1.7 change in exponents that affects rendering of circuit diagrams

### DIFF
--- a/src/openfermion/circuits/gates/four_qubit_gates.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates.py
@@ -124,9 +124,17 @@ class DoubleExcitationGate(cirq.EigenGate):
             # Split up this string to avoid SyntaxError in Python 3.12.
             down_up = r'\/ /' + '\\'
             wire_symbols = (up_down, up_down, down_up, down_up)
-        return cirq.CircuitDiagramInfo(
-            wire_symbols=wire_symbols, exponent=self._diagram_exponent(args)
-        )
+
+        exponent = self._diagram_exponent(args)
+        if isinstance(exponent, (int, float)):
+            # Canonicalize rounded exponent into (-1, 1] range (DoubleExcitation has period 2)
+            h = 1.0
+            if not (-h < exponent <= h):
+                exponent = h - exponent
+                exponent %= 2.0
+                exponent = h - exponent
+
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols, exponent=exponent)
 
     def __repr__(self):
         if self.exponent == 1:

--- a/src/openfermion/circuits/gates/four_qubit_gates.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates.py
@@ -126,13 +126,9 @@ class DoubleExcitationGate(cirq.EigenGate):
             wire_symbols = (up_down, up_down, down_up, down_up)
 
         exponent = self._diagram_exponent(args)
-        if isinstance(exponent, (int, float)):
+        if isinstance(exponent, (int, float, np.integer, np.floating)):
             # Canonicalize rounded exponent into (-1, 1] range (DoubleExcitation has period 2)
-            h = 1.0
-            if not (-h < exponent <= h):
-                exponent = h - exponent
-                exponent %= 2.0
-                exponent = h - exponent
+            exponent = 1.0 - (1.0 - exponent) % 2.0
 
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols, exponent=exponent)
 

--- a/src/openfermion/circuits/gates/four_qubit_gates.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates.py
@@ -13,6 +13,7 @@
 
 from typing import Optional, Union
 
+import numbers
 import numpy as np
 import sympy
 
@@ -126,9 +127,9 @@ class DoubleExcitationGate(cirq.EigenGate):
             wire_symbols = (up_down, up_down, down_up, down_up)
 
         exponent = self._diagram_exponent(args)
-        if isinstance(exponent, (int, float, np.integer, np.floating)):
+        if isinstance(exponent, numbers.Real):
             # Canonicalize rounded exponent into (-1, 1] range (DoubleExcitation has period 2)
-            exponent = 1.0 - (1.0 - exponent) % 2.0
+            exponent = 1.0 - (1.0 - float(exponent)) % 2.0
 
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols, exponent=exponent)
 

--- a/src/openfermion/circuits/gates/four_qubit_gates_test.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates_test.py
@@ -379,12 +379,7 @@ def test_double_excitation_diagram_real_exponent_types():
     import sympy
 
     # Test types that should be canonicalized (e.g. 2.3 -> 0.3)
-    exponents = [
-        2.3,
-        numpy.float64(2.3),
-        sympy.Float(2.3),
-        fractions.Fraction(23, 10),
-    ]
+    exponents = [2.3, numpy.float64(2.3), sympy.Float(2.3), fractions.Fraction(23, 10)]
     for exponent in exponents:
         gate = openfermion.DoubleExcitationGate(exponent=exponent)
         info = cirq.protocols.circuit_diagram_info(gate)
@@ -396,4 +391,3 @@ def test_double_excitation_diagram_real_exponent_types():
     gate = openfermion.DoubleExcitationGate(exponent=sym)
     info = cirq.protocols.circuit_diagram_info(gate)
     assert info.exponent == sym
-

--- a/src/openfermion/circuits/gates/four_qubit_gates_test.py
+++ b/src/openfermion/circuits/gates/four_qubit_gates_test.py
@@ -372,3 +372,28 @@ def test_double_excitation_matches_fermionic_evolution(exponent):
     time_evol_op = time_evol_op.todense()
 
     cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(gate), time_evol_op, atol=1e-7)
+
+
+def test_double_excitation_diagram_real_exponent_types():
+    import fractions
+    import sympy
+
+    # Test types that should be canonicalized (e.g. 2.3 -> 0.3)
+    exponents = [
+        2.3,
+        numpy.float64(2.3),
+        sympy.Float(2.3),
+        fractions.Fraction(23, 10),
+    ]
+    for exponent in exponents:
+        gate = openfermion.DoubleExcitationGate(exponent=exponent)
+        info = cirq.protocols.circuit_diagram_info(gate)
+        # 1.0 - (1.0 - 2.3) % 2.0 is 0.3
+        assert numpy.isclose(float(info.exponent), 0.3)
+
+    # Symbolic exponent should remain untouched
+    sym = sympy.Symbol('x')
+    gate = openfermion.DoubleExcitationGate(exponent=sym)
+    info = cirq.protocols.circuit_diagram_info(gate)
+    assert info.exponent == sym
+


### PR DESCRIPTION
In versions of Cirq below 1.7, `cirq.EigenGate._diagram_exponent()` automatically canonicalized exponents into the interval (-period/2, period/2]. Because `DoubleExcitationGate` has a diagram period of 2, an exponent of `2.3` used to be canonicalized to `0.3` for diagram purposes (because 2.3 mod 2 ≡ 0.3).

In the just-released Cirq 1.7.0, the canonicalization logic was removed from `EigenGate._diagram_exponent()` – I think it was in PR https://github.com/quantumlib/Cirq/pull/7954. As a result, `DoubleExcitation(d, b, a, c) ** 2.3` is now rendered in diagrams with `^2.3` instead of `^0.3`. Some tests in `four_qubit_gates_test.py` compared circuit diagrams, and those tests fail in Cirq 1.7.0

Since we need to support both 1.7.0 and lower versions of Cirq, this PR adds a step to put the exponent in the canonical form that was used before. This seems like the best approach to preserve backward compatibility and still work with the latest version of Cirq.