### PR TITLE
Version bump for release 1.8.0

### DIFF
--- a/src/openfermion/_version.py
+++ b/src/openfermion/_version.py
@@ -12,4 +12,4 @@
 
 """Define version number here and read it from setup.py automatically"""
 
-__version__ = "1.7.2.dev0"
+__version__ = "1.8.0"


### PR DESCRIPTION
Bump the version in main so that we can tag the 1.8.0 release.