### PR TITLE
Fix #1428: add `-n` flag to nightly pytest

### DIFF
--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -95,7 +95,7 @@ jobs:
         run: echo '::add-matcher::.github/problem-matchers/pytest.json'
 
       - name: Run Pytest
-        run: check/pytest
+        run: check/pytest -n logical
 
       - name: Print debugging info upon job failure
         if: failure()

--- a/.github/workflows/nightly-pytest.yaml
+++ b/.github/workflows/nightly-pytest.yaml
@@ -95,7 +95,7 @@ jobs:
         run: echo '::add-matcher::.github/problem-matchers/pytest.json'
 
       - name: Run Pytest
-        run: check/pytest -n logical
+        run: check/pytest -n auto
 
       - name: Print debugging info upon job failure
         if: failure()


### PR DESCRIPTION
Running pytest in parallel will speed it up and use fewer CPU minutes.