### PR TITLE
Fix #1405: potential pool.join deadlock in ParallelLinearQubitOperator 

### DIFF
--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -194,8 +194,11 @@ class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):
             apply_operator, [(operator, x) for operator in self.linear_operators]
         )
         pool.close()
+        # Consume results before join(): imap_unordered uses a bounded pipe and
+        # workers block on write if the main process has not read them yet.
+        result = functools.reduce(numpy.add, vecs)
         pool.join()
-        return functools.reduce(numpy.add, vecs)
+        return result
 
 
 def apply_operator(args):

--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -196,10 +196,10 @@ class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):
         pool.close()
         # Consume results before join(): imap_unordered uses a bounded pipe and
         # workers block on write if the main process has not read them yet.
-    try:
-        result = functools.reduce(numpy.add, vecs)
-    finally:
-        pool.join()
+        try:
+            result = functools.reduce(numpy.add, vecs)
+        finally:
+            pool.join()
         return result
 
 

--- a/src/openfermion/linalg/linear_qubit_operator.py
+++ b/src/openfermion/linalg/linear_qubit_operator.py
@@ -196,7 +196,9 @@ class ParallelLinearQubitOperator(scipy.sparse.linalg.LinearOperator):
         pool.close()
         # Consume results before join(): imap_unordered uses a bounded pipe and
         # workers block on write if the main process has not read them yet.
+    try:
         result = functools.reduce(numpy.add, vecs)
+    finally:
         pool.join()
         return result
 

--- a/src/openfermion/linalg/linear_qubit_operator_test.py
+++ b/src/openfermion/linalg/linear_qubit_operator_test.py
@@ -11,6 +11,7 @@
 #   limitations under the License.
 """Tests for linear_qubit_operator.py."""
 
+import sys
 import unittest
 
 import numpy
@@ -269,6 +270,18 @@ class ParallelLinearQubitOperatorTest(unittest.TestCase):
             self.qubit_operator, self.n_qubits, options=options
         )
         self.assertTrue(numpy.allclose(parallel_qubit_op * self.vec, self.expected_matvec))
+
+    @unittest.skipIf(sys.platform == 'win32', 'forkserver multiprocessing is Unix-only')
+    def test_matvec_large_vector_multiprocess(self):
+        """Regression test for imap_unordered/pool.join() pipe deadlock (#1405)."""
+        n_qubits = 14
+        qubit_operator = QubitOperator('Z0') + QubitOperator('Z1') + QubitOperator('Z2')
+        options = LinearQubitOperatorOptions(processes=2)
+        parallel_op = ParallelLinearQubitOperator(qubit_operator, n_qubits, options=options)
+        serial_op = LinearQubitOperator(qubit_operator, n_qubits)
+
+        vec = numpy.ones(2**n_qubits, dtype=complex)
+        self.assertTrue(numpy.allclose(parallel_op * vec, serial_op * vec))
 
 
 class UtilityFunctionTest(unittest.TestCase):


### PR DESCRIPTION
Consume imap_unordered results before joining the worker pool to avoid pipe backpressure deadlocks when state vectors are large.

Fixes #1405 