### PR TITLE
Update the installation instructions in all tutorial notebooks

### DIFF
--- a/docs/tutorials/binary_code_transforms.ipynb
+++ b/docs/tutorials/binary_code_transforms.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/binary_code_transforms.ipynb
+++ b/docs/tutorials/binary_code_transforms.ipynb
@@ -81,10 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/bosonic_operators.ipynb
+++ b/docs/tutorials/bosonic_operators.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/bosonic_operators.ipynb
+++ b/docs/tutorials/bosonic_operators.ipynb
@@ -81,10 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_1_basis_change.ipynb
+++ b/docs/tutorials/circuits_1_basis_change.ipynb
@@ -90,10 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_1_basis_change.ipynb
+++ b/docs/tutorials/circuits_1_basis_change.ipynb
@@ -90,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
+++ b/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
+++ b/docs/tutorials/circuits_2_diagonal_coulomb_trotter.ipynb
@@ -81,10 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
+++ b/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
+++ b/docs/tutorials/circuits_3_arbitrary_basis_trotter.ipynb
@@ -81,10 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/intro_to_openfermion.ipynb
+++ b/docs/tutorials/intro_to_openfermion.ipynb
@@ -90,10 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/intro_to_openfermion.ipynb
+++ b/docs/tutorials/intro_to_openfermion.ipynb
@@ -90,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/intro_workshop_exercises.ipynb
+++ b/docs/tutorials/intro_workshop_exercises.ipynb
@@ -79,12 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion as of\n",
-    "    import openfermionpyscf as ofpyscf\n",
-    "except ImportError:\n",
-    "    print(\"Installing OpenFermion and OpenFermion-PySCF...\")\n",
-    "    !pip install openfermion openfermionpyscf --quiet"
+    "!pip install -q openfermion openfermionpyscf"
    ]
   },
   {

--- a/docs/tutorials/intro_workshop_exercises.ipynb
+++ b/docs/tutorials/intro_workshop_exercises.ipynb
@@ -79,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion openfermionpyscf"
+    "%pip install -q openfermion openfermionpyscf"
    ]
   },
   {

--- a/docs/tutorials/jordan_wigner_and_bravyi_kitaev_transforms.ipynb
+++ b/docs/tutorials/jordan_wigner_and_bravyi_kitaev_transforms.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q openfermion"
+    "%pip install -q openfermion"
    ]
   },
   {

--- a/docs/tutorials/jordan_wigner_and_bravyi_kitaev_transforms.ipynb
+++ b/docs/tutorials/jordan_wigner_and_bravyi_kitaev_transforms.ipynb
@@ -81,10 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import openfermion\n",
-    "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/OpenFermion.git@main#egg=openfermion"
+    "!pip install -q openfermion"
    ]
   },
   {


### PR DESCRIPTION
This replaces the previous instructions with a simpler and more direct pip installation command.