### PR TITLE
Add workflow to regenerate env files after dependency updates

### DIFF
--- a/.github/workflows/regenerate-env-files.yaml
+++ b/.github/workflows/regenerate-env-files.yaml
@@ -50,7 +50,8 @@ on:
 permissions: read-all
 
 concurrency:
-  group: regenerate-env-files-${{github.event.pull_request.number || github.ref}}
+  group: >-
+    regenerate-env-files-${{github.event.pull_request.number || github.ref}}
   cancel-in-progress: true
 
 jobs:
@@ -66,11 +67,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      CHECKOUT_REF: ${{github.event.pull_request.head.ref || github.ref}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{github.event.pull_request.head.ref || github.ref}}
+          ref: ${{env.CHECKOUT_REF}}
           fetch-depth: 0
           token: ${{secrets.GITHUB_TOKEN}}
 
@@ -86,48 +89,62 @@ jobs:
         id: publish
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          EVENT_NAME: ${{github.event_name}}
+          PR_HEAD_REF: ${{github.event.pull_request.head.ref}}
+          REF_NAME: ${{github.ref_name}}
+          REF_FULL: ${{github.ref}}
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- dev_tools/requirements/envs dev_tools/requirements/max_compat; then
+          if git diff --quiet -- \
+              dev_tools/requirements/envs \
+              dev_tools/requirements/max_compat; then
             echo "Environment files are already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
           git add dev_tools/requirements/envs dev_tools/requirements/max_compat
           git commit \
             -m "Regenerate environment files after dependency update" \
             -m "Automated commit from the regenerate-env-files workflow."
 
-          if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            git push origin "HEAD:${{github.event.pull_request.head.ref}}"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            git push origin "HEAD:${PR_HEAD_REF}"
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-            git push origin "HEAD:${{github.ref_name}}"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            git push origin "HEAD:${REF_NAME}"
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [[ "${{github.event_name}}" == "push" && "${{github.ref}}" == "refs/heads/main" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REF_FULL}" == "refs/heads/main" ]]; then
             branch="automation/regenerate-env-files-${GITHUB_RUN_ID}"
             git checkout -b "${branch}"
             git push origin "${branch}"
+            pr_body_file="$(mktemp)"
+            printf '%s\n' \
+              'Automated regeneration triggered by a push to main that changed' \
+              'files under dev_tools/requirements/deps/. Review and merge to' \
+              'keep compiled environment files in sync.' \
+              > "${pr_body_file}"
             gh pr create \
               --title "Regenerate environment files after dependency update" \
-              --body "Automated regeneration triggered by a push to \`main\` that changed files under \`dev_tools/requirements/deps/\`. Review and merge to keep compiled environment files in sync." \
+              --body-file "${pr_body_file}" \
               --base main \
               --head "${branch}"
+            rm -f "${pr_body_file}"
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git push origin "HEAD:${{github.ref_name}}"
+          git push origin "HEAD:${REF_NAME}"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Comment on pull request
@@ -136,6 +153,13 @@ jobs:
           && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
         run: |
-          gh pr comment "${{github.event.pull_request.number}}" \
-            --body "Regenerated compiled environment files in \`dev_tools/requirements/envs/\` and \`dev_tools/requirements/max_compat/\` using \`dev_tools/requirements/create-env-files.sh\`."
+          comment_body_file="$(mktemp)"
+          printf '%s\n' \
+            'Regenerated compiled environment files in' \
+            'dev_tools/requirements/envs/ and dev_tools/requirements/max_compat/' \
+            'using dev_tools/requirements/create-env-files.sh.' \
+            > "${comment_body_file}"
+          gh pr comment "${PR_NUMBER}" --body-file "${comment_body_file}"
+          rm -f "${comment_body_file}"

--- a/.github/workflows/regenerate-env-files.yaml
+++ b/.github/workflows/regenerate-env-files.yaml
@@ -1,0 +1,134 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Regenerate compiled environment files when dependency inputs change.
+#
+# Dependabot updates dev_tools/requirements/deps/*.txt but cannot run
+# dev_tools/requirements/create-env-files.sh. This workflow runs that script
+# under maintainer control:
+#   * On pull requests that change deps inputs, results are pushed back to the
+#     same branch so reviewers can merge deps and env files together.
+#   * After a merge to main, a follow-up pull request is opened if env files
+#     are still out of date.
+#   * Maintainers can also invoke the workflow manually.
+#
+# Manual invocation:
+# https://github.com/quantumlib/OpenFermion/actions/workflows/regenerate-env-files.yaml
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Regenerate environment files
+run-name: >-
+  Regenerate environment files
+  ${{github.event_name == 'workflow_dispatch' && ' (manual)' || '' }}
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'dev_tools/requirements/deps/**'
+
+  pull_request:
+    paths:
+      - 'dev_tools/requirements/deps/**'
+
+permissions: read-all
+
+concurrency:
+  group: regenerate-env-files-${{github.event.pull_request.number || github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate environment files
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{github.event.pull_request.head.ref || github.ref}}
+          fetch-depth: 0
+          token: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Regenerate environment files
+        run: ./dev_tools/requirements/create-env-files.sh
+
+      - name: Commit and publish if changed
+        id: publish
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- dev_tools/requirements/envs dev_tools/requirements/max_compat; then
+            echo "Environment files are already up to date."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dev_tools/requirements/envs dev_tools/requirements/max_compat
+          git commit \
+            -m "Regenerate environment files after dependency update" \
+            -m "Automated commit from the regenerate-env-files workflow."
+
+          if [[ "${{github.event_name}}" == "pull_request" ]]; then
+            git push origin "HEAD:${{github.event.pull_request.head.ref}}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
+            branch="automation/regenerate-env-files-${GITHUB_RUN_ID}"
+            git checkout -b "${branch}"
+            git push origin "${branch}"
+            gh pr create \
+              --title "Regenerate environment files after dependency update" \
+              --body "Automated regeneration triggered by a push to \`main\` that changed files under \`dev_tools/requirements/deps/\`. Review and merge to keep compiled environment files in sync." \
+              --base main \
+              --head "${branch}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git push origin "HEAD:${{github.ref_name}}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on pull request
+        if: >-
+          steps.publish.outputs.changed == 'true'
+          && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          gh pr comment "${{github.event.pull_request.number}}" \
+            --body "Regenerated compiled environment files in \`dev_tools/requirements/envs/\` and \`dev_tools/requirements/max_compat/\` using \`dev_tools/requirements/create-env-files.sh\`."

--- a/.github/workflows/regenerate-env-files.yaml
+++ b/.github/workflows/regenerate-env-files.yaml
@@ -21,8 +21,9 @@
 #   * On pull requests that change deps inputs, results are pushed back to the
 #     same branch so reviewers can merge deps and env files together.
 #   * After a merge to main, a follow-up pull request is opened if env files
-#     are still out of date.
-#   * Maintainers can also invoke the workflow manually.
+#     are still out of date (requires the repository setting that allows GitHub
+#     Actions to create pull requests).
+#   * Manual invocation pushes directly to the selected branch.
 #
 # Manual invocation:
 # https://github.com/quantumlib/OpenFermion/actions/workflows/regenerate-env-files.yaml
@@ -107,7 +108,13 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
+          if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
+            git push origin "HEAD:${{github.ref_name}}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{github.event_name}}" == "push" && "${{github.ref}}" == "refs/heads/main" ]]; then
             branch="automation/regenerate-env-files-${GITHUB_RUN_ID}"
             git checkout -b "${branch}"
             git push origin "${branch}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,5 +373,9 @@ When a pull request changes files under `dev_tools/requirements/deps/`, the
 automatically runs `create-env-files.sh` and pushes any resulting updates back to
 the same branch. After a dependency update is merged to `main`, that workflow can
 also open a follow-up pull request if the compiled environment files are still out
