### PR TITLE
Speed up LinearQubitOperator matvec

### DIFF
--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -115,7 +115,7 @@ class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
         """
         arr = numpy.asarray(x)
         vec = arr.reshape(-1)
-        indices = numpy.arange(vec.size, dtype=numpy.uint64)
+        indices = None
         retvec = numpy.zeros(vec.size, dtype=complex)
 
         for qubit_term, coefficient in self.qubit_operator.terms.items():
@@ -133,9 +133,12 @@ class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
                 else:
                     z_mask ^= bit
 
-            amplitudes = coefficient * [1, 1j, -1, -1j][y_count % 4] * vec
+            amplitudes = coefficient * (1, 1j, -1, -1j)[y_count % 4] * vec
+            if z_mask or x_mask:
+                if indices is None:
+                    indices = numpy.arange(vec.size, dtype=numpy.uint64)
             if z_mask:
-                signs = 1 - 2 * _bit_parity(indices & numpy.uint64(z_mask)).astype(numpy.int64)
+                signs = 1 - 2 * _bit_parity(indices & numpy.uint64(z_mask)).astype(numpy.int8)
                 amplitudes = signs * amplitudes
             if x_mask:
                 retvec[indices ^ numpy.uint64(x_mask)] += amplitudes

--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -24,6 +24,17 @@ from openfermion.utils.operator_utils import count_qubits
 from openfermion.config import get_available_cpu_count
 
 
+def _bit_parity(values):
+    """Returns the parity of the population count of each uint64 value."""
+    values = values ^ (values >> numpy.uint64(32))
+    values = values ^ (values >> numpy.uint64(16))
+    values = values ^ (values >> numpy.uint64(8))
+    values = values ^ (values >> numpy.uint64(4))
+    values = values ^ (values >> numpy.uint64(2))
+    values = values ^ (values >> numpy.uint64(1))
+    return values & numpy.uint64(1)
+
+
 class LinearQubitOperatorOptions:
     """Options for LinearQubitOperator."""
 
@@ -63,20 +74,14 @@ class LinearQubitOperatorOptions:
 class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
     """A LinearOperator implied from a QubitOperator.
 
-    The idea is that a single i_th qubit operator, O_i, is a 2-by-2 matrix, to
-    be applied on a vector of length n_hilbert / 2^i, performs permutations
-    and/or adds an extra factor for its first half and the second half, e.g. a `Z`
-    operator keeps the first half unchanged, while adds a factor of -1 to the
-    second half, while an `I` keeps it both components unchanged.
-
-    Note that the vector length is n_hilbert / 2^i, therefore when one works on
-    i monotonically (in increasing order), one keeps splitting the vector to the
-    right size and then apply O_i on them independently.
-
-    Also note that operator O_i, is an *envelop operator* for all operators
-    after it, i.e. {O_j | j > i}, which implies that starting with i = 0, one
-    can split the vector, apply O_i, split the resulting vector (cached) again
-    for the next operator."""
+    Each term of the QubitOperator is a tensor product of Pauli operators and
+    acts on an amplitude vector as a signed permutation. Qubit q corresponds to
+    bit (n_qubits - 1 - q) of the amplitude index. The qubits carrying an X or Y
+    flip that bit, so the amplitude at index c moves to index c ^ x_mask, where
+    x_mask collects those bits. The qubits carrying a Y or Z multiply the
+    amplitude by -1 whenever the matching index bit is set, and every Y adds a
+    further factor of 1j. Applying a term is therefore a reindexing of the vector
+    together with these per-index signs, accumulated over all terms."""
 
     def __init__(self, qubit_operator, n_qubits=None):
         """
@@ -108,38 +113,36 @@ class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
         Returns:
           retvec(numpy.ndarray): same to the shape of input vector of x.
         """
-        retvec = numpy.zeros(x.shape, dtype=complex)
-        # Loop through the terms.
-        for qubit_term in self.qubit_operator.terms:
-            vecs = [x]
-            tensor_factor = 0
-            coefficient = self.qubit_operator.terms[qubit_term]
+        arr = numpy.asarray(x)
+        vec = arr.reshape(-1)
+        indices = numpy.arange(vec.size, dtype=numpy.uint64)
+        retvec = numpy.zeros(vec.size, dtype=complex)
 
-            for pauli_operator in qubit_term:
-                # Split vector by half and half for each bit.
-                if pauli_operator[0] > tensor_factor:
-                    vecs = [
-                        v
-                        for iter_v in vecs
-                        for v in numpy.split(iter_v, 2 ** (pauli_operator[0] - tensor_factor))
-                    ]
+        for qubit_term, coefficient in self.qubit_operator.terms.items():
+            x_mask = 0
+            z_mask = 0
+            y_count = 0
+            for qubit, action in qubit_term:
+                bit = 1 << (self.n_qubits - 1 - qubit)
+                if action == 'X':
+                    x_mask ^= bit
+                elif action == 'Y':
+                    x_mask ^= bit
+                    z_mask ^= bit
+                    y_count += 1
+                else:
+                    z_mask ^= bit
 
-                # Note that this is to make sure that XYZ operations always work
-                # on vector pairs.
-                vec_pairs = [numpy.split(v, 2) for v in vecs]
+            amplitudes = coefficient * (1j ** (y_count % 4)) * vec
+            if z_mask:
+                signs = 1 - 2 * _bit_parity(indices & numpy.uint64(z_mask)).astype(numpy.int64)
+                amplitudes = signs * amplitudes
+            if x_mask:
+                retvec[indices ^ numpy.uint64(x_mask)] += amplitudes
+            else:
+                retvec += amplitudes
 
