### PR TITLE
Make `create-env-files.sh` respect min python version supported

### DIFF
--- a/dev_tools/requirements/create-env-files.sh
+++ b/dev_tools/requirements/create-env-files.sh
@@ -16,36 +16,56 @@
 set -o errexit
 set -o nounset
 
-declare -r usage="Usage: ${0} [-h] [UV_OPTIONS]
+# Go to the top of the local TFQ git tree. Do it early in case this fails.
+script_dir=$(CDPATH="" cd -- "$(dirname -- "${0}")" && pwd -P)
+repo_dir=$(git -C "${script_dir}" rev-parse --show-toplevel 2>/dev/null)
+cd "${repo_dir}"
+
+default_min_python=$(python3 -c 'import re
+s = open("pyproject.toml").read()
+m = re.search(r"requires-python.*?>=?(\d+\.\d+)", s)
+if not m:
+    m = re.search(r"target-version.*?py(\d)(\d+)", s)
+print(m.group(1) if "requires-python" in m.re.pattern else m.expand(r"\1.\2"))
+' 2>/dev/null || echo "3.10")
+
+declare -r usage="Usage: ${0} [-h] [-p X.Y] [UV_OPTIONS]
 Generate environment files for OpenFermion development using uv's
 'universal' option, making the result compatible with multiple
 Python versions. The output is written to subdirectories under
 dev_tools/requirements/.
 
 Options:
-  -h   Show this help message and exit
+  -h       Show this help message and exit
+  -p X.Y   Minimum Python version to support (default: ${default_min_python})
 
 All other options on the command line will be passed directly to
 'uv pip compile'. Run 'uv pip compile --help' to learn about the
 options available."
 
+min_python=("--python-version" "${default_min_python}")
+
 while [[ $# -gt 0 ]]; do
     case "${1}" in
         -h|--help) echo "${usage}"; exit 0 ;;
+        -p|--min-python|--python-version)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "Error: option '${1}' requires an argument" >&2
+                echo "${usage}" >&2
+                exit 1
+            fi
+            min_python=("--python-version" "${2}")
+            shift 2
+            ;;
         *) break ;;
     esac
 done
-
-# Go to the top of the local TFQ git tree. Do it early in case this fails.
-script_dir=$(CDPATH="" cd -- "$(dirname -- "${0}")" && pwd -P)
-repo_dir=$(git -C "${script_dir}" rev-parse --show-toplevel 2>/dev/null)
-cd "${repo_dir}"
 
 mkdir -p dev_tools/requirements/envs dev_tools/requirements/max_compat
 
 # ~~~~ Generate basic requirements files ~~~~
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/format.txt \
     dev_tools/requirements/deps/mypy.txt \
@@ -56,45 +76,45 @@ uv pip compile "$@" \
     dev_tools/requirements/deps/runtime.txt \
     dev_tools/requirements/deps/shellcheck.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/format.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/format.txt \
     dev_tools/requirements/deps/runtime.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/pylint.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/pylint.txt \
     dev_tools/requirements/deps/runtime.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/pytest.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/pytest.txt \
     dev_tools/requirements/deps/runtime.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/pytest-extra.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/pytest.txt \
     dev_tools/requirements/deps/resource_estimates_runtime.txt \
     dev_tools/requirements/deps/runtime.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/mypy.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/mypy.txt \
     dev_tools/requirements/deps/runtime.txt
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/envs/shellcheck.env.txt \
     -c dev_tools/requirements/envs/dev.env.txt \
     dev_tools/requirements/deps/shellcheck.txt
 
 # ~~~~ Generate max_compat files ~~~~
 
-uv pip compile "$@" \
+uv pip compile "${min_python[@]}" "$@" \
     -o dev_tools/requirements/max_compat/pytest-max-compat.env.txt \
     -c dev_tools/requirements/deps/oldest-versions.txt \
     dev_tools/requirements/deps/pytest.txt \


### PR DESCRIPTION
This makes `dev_tools/requirements/create-env-files.sh` get the minimum version of Python the project supports from pyproject.toml, and use that as a constraint passed to `uv`.