### PR TITLE
Mark `test_kpoint_isdf_symmetries()` as flaky

### DIFF
--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
@@ -360,7 +360,7 @@ def get_complement(miller_indx, kmesh):
 
 @pytest.mark.skipif(not HAVE_DEPS_FOR_RESOURCE_ESTIMATES, reason='pyscf and/or jax not installed.')
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=1)
+@pytest.mark.flaky(retries=1)
 def test_kpoint_isdf_symmetries():
     cell = gto.Cell()
     cell.atom = """

--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
@@ -360,6 +360,7 @@ def get_complement(miller_indx, kmesh):
 
 @pytest.mark.skipif(not HAVE_DEPS_FOR_RESOURCE_ESTIMATES, reason='pyscf and/or jax not installed.')
 @pytest.mark.slow
+@pytest.mark.flaky(reruns=1)
 def test_kpoint_isdf_symmetries():
     cell = gto.Cell()
     cell.atom = """


### PR DESCRIPTION
This function in file `src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py` occasionally fails to converge. This PR marks it as flaky and tells pytest to retry it once, so that people don't waste time chasing ghosts.