-                # There is an non-identity op here, transform the vector.
-                xyz = {
-                    'X': lambda vps: [[vp[1], vp[0]] for vp in vps],
-                    'Y': lambda vps: [[-1j * vp[1], 1j * vp[0]] for vp in vps],
-                    'Z': lambda vps: [[vp[0], -vp[1]] for vp in vps],
-                }
-                vecs = [v for vp in xyz[pauli_operator[1]](vec_pairs) for v in vp]
-                tensor_factor = pauli_operator[0] + 1
-
-            # No need to check tensor_factor, i.e. to deal with bits left.
-            retvec += coefficient * numpy.concatenate(vecs)
-        return retvec
+        return retvec.reshape(arr.shape)
 
 
 class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):

--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -133,7 +133,7 @@ class LinearQubitOperator(scipy.sparse.linalg.LinearOperator):
                 else:
                     z_mask ^= bit
 
-            amplitudes = coefficient * (1j ** (y_count % 4)) * vec
+            amplitudes = coefficient * [1, 1j, -1, -1j][y_count % 4] * vec
             if z_mask:
                 signs = 1 - 2 * _bit_parity(indices & numpy.uint64(z_mask)).astype(numpy.int64)
                 amplitudes = signs * amplitudes


### PR DESCRIPTION
Second of the operator hot-path findings from #1407; the first is #1415.

`LinearQubitOperator._matvec` applies a `QubitOperator` to a state vector, and it
is the inner loop behind `generate_linear_qubit_operator` and the eigensolvers
built on top of it. For each term it took the input vector, split it into `2**k`
pieces to reach the first non-identity qubit, split each of those in half, applied
the 2x2 Pauli to the pairs, and concatenated everything back, once per Pauli in
the term. That is a lot of Python-level list building and array copying for what
is, per term, a single reindexing of the amplitudes.

A Pauli string acts on the state vector as a signed permutation, so it can be
written directly on the flat index. Number the amplitudes `0 .. 2**n - 1` and put
qubit `q` at bit `n - 1 - q` (the ordering the split version already used, and the
one `qubit_operator_sparse` uses). Then for one term:

- the X and Y qubits flip their bit, so amplitude `c` moves to `c ^ x_mask`;
- the Y and Z qubits give a factor of -1 whenever the matching bit of `c` is set,
  that is `(-1)` raised to the parity of `popcount(c & z_mask)`;
- each Y gives an extra factor of `1j`.

So the term becomes `out[idx ^ x_mask] += coeff * 1j**(y_count % 4) * sign * x`,
where `sign` is a vector of +-1 from the bit parity and `idx ^ x_mask` is a
permutation of the indices, which is what makes the fancy-indexed `+=` safe. The
masks are cheap integer folds over the term and the per-amplitude work is a few
vectorized numpy operations with no intermediate lists.

This is an implementation change only. Public behavior is unchanged: complex
output, inputs of shape `(dim,)` or `(dim, 1)`, the identity term, operators
declared on more qubits than they act on, and the empty operator all behave as
before. Only the serial `_matvec` is touched; `ParallelLinearQubitOperator` is
left alone.

The parity of `popcount` uses a small xor-fold helper on uint64 rather than
`numpy.bitwise_count`, because the project still supports numpy 1.26 (the
max_compat CI job pins `numpy==1.26.4`) and `bitwise_count` needs numpy 2.0.

### Correctness

`linear_qubit_operator_test.py` passes unchanged. On top of that I compared the
new matvec against `qubit_operator_sparse(op) @ x` over random operators for
`n = 2..12` (mixed X/Y/Z, term counts including the empty and identity-only
operators), real and complex `x`, shapes `(dim,)` and `(dim, 1)`, and `n_qubits`
oversized by 2, plus a `scipy.sparse.linalg.eigsh` run checked against dense
eigenvalues. Worst absolute differences:

    random real x, shape (dim,)          5.4e-15
    random complex x, shape (dim,)       9.1e-15
    random complex x, shape (dim, 1)     9.1e-15
    oversized n_qubits by 2              2.4e-15
    identity-only and empty operator     0
    eigsh vs dense (3 smallest)          8.9e-15

black and mypy are clean on the file.

### Motivation

This is what #499 asked for. That issue called for a better `_matvec`, measured
that one was worth 80-100x at system sizes of 16 qubits and up, and noted that
`ParallelLinearQubitOperator` could then be deleted as obsolete once the serial
path was fast. The sketch there routed each Pauli through Cirq's
`apply_unitary`; no port ever landed and the issue was closed for inactivity in
2025. This PR gets the same win with plain numpy on the flat index, so it adds
no dependency, and the 120x at 16 qubits below bears out the issue's estimate.

The parallel path is also where the deadlock possibility in #1405 lives, and
with the serial matvec this fast there is rarely a reason to reach for it.
Removing it, as #499 suggested, would be a separate change; this PR fixes
neither issue.

### Benchmarks

Random QubitOperators with mixed X/Y/Z terms applied to a complex state vector:

    n_qubits   terms    before     after    speedup
       16       100     20.5 s     0.17 s      120x
       18       100     87.0 s     1.5 s        60x
       20        50      157 s     3.0 s        52x

Measured on my laptop (Intel Core Ultra 5 225, Windows, Python 3.12, numpy 2.5).
I ran the base/patch comparison twice in alternation with fixed seeds, taking
medians over three runs at n = 16 and single runs at n = 18 and 20 since the old
code takes minutes there; the per-round speedups agreed within a few percent, so
the table pools both rounds.
