### PR TITLE
Don't add package name to `site_path` value in `dev_tools/docs/build_api_docs.py`

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -35,7 +35,7 @@ flags.DEFINE_string(
 
 flags.DEFINE_bool("search_hints", True, "Include metadata search hints in the generated files")
 
-flags.DEFINE_string("site_path", "/reference/python/openfermion", "Path prefix in the _toc.yaml")
+flags.DEFINE_string("site_path", "/reference/python", "Path prefix in the _toc.yaml")
 
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
The base `site_path` parameter value is used to construct the absolute URLs for the table of contents and redirects. Past organizations of the DevSite-based API documentation for OpenFermion must have been slightly different. To make things work correctly today, the value of `site_path` in dev_tools/docs/build_api_docs.py must omit the `openfermion` part, because the Python API generator (`tensorflow_docs.api_generator`) automatically appends the Python package's namespace (`openfermion`) to the base `site_path`.

This change only affects the metadata links generated in the `_toc.yaml` and `_redirects.yaml` files used for the web site served internally by Google.