-of date. Maintainers can trigger regeneration manually from the
-[Actions tab](https://github.com/quantumlib/OpenFermion/actions/workflows/regenerate-env-files.yaml).
+of date. On `quantumlib/OpenFermion`, this follow-up pull request requires the
+repository setting **Allow GitHub Actions to create and approve pull requests**
+under Settings → Actions → General. Maintainers can trigger regeneration manually
+from the
+[Actions tab](https://github.com/quantumlib/OpenFermion/actions/workflows/regenerate-env-files.yaml);
+manual runs push updates directly to the selected branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,3 +367,11 @@ The lists of OpenFermion dependencies in `dev_tools/requirements/envs/` and
 pip install -r dev_tools/requirements/envs/dev.env.txt
 ./dev_tools/requirements/create-env-files.sh
 ```
+
+When a pull request changes files under `dev_tools/requirements/deps/`, the
+[`regenerate-env-files` workflow](.github/workflows/regenerate-env-files.yaml)
+automatically runs `create-env-files.sh` and pushes any resulting updates back to
+the same branch. After a dependency update is merged to `main`, that workflow can
+also open a follow-up pull request if the compiled environment files are still out
+of date. Maintainers can trigger regeneration manually from the
+[Actions tab](https://github.com/quantumlib/OpenFermion/actions/workflows/regenerate-env-files.yaml).


### PR DESCRIPTION
Dependabot updates dev_tools/requirements/deps/, but can't run create-env-files.sh to rebuild the compiled env files. This PR adds a workflow that does that automatically, as requested by 1332.

On PRs it pushes regenerated env files back to the same branch, after a merge to main it can open a follow-up PR if needed. Manual runs from actions push straight to the branch you pick. CONTRIBUTING.md documents this also now and notes upstream needs the "Allow GitHub Actions to create pull requests" setting for the post-merge PR path.

Fixes #1332