### PR TITLE
Restore previous behavior to PolynomialTensor.rotate_basis() by default

### DIFF
--- a/docs/tutorials/intro_to_openfermion.ipynb
+++ b/docs/tutorials/intro_to_openfermion.ipynb
@@ -675,7 +675,7 @@
     "\n",
     "Because the RDMs and molecular Hamiltonians are both compactly represented and manipulated as 2- and 4- index tensors, we can represent them in a particularly efficient form using  similar data structures. The InteractionOperator data structure can be initialized for a Hamiltonian by passing the constant $h_0$ (or 0), as well as numpy arrays representing $h_{pq}$ (or $\\rho_{pq}$) and $h_{pqrs}$ (or $\\rho_{pqrs}$). Importantly, InteractionOperators can also be obtained by calling MolecularData.get_molecular_hamiltonian() or by calling the function get_interaction_operator() (found in openfermion.transforms) on a FermionOperator. The InteractionRDM data structure is similar but represents RDMs. For instance, one can get a molecular RDM by calling MolecularData.get_molecular_rdm(). When generating Hamiltonians from the MolecularData class, one can choose to restrict the system to an active space.\n",
     "\n",
-    "These classes inherit from the same base class, PolynomialTensor. This data structure overloads the slice operator [] so that one can get or set the key attributes of the InteractionOperator: $\\textrm{.constant}$, $\\textrm{.one_body_coefficients}$ and $\\textrm{.two_body_coefficients}$ . For instance, InteractionOperator[(p, 1), (q, 1), (r, 0), (s, 0)] would return $h_{pqrs}$ and InteractionRDM would return $\\rho_{pqrs}$. Importantly, the class supports fast basis transformations using the method PolynomialTensor.rotate_basis(rotation_matrix).\n",
+    "These classes inherit from the same base class, PolynomialTensor. This data structure overloads the slice operator [] so that one can get or set the key attributes of the InteractionOperator: $\\textrm{.constant}$, $\\textrm{.one_body_coefficients}$ and $\\textrm{.two_body_coefficients}$ . For instance, InteractionOperator[(p, 1), (q, 1), (r, 0), (s, 0)] would return $h_{pqrs}$ and InteractionRDM would return $\\rho_{pqrs}$. Importantly, the class supports fast basis transformations using the method PolynomialTensor.rotate_basis(rotation_matrix, transpose).\n",
     "But perhaps most importantly, one can map the InteractionOperator to any of the other data structures we've described here.\n",
     "\n",
     "Below, we load MolecularData from a saved calculation of LiH. We then obtain an InteractionOperator representation of this system in an active space. We then map that operator to qubits. We then demonstrate that one can rotate the orbital basis of the InteractionOperator using random angles to obtain a totally different operator that is still iso-spectral."
@@ -744,7 +744,7 @@
     "    rotation_matrix = scipy.linalg.expm(kappa)\n",
     "\n",
     "    # Apply the unitary.\n",
-    "    molecular_hamiltonian.rotate_basis(rotation_matrix)\n",
+    "    molecular_hamiltonian.rotate_basis(rotation_matrix, transpose=False)\n",
     "\n",
     "# Get qubit Hamiltonian in rotated basis.\n",
     "qubit_hamiltonian = jordan_wigner(molecular_hamiltonian)\n",

--- a/src/openfermion/chem/molecular_data_test.py
+++ b/src/openfermion/chem/molecular_data_test.py
@@ -290,8 +290,8 @@ class MolecularDataTest(unittest.TestCase):
         rotation_matrix = scipy.linalg.expm(rotation_generator - rotation_generator.T)
 
         # Compute total energy from RDM under some basis set rotation.
-        molecular_rdm.rotate_basis(rotation_matrix)
-        molecular_hamiltonian.rotate_basis(rotation_matrix)
+        molecular_rdm.rotate_basis(rotation_matrix, transpose=False)
+        molecular_hamiltonian.rotate_basis(rotation_matrix, transpose=False)
         total_energy = molecular_rdm.expectation(molecular_hamiltonian)
         self.assertAlmostEqual(total_energy, self.molecule.cisd_energy)
 

