### PR TITLE
Add missing `r` to `gvec_map_logic.py` module docstring

### DIFF
--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/gvec_map_logic.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/gvec_map_logic.py
@@ -10,7 +10,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Module for testing how to map k-points between each other.
+r"""Module for testing how to map k-points between each other.
 
 Reciprocal lattice vectors ($G_{\mathrm{pqr}}$) are defined as linear combinations of
 underlying primitive vectors ${b_i}$ via


### PR DESCRIPTION
The module doc string in 	`src/openfermion/resource_estimates/pbc/thc/factorizations/gvec_map_logic.py` was not an "r" string, which led to parsing errors due to the LaTeX notation used in the content of the string. This adds the missing `r` prefix.