### PR TITLE
Use `retry_once_with_later_random_values()` in isdf_test.py

### DIFF
--- a/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
+++ b/src/openfermion/resource_estimates/pbc/thc/factorizations/isdf_test.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from openfermion.resource_estimates import HAVE_DEPS_FOR_RESOURCE_ESTIMATES
+from openfermion.testing import retry_once_with_later_random_values
 
 if HAVE_DEPS_FOR_RESOURCE_ESTIMATES:
     from ase.build import bulk
@@ -360,7 +361,7 @@ def get_complement(miller_indx, kmesh):
 
 @pytest.mark.skipif(not HAVE_DEPS_FOR_RESOURCE_ESTIMATES, reason='pyscf and/or jax not installed.')
 @pytest.mark.slow
-@pytest.mark.flaky(retries=1)
+@retry_once_with_later_random_values
 def test_kpoint_isdf_symmetries():
     cell = gto.Cell()
     cell.atom = """


### PR DESCRIPTION
The test `test_kpoint_isdf_symmetries()` will occasionally fail, and when it does, retrying won't work unless a different random seed is used.