--- a/src/openfermion/hamiltonians/hartree_fock.py
+++ b/src/openfermion/hamiltonians/hartree_fock.py
@@ -112,8 +112,12 @@ class HartreeFockFunctional:
             _, core_orbs = sp.linalg.eigh(one_body_integrals, b=overlap)
 
             molecular_hamiltonian = generate_hamiltonian(
-                one_body_integrals=general_basis_change(self.obi, core_orbs, (1, 0)),
-                two_body_integrals=general_basis_change(self.tbi, core_orbs, (1, 1, 0, 0)),
+                one_body_integrals=general_basis_change(
+                    self.obi, core_orbs, (1, 0), transpose=False
+                ),
+                two_body_integrals=general_basis_change(
+                    self.tbi, core_orbs, (1, 1, 0, 0), transpose=False
+                ),
                 constant=self.constant_offset,
             )
             self.hamiltonian = molecular_hamiltonian

--- a/src/openfermion/hamiltonians/hartree_fock_test.py
+++ b/src/openfermion/hamiltonians/hartree_fock_test.py
@@ -100,8 +100,8 @@ def test_gradient():
     mo_obi = molecule.one_body_integrals
     mo_tbi = molecule.two_body_integrals
     rotation_mat = molecule.canonical_orbitals.T.dot(overlap)
-    obi = general_basis_change(mo_obi, rotation_mat, (1, 0))
-    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0))
+    obi = general_basis_change(mo_obi, rotation_mat, (1, 0), transpose=False)
+    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0), transpose=False)
     hff = HartreeFockFunctional(
         one_body_integrals=obi,
         two_body_integrals=tbi,
@@ -150,8 +150,8 @@ def test_gradient_lih():
     mo_obi = molecule.one_body_integrals
     mo_tbi = molecule.two_body_integrals
     rotation_mat = molecule.canonical_orbitals.T.dot(overlap)
-    obi = general_basis_change(mo_obi, rotation_mat, (1, 0))
-    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0))
+    obi = general_basis_change(mo_obi, rotation_mat, (1, 0), transpose=False)
+    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0), transpose=False)
 
     hff = HartreeFockFunctional(
         one_body_integrals=obi,
@@ -201,8 +201,8 @@ def test_rhf_func_generator():
     mo_obi = molecule.one_body_integrals
     mo_tbi = molecule.two_body_integrals
     rotation_mat = molecule.canonical_orbitals.T.dot(overlap)
-    obi = general_basis_change(mo_obi, rotation_mat, (1, 0))
-    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0))
+    obi = general_basis_change(mo_obi, rotation_mat, (1, 0), transpose=False)
+    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0), transpose=False)
 
     hff = HartreeFockFunctional(
         one_body_integrals=obi,
@@ -273,8 +273,8 @@ def test_rhf_min():
     mo_obi = molecule.one_body_integrals
     mo_tbi = molecule.two_body_integrals
     rotation_mat = molecule.canonical_orbitals.T.dot(overlap)
-    obi = general_basis_change(mo_obi, rotation_mat, (1, 0))
-    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0))
+    obi = general_basis_change(mo_obi, rotation_mat, (1, 0), transpose=False)
+    tbi = general_basis_change(mo_tbi, rotation_mat, (1, 1, 0, 0), transpose=False)
     hff = HartreeFockFunctional(
         one_body_integrals=obi,
         two_body_integrals=tbi,

--- a/src/openfermion/ops/representations/interaction_rdm.py
+++ b/src/openfermion/ops/representations/interaction_rdm.py
@@ -61,7 +61,7 @@ class InteractionRDM(PolynomialTensor):
         """Set the value of the two-body tensor."""
         self.n_body_tensors[1, 1, 0, 0] = value
 
-    def rotate_basis(self, rotation_matrix):
+    def rotate_basis(self, rotation_matrix, transpose=None):
         """Rotate the orbital basis of the InteractionRDM.
 
         Note that rotating the basis of an RDM M via some rotation uses the
@@ -75,8 +75,11 @@ class InteractionRDM(PolynomialTensor):
         Args:
             rotation_matrix: A square numpy array or matrix having
                 dimensions of n_qubits by n_qubits. Assumed to be unitary.
+            transpose: If True, transposes the rotation matrix before applying it.
+                If None (default), behaves as True to maintain backwards
+                compatibility, but raises a DeprecationWarning.
         """
-        super().rotate_basis(numpy.conjugate(rotation_matrix))
+        super().rotate_basis(numpy.conjugate(rotation_matrix), transpose=transpose)
 
     def expectation(self, operator):
         """Return expectation value of an InteractionRDM with an operator.

--- a/src/openfermion/ops/representations/interaction_rdm.py
+++ b/src/openfermion/ops/representations/interaction_rdm.py
@@ -12,6 +12,7 @@
 """Class and functions to store reduced density matrices."""
 
 import copy
+import warnings
 import numpy
 
 from openfermion.ops.operators import FermionOperator, QubitOperator
@@ -61,7 +62,7 @@ class InteractionRDM(PolynomialTensor):
         """Set the value of the two-body tensor."""
         self.n_body_tensors[1, 1, 0, 0] = value
 
-    def rotate_basis(self, rotation_matrix, transpose=None):
+    def rotate_basis(self, rotation_matrix: numpy.ndarray, transpose: bool | None = None) -> None:
         """Rotate the orbital basis of the InteractionRDM.
 
         Note that rotating the basis of an RDM M via some rotation uses the
@@ -76,9 +77,20 @@ class InteractionRDM(PolynomialTensor):
             rotation_matrix: A square numpy array or matrix having
                 dimensions of n_qubits by n_qubits. Assumed to be unitary.
             transpose: If True, transposes the rotation matrix before applying it.
+                If False, the rotation matrix is not transposed.
                 If None (default), behaves as True to maintain backwards
-                compatibility, but raises a DeprecationWarning.
+                compatibility, but raises a FutureWarning.
         """
+        if transpose is None:
+            warnings.warn(
+                "InteractionRDM.rotate_basis was called without specifying the 'transpose' "
+                "parameter. The current default is transpose=True to maintain backwards "
+                "compatibility, but this will change to transpose=False in a future release. "
+                "Specify the value of 'transpose' explicitly to silence this warning.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            transpose = True
         super().rotate_basis(numpy.conjugate(rotation_matrix), transpose=transpose)
 
     def expectation(self, operator):

--- a/src/openfermion/ops/representations/interaction_rdm_test.py
+++ b/src/openfermion/ops/representations/interaction_rdm_test.py
@@ -131,6 +131,15 @@ class InteractionRDMTest(unittest.TestCase):
         self.assertTrue(numpy.allclose(temp_rdm.one_body_tensor, expected_one_body))
         self.assertTrue(numpy.allclose(temp_rdm.two_body_tensor, expected_two_body))
 
+    def test_rotate_basis_warning(self):
+        """Test that calling rotate_basis without transpose raises a warning."""
+        n_orbitals = 2
+        one_body_rdm = numpy.identity(n_orbitals)
+        two_body_rdm = numpy.zeros((n_orbitals, n_orbitals, n_orbitals, n_orbitals))
+        rdm = InteractionRDM(one_body_rdm, two_body_rdm)
+        with self.assertWarns(FutureWarning):
+            rdm.rotate_basis(numpy.identity(n_orbitals))
+
     def test_expectation_rotation_invariance(self):
         """Test invariance of expectation value under basis rotations."""
 

--- a/src/openfermion/ops/representations/interaction_rdm_test.py
+++ b/src/openfermion/ops/representations/interaction_rdm_test.py
@@ -100,7 +100,32 @@ class InteractionRDMTest(unittest.TestCase):
         expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1))
 
         # Rotate RDM
-        temp_rdm.rotate_basis(u)
+        temp_rdm.rotate_basis(u, transpose=False)
+
+        # Compare
+        self.assertTrue(numpy.allclose(temp_rdm.one_body_tensor, expected_one_body))
+        self.assertTrue(numpy.allclose(temp_rdm.two_body_tensor, expected_two_body))
+
+    def test_rotate_basis_transpose(self):
+        """Test RDM basis set rotation with transpose=True"""
+        # Get molecular RDM
+        temp_rdm = self.molecule.get_molecular_rdm()
+        temp_one_body = temp_rdm.one_body_tensor
+        temp_two_body = temp_rdm.two_body_tensor
+        n_orbitals = temp_rdm.n_body_tensors[(1, 0)].shape[0]
+
+        # Generate random rotation matrix U
+        x = numpy.random.rand(n_orbitals, n_orbitals) + 1j * numpy.random.rand(
+            n_orbitals, n_orbitals
+        )
+        u, _ = numpy.linalg.qr(x)  # QR decomposition guarantees u is unitary
+
+        # Compute reference RDM
+        expected_one_body = general_basis_change(temp_one_body, u, (0, 1))
+        expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1))
+
+        # Rotate RDM
+        temp_rdm.rotate_basis(u.T, transpose=True)
 
         # Compare
         self.assertTrue(numpy.allclose(temp_rdm.one_body_tensor, expected_one_body))
@@ -140,8 +165,8 @@ class InteractionRDMTest(unittest.TestCase):
         exp_before = rdm.expectation(op)
 
         # Rotate both RDM and Operator with U
-        rdm.rotate_basis(u)
-        op.rotate_basis(u)
+        rdm.rotate_basis(u, transpose=False)
+        op.rotate_basis(u, transpose=False)
 
         # Calculate expectation value in rotated basis
         exp_after = rdm.expectation(op)

--- a/src/openfermion/ops/representations/interaction_rdm_test.py
+++ b/src/openfermion/ops/representations/interaction_rdm_test.py
@@ -96,8 +96,8 @@ class InteractionRDMTest(unittest.TestCase):
         u, _ = numpy.linalg.qr(x)  # QR decomposition guarantees u is unitary
 
         # Compute reference RDM
-        expected_one_body = general_basis_change(temp_one_body, u, (0, 1))
-        expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1))
+        expected_one_body = general_basis_change(temp_one_body, u, (0, 1), transpose=False)
+        expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1), transpose=False)
 
         # Rotate RDM
         temp_rdm.rotate_basis(u, transpose=False)
@@ -121,8 +121,8 @@ class InteractionRDMTest(unittest.TestCase):
         u, _ = numpy.linalg.qr(x)  # QR decomposition guarantees u is unitary
 
         # Compute reference RDM
-        expected_one_body = general_basis_change(temp_one_body, u, (0, 1))
-        expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1))
+        expected_one_body = general_basis_change(temp_one_body, u, (0, 1), transpose=False)
+        expected_two_body = general_basis_change(temp_two_body, u, (0, 0, 1, 1), transpose=False)
 
         # Rotate RDM
         temp_rdm.rotate_basis(u.T, transpose=True)

--- a/src/openfermion/ops/representations/polynomial_tensor.py
+++ b/src/openfermion/ops/representations/polynomial_tensor.py
@@ -14,6 +14,7 @@ fermionic ladder operators."""
 
 import copy
 import itertools
+import warnings
 import operator
 
 import numpy
@@ -360,7 +361,7 @@ class PolynomialTensor:
             strings.append('{} {}\n'.format(key, self[key]))
         return ''.join(strings) if strings else '0'
 
-    def rotate_basis(self, rotation_matrix):
+    def rotate_basis(self, rotation_matrix, transpose=None):
         """
         Rotate the orbital basis of the PolynomialTensor.
 
@@ -368,7 +369,22 @@ class PolynomialTensor:
             rotation_matrix: A square numpy array or matrix having
                 dimensions of n_qubits by n_qubits. Assumed to be real and
                 invertible.
+            transpose: If True, transposes the rotation matrix before applying it.
+                If None (default), behaves as True to maintain backwards
+                compatibility, but raises a DeprecationWarning.
         """
+        if transpose is None:
+            warnings.warn(
+                "rotate_basis(R) is deprecated, please use rotate_basis(R, transpose). "
+                "tranpose=True will be used currently to maintain backwards compatiblity, "
+                "but the default will change to transpose=False a future release",
+                DeprecationWarning,
+            )
+            transpose = True
+
+        if transpose:
+            rotation_matrix = rotation_matrix.T
+
         for key in self.n_body_tensors:
             if key == ():
                 pass

--- a/src/openfermion/ops/representations/polynomial_tensor.py
+++ b/src/openfermion/ops/representations/polynomial_tensor.py
@@ -29,7 +29,12 @@ class PolynomialTensorError(Exception):
     pass
 
 
-def general_basis_change(general_tensor, rotation_matrix, key):
+def general_basis_change(
+    general_tensor: numpy.ndarray,
+    rotation_matrix: numpy.ndarray,
+    key: tuple[int, ...],
+    transpose: bool | None = None,
+) -> numpy.ndarray:
     r"""Change the basis of a general interaction tensor.
 
     M'^{p_1p_2...p_n} = R^{p_1}_{a_1} R^{p_2}_{a_2} ...
@@ -53,10 +58,28 @@ def general_basis_change(general_tensor, rotation_matrix, key):
             $a^\dagger_p a_q$ would have a key of (1, 0) whereas a tensor
             storing coefficients of $a^\dagger_p a_q a_r a^\dagger_s$
             would have a key of (1, 0, 0, 1).
+        transpose: If True, transposes the rotation matrix before applying it.
+            If False, the rotation matrix is not transposed.
+            If None (default), behaves as True to maintain backwards
+            compatibility, but raises a FutureWarning.
 
     Returns:
         transformed_general_tensor: general_tensor in the rotated basis.
     """
+    if transpose is None:
+        warnings.warn(
+            "general_basis_change was called without specifying the 'transpose' "
+            "parameter. The current default is transpose=True to maintain backwards "
+            "compatibility, but this will change to transpose=False in a future release. "
+            "Specify the value of 'transpose' explicitly to silence this warning.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        transpose = True
+
+    if transpose:
+        rotation_matrix = rotation_matrix.T
+
     # If operator acts on spin degrees of freedom, enlarge rotation matrix.
     n_orbitals = rotation_matrix.shape[0]
     if general_tensor.shape[0] == 2 * n_orbitals:
@@ -385,15 +408,12 @@ class PolynomialTensor:
             )
             transpose = True
 
-        if transpose:
-            rotation_matrix = rotation_matrix.T
-
         for key in self.n_body_tensors:
             if key == ():
                 pass
             else:
                 self.n_body_tensors[key] = general_basis_change(
-                    self.n_body_tensors[key], rotation_matrix, key
+                    self.n_body_tensors[key], rotation_matrix, key, transpose=transpose
                 )
 
     def __repr__(self):

--- a/src/openfermion/ops/representations/polynomial_tensor.py
+++ b/src/openfermion/ops/representations/polynomial_tensor.py
@@ -361,7 +361,7 @@ class PolynomialTensor:
             strings.append('{} {}\n'.format(key, self[key]))
         return ''.join(strings) if strings else '0'
 
-    def rotate_basis(self, rotation_matrix, transpose=None):
+    def rotate_basis(self, rotation_matrix: numpy.ndarray, transpose: bool | None = None) -> None:
         """
         Rotate the orbital basis of the PolynomialTensor.
 
@@ -370,15 +370,18 @@ class PolynomialTensor:
                 dimensions of n_qubits by n_qubits. Assumed to be real and
                 invertible.
             transpose: If True, transposes the rotation matrix before applying it.
+                If False, does not transpose the rotation matrix.
                 If None (default), behaves as True to maintain backwards
-                compatibility, but raises a DeprecationWarning.
+                compatibility, but raises a FutureWarning.
         """
         if transpose is None:
             warnings.warn(
-                "rotate_basis(R) is deprecated, please use rotate_basis(R, transpose). "
-                "tranpose=True will be used currently to maintain backwards compatiblity, "
-                "but the default will change to transpose=False a future release",
-                DeprecationWarning,
+                "PolynomialTensor.rotate_basis was called without specifying the 'transpose' "
+                "parameter. The current default is transpose=True to maintain backwards "
+                "compatibility, but this will change to transpose=False in a future release. "
+                "Specify the value of 'transpose' explicitly to silence this warning.",
+                FutureWarning,
+                stacklevel=2,
             )
             transpose = True
 

--- a/src/openfermion/ops/representations/polynomial_tensor_test.py
+++ b/src/openfermion/ops/representations/polynomial_tensor_test.py
@@ -575,7 +575,7 @@ class PolynomialTensorTest(unittest.TestCase):
     def test_rotate_basis_warning(self):
         n_qubits = 2
         polynomial_tensor = PolynomialTensor({(1, 0): numpy.identity(n_qubits)})
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(FutureWarning):
             polynomial_tensor.rotate_basis(numpy.identity(n_qubits))
 
     def test_rotate_basis_max_order(self):

--- a/src/openfermion/ops/representations/polynomial_tensor_test.py
+++ b/src/openfermion/ops/representations/polynomial_tensor_test.py
@@ -16,7 +16,7 @@ import unittest
 import copy
 import numpy
 
-from openfermion.ops.representations import PolynomialTensor
+from openfermion.ops.representations import PolynomialTensor, general_basis_change
 from openfermion.transforms.opconversions import get_fermion_operator
 from openfermion.circuits.slater_determinants_test import random_quadratic_hamiltonian
 
@@ -623,3 +623,24 @@ class PolynomialTensorTest(unittest.TestCase):
             self.assertEqual(tensor + numpy_scalar, tensor + python_scalar)
             self.assertEqual(tensor - numpy_scalar, tensor - python_scalar)
             self.assertEqual(tensor / numpy_scalar, tensor / python_scalar)
+
+    def test_general_basis_change_warning(self):
+        n_orbitals = 2
+        tensor = numpy.identity(n_orbitals)
+        with self.assertWarns(FutureWarning):
+            general_basis_change(tensor, numpy.identity(n_orbitals), (1, 0))
+
+    def test_general_basis_change_transpose(self):
+        n_orbitals = 2
+        # Use a non-symmetric tensor to differentiate transpose
+        tensor = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        u = numpy.array([[0.8, 0.6], [-0.6, 0.8]])
+
+        expected_old = u.conj().T @ tensor @ u
+        expected_new = u.conj() @ tensor @ u.T
+
+        result_old = general_basis_change(tensor, u, (1, 0), transpose=True)
+        self.assertTrue(numpy.allclose(result_old, expected_old))
+
+        result_new = general_basis_change(tensor, u, (1, 0), transpose=False)
+        self.assertTrue(numpy.allclose(result_new, expected_new))

--- a/src/openfermion/ops/representations/polynomial_tensor_test.py
+++ b/src/openfermion/ops/representations/polynomial_tensor_test.py
@@ -435,8 +435,8 @@ class PolynomialTensorTest(unittest.TestCase):
             {(): self.constant, (1, 0): one_body_spinful, (1, 1, 0, 0): two_body_spinful}
         )
 
-        polynomial_tensor.rotate_basis(rotation_matrix_identical)
-        polynomial_tensor_spinful.rotate_basis(rotation_matrix_identical)
+        polynomial_tensor.rotate_basis(rotation_matrix_identical, transpose=False)
+        polynomial_tensor_spinful.rotate_basis(rotation_matrix_identical, transpose=False)
         self.assertEqual(polynomial_tensor, want_polynomial_tensor)
         self.assertEqual(polynomial_tensor_spinful, want_polynomial_tensor_spinful)
 
@@ -471,7 +471,7 @@ class PolynomialTensorTest(unittest.TestCase):
         want_polynomial_tensor = PolynomialTensor(
             {(): self.constant, (1, 0): one_body_reverse, (1, 1, 0, 0): two_body_reverse}
         )
-        polynomial_tensor.rotate_basis(rotation_matrix_reverse)
+        polynomial_tensor.rotate_basis(rotation_matrix_reverse, transpose=False)
         self.assertEqual(polynomial_tensor, want_polynomial_tensor)
 
     def test_rotate_basis_cyclic(self):
@@ -499,7 +499,7 @@ class PolynomialTensorTest(unittest.TestCase):
             {(): self.constant, (1, 0): ref_one_body, (1, 1, 0, 0): ref_two_body}
         )
 
-        polynomial_tensor.rotate_basis(rotation_matrix)
+        polynomial_tensor.rotate_basis(rotation_matrix, transpose=False)
         self.assertEqual(polynomial_tensor, ref_polynomial_tensor)
 
     def test_rotate_basis_quadratic_hamiltonian_real(self):
@@ -520,7 +520,7 @@ class PolynomialTensorTest(unittest.TestCase):
 
         # Rotate a basis where the Hamiltonian is diagonal
         _, diagonalizing_unitary, _ = quad_ham.diagonalizing_bogoliubov_transform()
-        quad_ham.rotate_basis(diagonalizing_unitary)
+        quad_ham.rotate_basis(diagonalizing_unitary, transpose=False)
 
         # Check that the rotated Hamiltonian is diagonal with the correct
         # orbital energies
@@ -536,6 +536,47 @@ class PolynomialTensorTest(unittest.TestCase):
 
         self.assertTrue(numpy.allclose(orbital_energies, new_orbital_energies))
         self.assertAlmostEqual(constant, new_constant)
+
+    def test_rotate_basis_quadratic_hamiltonian_transpose_real(self):
+        self.do_rotate_basis_quadratic_hamiltonian_transpose(True)
+
+    def test_rotate_basis_quadratic_hamiltonian_transpose_complex(self):
+        self.do_rotate_basis_quadratic_hamiltonian_transpose(False)
+
+    def do_rotate_basis_quadratic_hamiltonian_transpose(self, real):
+        """Test diagonalizing a quadratic Hamiltonian that conserves particle
+        number with transposed rotation."""
+        n_qubits = 5
+
+        # Initialize a particle-number-conserving quadratic Hamiltonian
+        # and compute its orbital energies
+        quad_ham = random_quadratic_hamiltonian(n_qubits, True, real=real)
+        orbital_energies, _, constant = quad_ham.diagonalizing_bogoliubov_transform()
+
+        # Rotate a basis where the Hamiltonian is diagonal
+        _, diagonalizing_unitary, _ = quad_ham.diagonalizing_bogoliubov_transform()
+        quad_ham.rotate_basis(diagonalizing_unitary.T, transpose=True)
+
+        # Check that the rotated Hamiltonian is diagonal with the correct
+        # orbital energies
+        D = numpy.zeros((n_qubits, n_qubits), dtype=complex)
+        D[numpy.diag_indices(n_qubits)] = orbital_energies
+        self.assertTrue(numpy.allclose(quad_ham.combined_hermitian_part, D))
+
+        # Check that the new Hamiltonian still conserves particle number
+        self.assertTrue(quad_ham.conserves_particle_number)
+
+        # Check that the orbital energies and constant are the same
+        new_orbital_energies, _, new_constant = quad_ham.diagonalizing_bogoliubov_transform()
+
+        self.assertTrue(numpy.allclose(orbital_energies, new_orbital_energies))
+        self.assertAlmostEqual(constant, new_constant)
+
+    def test_rotate_basis_warning(self):
+        n_qubits = 2
+        polynomial_tensor = PolynomialTensor({(1, 0): numpy.identity(n_qubits)})
+        with self.assertWarns(DeprecationWarning):
+            polynomial_tensor.rotate_basis(numpy.identity(n_qubits))
 
     def test_rotate_basis_max_order(self):
         for order in [15, 16]:
@@ -563,7 +604,7 @@ class PolynomialTensorTest(unittest.TestCase):
             num *= rotation
         want_polynomial_tensor = PolynomialTensor({key: numpy.zeros(shape) + num})
 
-        polynomial_tensor.rotate_basis(numpy.array([[rotation]]))
+        polynomial_tensor.rotate_basis(numpy.array([[rotation]]), transpose=False)
 
         return polynomial_tensor, want_polynomial_tensor
 


### PR DESCRIPTION
PolynomialTensor's rotate_basis method previously used the transpose of the rotation matrix. This is not correct, but changing it in #805 broke users' code. A `transpose` flag is introduced to specify whether or not to transpose the rotation matrix, with `True` being the default for now (to be changed to the preferred `False` in a later release). A deprecation warning is given if the transpose flag is not specified.